### PR TITLE
Update __init__.py to include linezone

### DIFF
--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -2,6 +2,7 @@ __version__ = "0.2.1"
 
 from supervision.detection.core import BoxAnnotator, Detections
 from supervision.detection.polygon_zone import PolygonZone, PolygonZoneAnnotator
+from supervision.detection.line_counter import LineZone, LineZoneAnnotator
 from supervision.detection.utils import generate_2d_mask
 from supervision.draw.color import Color, ColorPalette
 from supervision.draw.utils import draw_filled_rectangle, draw_polygon, draw_text


### PR DESCRIPTION
Add export of linezone

# Description

This adds LineZone and LineZoneAnnotator to the manin __init__ file so they can be easily referenced.
To close Issue #30

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
