### PR TITLE
Fix issue where the LineZone.trigger function expects 4 values instead of 5

### DIFF
--- a/supervision/detection/line_counter.py
+++ b/supervision/detection/line_counter.py
@@ -35,7 +35,7 @@ class LineZone:
             detections (Detections): The detections for which to update the counts.
 
         """
-        for xyxy, confidence, class_id, tracker_id in detections:
+        for xyxy, _, confidence, class_id, tracker_id in detections:
             # handle detections with no tracker_id
             if tracker_id is None:
                 continue


### PR DESCRIPTION
# Description

Added `_` for the LineZone trigger function to properly unpack values. 

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I created a [Detections](https://github.com/roboflow/supervision/blob/e091f9c9594bcb1d04a8fbfffc885722c4c2c765/supervision/detection/core.py#L51) class using yolov8 results, and passed those detections into a LineZone.trigger() call and no longer receive the error `too many values to unpack (expected 4)`

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
