### PR TITLE
copy_paste utility function

### DIFF
--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 from supervision.detection.core import BoxAnnotator, Detections
 from supervision.detection.polygon_zone import PolygonZone, PolygonZoneAnnotator

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -3,6 +3,7 @@ from typing import Optional
 import cv2
 import numpy as np
 
+from supervision.detection.utils import generate_2d_mask
 from supervision.draw.color import Color
 from supervision.geometry.core import Point, Rect
 
@@ -163,7 +164,8 @@ def draw_text(
     cv2.putText(
         img=scene,
         text=text,
-        org=(text_anchor.x - text_width // 2, text_anchor.y + text_height // 2),
+        org=(text_anchor.x - text_width // 2,
+             text_anchor.y + text_height // 2),
         fontFace=text_font,
         fontScale=text_scale,
         color=text_color.as_bgr(),
@@ -171,3 +173,31 @@ def draw_text(
         lineType=cv2.LINE_AA,
     )
     return scene
+
+
+def copy_paste(source_image: np.ndarray, source_polygon: np.ndarray, target_image: np.ndarray):
+    """
+    Copy and paste a region from a source image into a target image.
+
+    Attributes:
+        source_image (np.ndarray): The image to be copied.
+        source_polygon (np.ndarray): The polygon to be copied.
+        target_image (np.ndarray): The image to be pasted into.
+
+
+    Returns:
+        np.ndarray: The target image with the source image pasted into it.
+    """
+    cv2.imshow('source', source_image)
+    cv2.imshow('target', target_image)
+    # print(source_image.shape)
+
+    width, height, depth = source_image.shape
+    mask = generate_2d_mask(source_polygon, (width, height))
+    cv2.imshow('mask', mask)
+
+    cutout = cv2.copyTo(source_image, mask, target_image)
+    cv2.imshow('cutout', cutout)
+
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()


### PR DESCRIPTION
# Description

This adds a `copy_paste` utility function to copy paste specific areas from one image into another.  Similar to e.g. the functionality in this notebook:  https://colab.research.google.com/drive/1VK5FPT41pQt4pVxMRn8oaYxPfAD_jUOa?usp=sharing#scrollTo=03bUCdJRNXux

We are looking at using this functionality in this project https://github.com/roboflow/magic-scissors and thought it would live well as a general too in supervision.

I've been testing this using the following script:
```
import cv2
import numpy as np
import supervision

cart_image = cv2.imread("./cart1.jpg")

jelly_image = cv2.imread("./jelly.jpg")
jelly_polygon_raw = [640, 374.162, 601.785, 188.653, 566.854, 151.682, 524.031, 88.138,
                     464.306, 41.928, 397.819, 8.423, 360.632, 8.423, 299.781, 0.337,
                     232.169, 6.115, 169.063, 33.842, 110.463, 71.967, 67.64, 121.643,
                     27.073, 175.943, 0.028, 282.231, 10.17, 394.298, 43.976, 470.547,
                     108.212, 554.887, 203.994, 605.716, 222.027, 621.892, 406.35, 640,
                     410.855, 640, 565.729, 547.955, 640, 374.894, 640, 374.162]
jelly_polygon = np.array(jelly_polygon_raw).astype(np.int32).reshape(-1, 2)

output = supervision.draw.utils.copy_paste(
    jelly_image,  # source image to copy / cutout from
    jelly_polygon,  # polygon area to cutout from source
    cart_image,  # background / target image
    0.2,  # scale
    300,  # x
    200  # y
)

cv2.imshow('output', output)
cv2.waitKey(0)
cv2.destroyAllWindows()
```
