### PR TITLE
feature/support for yolo dataset export

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,8 @@
+### 0.8.0 <small>May 17, 2023</small>
+
+- Added [[#100](https://github.com/roboflow/supervision/pull/100)]: ability to save datasets in YOLO format using `Dataset.as_yolo`.
+- Added [[#100](https://github.com/roboflow/supervision/pull/100)]: support for Dataset inheritance. Current `Dataset` got renamed to `DetectionDataset` and make it inherit from `BaseDataset`.   
+
 ### 0.7.0 <small>May 11, 2023</small>
 
 - Added [[#91](https://github.com/roboflow/supervision/pull/91)]: `Detections.from_yolo_nas` to enable seamless integration with [YOLO-NAS](https://github.com/Deci-AI/super-gradients/blob/master/YOLONAS.md) model.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,8 @@
 ### 0.8.0 <small>May 17, 2023</small>
 
-- Added [[#100](https://github.com/roboflow/supervision/pull/100)]: ability to save datasets in YOLO format using `Dataset.as_yolo`.
-- Added [[#100](https://github.com/roboflow/supervision/pull/100)]: support for Dataset inheritance. Current `Dataset` got renamed to `DetectionDataset` and make it inherit from `BaseDataset`.   
+- Added [[#100](https://github.com/roboflow/supervision/pull/100)]: support for Dataset inheritance. Current `Dataset` got renamed to `DetectionDataset` and make it inherit from `BaseDataset`.
+- Added [[#100](https://github.com/roboflow/supervision/pull/100)]: ability to save datasets in YOLO format using `DetectionDataset.as_yolo`.
+- Changed [[#100](https://github.com/roboflow/supervision/pull/100)]: default value of `approximation_percentage` parameter from `0.75` to `0.0` in `DetectionDataset.as_yolo` and `DetectionDataset.as_pascal_voc`.
 
 ### 0.7.0 <small>May 11, 2023</small>
 

--- a/docs/dataset/core.md
+++ b/docs/dataset/core.md
@@ -1,8 +1,8 @@
 !!! warning
 
-    `Dataset` API is still fluid and may change. If you use Dataset in your project until further notice, freeze the 
-    `supervision` version in your `requirements.txt`.
+    Dataset API is still fluid and may change. If you use Dataset API in your project until further notice, freeze the 
+    `supervision` version in your `requirements.txt` or `setup.py`.
 
-## Dataset
+## DetectionDataset
 
 :::supervision.dataset.core.DetectionDataset

--- a/docs/dataset/core.md
+++ b/docs/dataset/core.md
@@ -5,4 +5,4 @@
 
 ## Dataset
 
-:::supervision.dataset.core.Dataset
+:::supervision.dataset.core.DetectionDataset

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setuptools.setup(
     install_requires=[
         'numpy>=1.20.0',
         'opencv-python',
-        'matplotlib'
+        'matplotlib',
+        'pyyaml'
     ],
     packages=find_packages(exclude=("tests",)),
     extras_require={

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -1,6 +1,6 @@
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
-from supervision.dataset.core import Dataset
+from supervision.dataset.core import BaseDataset, DetectionDataset
 from supervision.detection.annotate import BoxAnnotator, MaskAnnotator
 from supervision.detection.core import Detections
 from supervision.detection.line_counter import LineZone, LineZoneAnnotator

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -220,3 +220,15 @@ class Dataset:
             force_masks=force_masks,
         )
         return Dataset(classes=classes, images=images, annotations=annotations)
+
+    @classmethod
+    def as_yolo(
+        cls,
+        images_directory_path: Optional[str] = None,
+        annotations_directory_path: Optional[str] = None,
+        data_yaml_path: Optional[str] = None,
+        min_image_area_percentage: float = 0.0,
+        max_image_area_percentage: float = 1.0,
+        approximation_percentage: float = 0.75,
+    ) -> None:
+        pass

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -67,7 +67,7 @@ class DetectionDataset(BaseDataset):
         annotations_directory_path: Optional[str] = None,
         min_image_area_percentage: float = 0.0,
         max_image_area_percentage: float = 1.0,
-        approximation_percentage: float = 0.75,
+        approximation_percentage: float = 0.0,
     ) -> None:
         """
         Exports the dataset to PASCAL VOC format. This method saves the images and their corresponding annotations in
@@ -238,7 +238,7 @@ class DetectionDataset(BaseDataset):
         data_yaml_path: Optional[str] = None,
         min_image_area_percentage: float = 0.0,
         max_image_area_percentage: float = 1.0,
-        approximation_percentage: float = 0.75,
+        approximation_percentage: float = 0.0,
     ) -> None:
         """
         Exports the dataset to YOLO (You Only Look Once) format. This method saves the images and their corresponding

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Iterator
+from typing import Dict, Iterator, List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -11,7 +11,11 @@ from supervision.dataset.formats.pascal_voc import (
     detections_to_pascal_voc,
     load_pascal_voc_annotations,
 )
-from supervision.dataset.formats.yolo import load_yolo_annotations, save_yolo_annotations, save_data_yaml
+from supervision.dataset.formats.yolo import (
+    load_yolo_annotations,
+    save_data_yaml,
+    save_yolo_annotations,
+)
 from supervision.dataset.ultils import save_dataset_images
 from supervision.detection.core import Detections
 from supervision.file import list_files_with_extensions
@@ -237,7 +241,9 @@ class DetectionDataset(BaseDataset):
         approximation_percentage: float = 0.75,
     ) -> None:
         if images_directory_path is not None:
-            save_dataset_images(images_directory_path=images_directory_path, images=self.images)
+            save_dataset_images(
+                images_directory_path=images_directory_path, images=self.images
+            )
         if annotations_directory_path is not None:
             save_yolo_annotations(
                 annotations_directory_path=annotations_directory_path,
@@ -245,7 +251,7 @@ class DetectionDataset(BaseDataset):
                 annotations=self.annotations,
                 min_image_area_percentage=min_image_area_percentage,
                 max_image_area_percentage=max_image_area_percentage,
-                approximation_percentage=approximation_percentage
+                approximation_percentage=approximation_percentage,
             )
         if data_yaml_path is not None:
             save_data_yaml(data_yaml_path=data_yaml_path, classes=self.classes)

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -29,7 +29,7 @@ class BaseDataset:
 @dataclass
 class DetectionDataset(BaseDataset):
     """
-    Dataclass containing information about the dataset.
+    Dataclass containing information about object detection dataset.
 
     Attributes:
         classes (List[str]): List containing dataset class names.

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -12,12 +12,18 @@ from supervision.dataset.formats.pascal_voc import (
     load_pascal_voc_annotations,
 )
 from supervision.dataset.formats.yolo import load_yolo_annotations
+from supervision.dataset.ultils import save_dataset_images
 from supervision.detection.core import Detections
 from supervision.file import list_files_with_extensions
 
 
 @dataclass
-class Dataset:
+class BaseDataset:
+    pass
+
+
+@dataclass
+class DetectionDataset(BaseDataset):
     """
     Dataclass containing information about the dataset.
 
@@ -107,7 +113,7 @@ class Dataset:
     @classmethod
     def from_pascal_voc(
         cls, images_directory_path: str, annotations_directory_path: str
-    ) -> Dataset:
+    ) -> DetectionDataset:
         """
         Creates a Dataset instance from PASCAL VOC formatted data.
 
@@ -116,7 +122,7 @@ class Dataset:
             annotations_directory_path (str): The path to the directory containing the PASCAL VOC XML annotations.
 
         Returns:
-            Dataset: A Dataset instance containing the loaded images and annotations.
+            DetectionDataset: A DetectionDataset instance containing the loaded images and annotations.
 
         Example:
             ```python
@@ -168,7 +174,7 @@ class Dataset:
         annotations = {
             image_name: detections for image_name, detections, _ in raw_annotations
         }
-        return Dataset(classes=classes, images=images, annotations=annotations)
+        return DetectionDataset(classes=classes, images=images, annotations=annotations)
 
     @classmethod
     def from_yolo(
@@ -177,7 +183,7 @@ class Dataset:
         annotations_directory_path: str,
         data_yaml_path: str,
         force_masks: bool = False,
-    ) -> Dataset:
+    ) -> DetectionDataset:
         """
         Creates a Dataset instance from YOLO formatted data.
 
@@ -188,7 +194,7 @@ class Dataset:
             force_masks (bool, optional): If True, forces masks to be loaded for all annotations, regardless of whether they are present.
 
         Returns:
-            Dataset: A Dataset instance containing the loaded images and annotations.
+            DetectionDataset: A DetectionDataset instance containing the loaded images and annotations.
 
         Example:
             ```python
@@ -219,11 +225,10 @@ class Dataset:
             data_yaml_path=data_yaml_path,
             force_masks=force_masks,
         )
-        return Dataset(classes=classes, images=images, annotations=annotations)
+        return DetectionDataset(classes=classes, images=images, annotations=annotations)
 
-    @classmethod
     def as_yolo(
-        cls,
+        self,
         images_directory_path: Optional[str] = None,
         annotations_directory_path: Optional[str] = None,
         data_yaml_path: Optional[str] = None,
@@ -231,4 +236,4 @@ class Dataset:
         max_image_area_percentage: float = 1.0,
         approximation_percentage: float = 0.75,
     ) -> None:
-        pass
+        save_dataset_images(images=self.images, images_directory_path=images_directory_path)

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -11,7 +11,7 @@ from supervision.dataset.formats.pascal_voc import (
     detections_to_pascal_voc,
     load_pascal_voc_annotations,
 )
-from supervision.dataset.formats.yolo import load_yolo_annotations
+from supervision.dataset.formats.yolo import load_yolo_annotations, save_yolo_annotations, save_data_yaml
 from supervision.dataset.ultils import save_dataset_images
 from supervision.detection.core import Detections
 from supervision.file import list_files_with_extensions
@@ -236,4 +236,16 @@ class DetectionDataset(BaseDataset):
         max_image_area_percentage: float = 1.0,
         approximation_percentage: float = 0.75,
     ) -> None:
-        save_dataset_images(images=self.images, images_directory_path=images_directory_path)
+        if images_directory_path is not None:
+            save_dataset_images(images_directory_path=images_directory_path, images=self.images)
+        if annotations_directory_path is not None:
+            save_yolo_annotations(
+                annotations_directory_path=annotations_directory_path,
+                images=self.images,
+                annotations=self.annotations,
+                min_image_area_percentage=min_image_area_percentage,
+                max_image_area_percentage=max_image_area_percentage,
+                approximation_percentage=approximation_percentage
+            )
+        if data_yaml_path is not None:
+            save_data_yaml(data_yaml_path=data_yaml_path, classes=self.classes)

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -240,6 +240,27 @@ class DetectionDataset(BaseDataset):
         max_image_area_percentage: float = 1.0,
         approximation_percentage: float = 0.75,
     ) -> None:
+        """
+        Exports the dataset to YOLO (You Only Look Once) format. This method saves the images and their corresponding
+        annotations in YOLO format, which is a simple text file that describes an object in the image. It also allows
+        for the optional saving of a data.yaml file, used in YOLOv5, that contains metadata about the dataset.
+
+        The method allows filtering the detections based on their area percentage and offers an option for polygon approximation.
+
+        Args:
+            images_directory_path (Optional[str]): The path to the directory where the images should be saved.
+                If not provided, images will not be saved.
+            annotations_directory_path (Optional[str]): The path to the directory where the annotations in
+                YOLO format should be saved. If not provided, annotations will not be saved.
+            data_yaml_path (Optional[str]): The path where the data.yaml file should be saved.
+                If not provided, the file will not be saved.
+            min_image_area_percentage (float): The minimum percentage of detection area relative to
+                the image area for a detection to be included.
+            max_image_area_percentage (float): The maximum percentage of detection area relative to
+                the image area for a detection to be included.
+            approximation_percentage (float): The percentage of polygon points to be removed from the input polygon,
+                in the range [0, 1). This is useful for simplifying the annotations.
+        """
         if images_directory_path is not None:
             save_dataset_images(
                 images_directory_path=images_directory_path, images=self.images

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -63,9 +63,6 @@ def detections_to_pascal_voc(
         str: An XML string in Pascal VOC format representing the detections.
     """
     height, width, depth = image_shape
-    image_area = height * width
-    minimum_detection_area = min_image_area_percentage * image_area
-    maximum_detection_area = max_image_area_percentage * image_area
 
     # Create root element
     annotation = Element("annotation")

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, Optional
 
 import cv2
 import numpy as np
@@ -130,7 +130,7 @@ def load_yolo_annotations(
         force_masks (bool, optional): If True, forces masks to be loaded for all annotations, regardless of whether they are present.
 
     Returns:
-        Tuple[List[str], Dict[str, np.ndarray], Dict[str, Detections]]: A tuple containing a list of class names, a dictionary with image paths as keys and images as values, and a dictionary with image paths as keys and corresponding Detections instances as values.
+        Tuple[List[str], Dict[str, np.ndarray], Dict[str, Detections]]: A tuple containing a list of class names, a dictionary with image names as keys and images as values, and a dictionary with image names as keys and corresponding Detections instances as values.
     """
     image_paths = list_files_with_extensions(
         directory=images_directory_path, extensions=["jpg", "jpeg", "png"]
@@ -156,6 +156,15 @@ def load_yolo_annotations(
             lines=lines, resolution_wh=resolution_wh, with_masks=with_masks
         )
 
-        images[str(image_path)] = image
-        annotations[str(image_path)] = annotation
+        images[image_path.name] = image
+        annotations[image_path.name] = annotation
     return classes, images, annotations
+
+
+def save_dataset_images(images: Dict[str, np.ndarray], images_directory_path: Optional[str] = None) -> None:
+    if images_directory_path is None:
+        return
+
+
+def save_yolo_annotations():
+    pass

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Union, Optional
 
 import cv2
+import yaml
 import numpy as np
 
 from supervision.dataset.ultils import approximate_mask_with_polygons
@@ -168,7 +169,7 @@ def object_to_pascal_voc(
     image_shape: Tuple[int, int, int],
     polygon: Optional[np.ndarray] = None
 ) -> str:
-    pass
+    height, width, _ = image_shape
 
 
 def detections_to_yolo_annotations(
@@ -199,5 +200,22 @@ def detections_to_yolo_annotations(
     return "\n".join(annotation)
 
 
-def save_yolo_annotations():
+def save_yolo_annotations(
+    annotations_directory_path: str,
+    images: Dict[str, np.ndarray],
+    annotations: Dict[str, Detections],
+    min_image_area_percentage: float = 0.0,
+    max_image_area_percentage: float = 1.0,
+    approximation_percentage: float = 0.75,
+) -> None:
     pass
+
+
+def save_data_yaml(data_yaml_path: str, classes: List[str]) -> None:
+    data = {
+        'nc': len(classes),
+        'names': classes
+    }
+    Path(data_yaml_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(data_yaml_path, 'w') as outfile:
+        yaml.dump(data, outfile, default_flow_style=False)

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -230,7 +230,7 @@ def save_yolo_annotations(
     approximation_percentage: float = 0.75,
 ) -> None:
     Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
-    for image_name, image in images:
+    for image_name, image in images.items():
         detections = annotations[image_name]
         yolo_annotations_name = _image_name_to_annotation_name(image_name=image_name)
         yolo_annotations_path = os.path.join(

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -185,7 +185,10 @@ def object_to_yolo(
         height = y_max - y_min
         return f"{int(class_id)} {x_center:.5f} {y_center:.5f} {width:.5f} {height:.5f}"
     else:
-        pass
+        polygon_relative = polygon / np.array([w, h], dtype=np.float32)
+        polygon_relative = polygon_relative.reshape(-1)
+        polygon_parsed = " ".join([f"{value:.5f}" for value in polygon_relative])
+        return f"{int(class_id)} {polygon_parsed}"
 
 
 def detections_to_yolo_annotations(

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Tuple, Union
 
 import cv2
 import numpy as np
@@ -159,11 +159,6 @@ def load_yolo_annotations(
         images[image_path.name] = image
         annotations[image_path.name] = annotation
     return classes, images, annotations
-
-
-def save_dataset_images(images: Dict[str, np.ndarray], images_directory_path: Optional[str] = None) -> None:
-    if images_directory_path is None:
-        return
 
 
 def save_yolo_annotations():

--- a/supervision/dataset/ultils.py
+++ b/supervision/dataset/ultils.py
@@ -40,7 +40,7 @@ def approximate_mask_with_polygons(
     ]
 
 
-def save_dataset_images(images: Dict[str, np.ndarray], images_directory_path: Optional[str] = None) -> None:
+def save_dataset_images(images_directory_path: str, images: Dict[str, np.ndarray]) -> None:
     Path(images_directory_path).mkdir(parents=True, exist_ok=True)
 
     for image_name, image in images.items():

--- a/supervision/dataset/ultils.py
+++ b/supervision/dataset/ultils.py
@@ -18,7 +18,7 @@ def approximate_mask_with_polygons(
     max_image_area_percentage: float = 1.0,
     approximation_percentage: float = 0.75,
 ) -> List[np.ndarray]:
-    height, width = mask
+    height, width = mask.shape
     image_area = height * width
     minimum_detection_area = min_image_area_percentage * image_area
     maximum_detection_area = max_image_area_percentage * image_area

--- a/supervision/dataset/ultils.py
+++ b/supervision/dataset/ultils.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Dict, List
 
 import cv2
 import numpy as np
@@ -40,7 +40,9 @@ def approximate_mask_with_polygons(
     ]
 
 
-def save_dataset_images(images_directory_path: str, images: Dict[str, np.ndarray]) -> None:
+def save_dataset_images(
+    images_directory_path: str, images: Dict[str, np.ndarray]
+) -> None:
     Path(images_directory_path).mkdir(parents=True, exist_ok=True)
 
     for image_name, image in images.items():

--- a/supervision/dataset/ultils.py
+++ b/supervision/dataset/ultils.py
@@ -1,5 +1,8 @@
-from typing import List
+import os
+from pathlib import Path
+from typing import List, Dict, Optional
 
+import cv2
 import numpy as np
 
 from supervision.detection.utils import (
@@ -35,3 +38,11 @@ def approximate_mask_with_polygons(
         approximate_polygon(polygon=polygon, percentage=approximation_percentage)
         for polygon in polygons
     ]
+
+
+def save_dataset_images(images: Dict[str, np.ndarray], images_directory_path: Optional[str] = None) -> None:
+    Path(images_directory_path).mkdir(parents=True, exist_ok=True)
+
+    for image_name, image in images.items():
+        target_image_path = os.path.join(images_directory_path, image_name)
+        cv2.imwrite(target_image_path, image)

--- a/supervision/detection/line_counter.py
+++ b/supervision/detection/line_counter.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 import cv2
 import numpy as np
@@ -6,7 +6,6 @@ import numpy as np
 from supervision.detection.core import Detections
 from supervision.draw.color import Color
 from supervision.geometry.core import Point, Rect, Vector
-from typing import Optional
 
 
 class LineZone:
@@ -70,6 +69,7 @@ class LineZone:
                 self.in_count += 1
             else:
                 self.out_count += 1
+
 
 class LineZoneAnnotator:
     def __init__(
@@ -145,9 +145,16 @@ class LineZoneAnnotator:
             lineType=cv2.LINE_AA,
         )
 
-        in_text = f"{self.custom_in_text}: {line_counter.in_count}" if self.custom_in_text is not None else f"in: {line_counter.in_count}"
-        out_text = f"{self.custom_out_text}: {line_counter.out_count}" if self.custom_out_text is not None else f"out: {line_counter.out_count}"
-
+        in_text = (
+            f"{self.custom_in_text}: {line_counter.in_count}"
+            if self.custom_in_text is not None
+            else f"in: {line_counter.in_count}"
+        )
+        out_text = (
+            f"{self.custom_out_text}: {line_counter.out_count}"
+            if self.custom_out_text is not None
+            else f"out: {line_counter.out_count}"
+        )
 
         (in_text_width, in_text_height), _ = cv2.getTextSize(
             in_text, cv2.FONT_HERSHEY_SIMPLEX, self.text_scale, self.text_thickness

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -220,7 +220,9 @@ def polygon_to_xyxy(polygon: np.ndarray) -> np.ndarray:
     return np.array([x_min, y_min, x_max, y_max])
 
 
-def approximate_polygon(polygon: np.ndarray, percentage: float) -> np.ndarray:
+def approximate_polygon(
+    polygon: np.ndarray, percentage: float, epsilon_step: float = 0.05
+) -> np.ndarray:
     """
     Approximates a given polygon by reducing a certain percentage of points.
 
@@ -228,11 +230,12 @@ def approximate_polygon(polygon: np.ndarray, percentage: float) -> np.ndarray:
     while preserving the general shape.
 
     Parameters:
-        polygon (np.ndarray): A 2D NumPy array of shape (N, 2) containing the x, y coordinates of the input polygon's points.
-        percentage (float): The percentage of points to be removed from the input polygon, in the range [0, 1).
+        polygon (np.ndarray): A 2D NumPy array of shape `(N, 2)` containing the `x`, `y` coordinates of the input polygon's points.
+        percentage (float): The percentage of points to be removed from the input polygon, in the range `[0, 1)`.
+        epsilon_step (float): Approximation accuracy step. Epsilon is the maximum distance between the original curve and its approximation.
 
     Returns:
-        np.ndarray: A new 2D NumPy array of shape (M, 2), where M <= N * (1 - percentage), containing the x, y coordinates of the
+        np.ndarray: A new 2D NumPy array of shape `(M, 2)`, where `M <= N * (1 - percentage)`, containing the `x`, `y` coordinates of the
             approximated polygon's points.
     """
 
@@ -246,8 +249,12 @@ def approximate_polygon(polygon: np.ndarray, percentage: float) -> np.ndarray:
 
     epsilon = 0
     approximated_points = polygon
-    while len(approximated_points) > target_points:
-        epsilon += 0.1
-        approximated_points = cv2.approxPolyDP(polygon, epsilon, closed=True)
+    while True:
+        epsilon += epsilon_step
+        new_approximated_points = cv2.approxPolyDP(polygon, epsilon, closed=True)
+        if len(new_approximated_points) > target_points:
+            approximated_points = new_approximated_points
+        else:
+            break
 
     return np.squeeze(approximated_points, axis=1)

--- a/supervision/file.py
+++ b/supervision/file.py
@@ -53,3 +53,16 @@ def read_txt_file(file_path: str) -> List[str]:
         lines = [line.rstrip("\n") for line in lines]
 
     return lines
+
+
+def save_text_file(lines: List[str], file_path: str):
+    """
+    Write a list of strings to a text file, each string on a new line.
+
+    Args:
+        lines (List[str]): The list of strings to be written to the file.
+        file_path (str): The path to the text file.
+    """
+    with open(file_path, "w") as file:
+        for line in lines:
+            file.write(line + "\n")

--- a/test/dataset/formats/test_yolo.py
+++ b/test/dataset/formats/test_yolo.py
@@ -283,6 +283,19 @@ def test_image_name_to_annotation_name(
             '1 0.30000 0.15000 0.20000 0.10000',
             DoesNotRaise()
         ),  # vertical bounding box on square image
+        (
+            np.array([100, 100, 200, 200], dtype=np.float32),
+            1,
+            (1000, 1000, 3),
+            np.array([
+                [100, 100],
+                [200, 100],
+                [200, 200],
+                [100, 100]
+            ], dtype=np.float32),
+            '1 0.10000 0.10000 0.20000 0.10000 0.20000 0.20000 0.10000 0.10000',
+            DoesNotRaise()
+        ),  # square mask on square image
     ]
 )
 def test_object_to_yolo(xyxy: np.ndarray, class_id: int, image_shape: Tuple[int, int, int], polygon: Optional[np.ndarray], expected_result: Optional[str], exception: Exception) -> None:

--- a/test/dataset/formats/test_yolo.py
+++ b/test/dataset/formats/test_yolo.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 
 from supervision.detection.core import Detections
-from supervision.dataset.formats.yolo import yolo_annotations_to_detections, _with_mask
+from supervision.dataset.formats.yolo import yolo_annotations_to_detections, _with_mask, _image_name_to_annotation_name
 
 
 def _mock_simple_mask(resolution_wh: Tuple[int, int], box: List[int]) -> np.array:
@@ -202,3 +202,38 @@ def test_yolo_annotations_to_detections(
         assert np.array_equal(result.xyxy, expected_result.xyxy)
         assert np.array_equal(result.class_id, expected_result.class_id)
         assert (result.mask is None and expected_result.mask is None) or _arrays_almost_equal(result.mask, expected_result.mask)
+
+
+@pytest.mark.parametrize(
+    'image_name, expected_result, exception',
+    [
+        (
+            'image.png',
+            'image.txt',
+            DoesNotRaise()
+        ),  # simple png image
+        (
+            'image.jpeg',
+            'image.txt',
+            DoesNotRaise()
+        ),  # simple jpeg image
+        (
+            'image.jpg',
+            'image.txt',
+            DoesNotRaise()
+        ),  # simple jpg image
+        (
+            'image.000.jpg',
+            'image.000.txt',
+            DoesNotRaise()
+        ),  # jpg image with multiple dots in name
+    ]
+)
+def test_image_name_to_annotation_name(
+    image_name: str,
+    expected_result: Optional[str],
+    exception: Exception
+) -> None:
+    with exception:
+        result = _image_name_to_annotation_name(image_name=image_name)
+        assert result == expected_result


### PR DESCRIPTION
# Description

- Added support for Dataset inheritance. The current `Dataset` got renamed to `DetectionDataset` and made it inherit from `BaseDataset`.
- Added ability to save datasets in YOLO format using `DetectionDataset.as_yolo`.
- Changed default value of `approximation_percentage` parameter from `0.75` to `0.0` in `DetectionDataset.as_yolo` and `DetectionDataset.as_pascal_voc`.


## Docs

-   [x] Docs updated? What were the changes:
