### PR TITLE
Adding yolov8 masks to detections

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -189,10 +189,9 @@ class Detections:
         """
         masks = None
         if yolov8_results.masks:
-            from ultralytics.yolo.utils.ops import scale_image
             masks = yolov8_results.masks.masks.cpu().numpy()  # masks, (N, H, W)
             masks = np.moveaxis(masks, 0, -1)  # masks, (H, W, N)
-            masks = scale_image(masks, yolov8_results.masks.orig_shape)
+            masks = cv2.resize(masks, (yolov8_results.masks.orig_shape[1], yolov8_results.masks.orig_shape[0]))
             masks = np.moveaxis(masks, -1, 0)  # masks, (N, H, W)
         return cls(
             xyxy=yolov8_results.boxes.xyxy.cpu().numpy(),

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -189,9 +189,9 @@ class Detections:
         """
         mask_maps = None
         if yolov8_results.masks:
-            orig_shape = yolov8_result.orig_shape
-            inference_shape = tuple(masks.data.shape[1:])
-            masks = yolov8_result.masks.data.cpu().numpy()
+            orig_shape = yolov8_results.orig_shape
+            inference_shape = tuple(yolov8_results.masks.data.shape[1:])
+            masks = yolov8_results.masks.data.cpu().numpy()
             # calculate pad and gain
             if inference_shape != orig_shape:
                 gain = min(inference_shape[0] / orig_shape[0], inference_shape[1] / orig_shape[1])  # gain  = old / new

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -193,6 +193,8 @@ class Detections:
             inference_shape = tuple(yolov8_results.masks.data.shape[1:])
             masks = yolov8_results.masks.data.cpu().numpy()
             # calculate pad and gain
+            pad = (0, 0)
+            gain = 0
             if inference_shape != orig_shape:
                 gain = min(inference_shape[0] / orig_shape[0], inference_shape[1] / orig_shape[1])  # gain  = old / new
                 pad = (inference_shape[1] - orig_shape[1] * gain) / 2, (inference_shape[0] - orig_shape[0] * gain) / 2

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -4,7 +4,7 @@ from dataclasses import astuple, dataclass
 from typing import Any, Iterator, List, Optional, Tuple
 
 import numpy as np
-
+import cv2
 from supervision.detection.utils import non_max_suppression, xywh_to_xyxy
 from supervision.geometry.core import Position
 from supervision.internal import deprecated

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -187,17 +187,31 @@ class Detections:
             >>> detections = sv.Detections.from_yolov8(result)
             ```
         """
-        masks = None
+        mask_maps = None
         if yolov8_results.masks:
-            masks = yolov8_results.masks.masks.cpu().numpy()  # masks, (N, H, W)
-            masks = np.moveaxis(masks, 0, -1)  # masks, (H, W, N)
-            masks = cv2.resize(masks, (yolov8_results.masks.orig_shape[1], yolov8_results.masks.orig_shape[0]))
-            masks = np.moveaxis(masks, -1, 0)  # masks, (N, H, W)
+            orig_shape = yolov8_result.orig_shape
+            inference_shape = tuple(masks.data.shape[1:])
+            masks = yolov8_result.masks.data.cpu().numpy()
+            # calculate pad and gain
+            if inference_shape != orig_shape:
+                gain = min(inference_shape[0] / orig_shape[0], inference_shape[1] / orig_shape[1])  # gain  = old / new
+                pad = (inference_shape[1] - orig_shape[1] * gain) / 2, (inference_shape[0] - orig_shape[0] * gain) / 2
+
+            top, left = int(pad[1]), int(pad[0])  # y, x
+            bottom, right = int(inference_shape[0] - pad[1]), int(inference_shape[1] - pad[0])
+
+            mask_maps = []
+            for i in range(masks.shape[0]):
+                mask = masks[i]
+                mask = mask[top:bottom, left:right]
+                mask = cv2.resize(mask, (orig_shape[1], orig_shape[0]))
+                mask_maps.append(mask)
+            mask_maps = np.asarray(mask_maps)
         return cls(
             xyxy=yolov8_results.boxes.xyxy.cpu().numpy(),
             confidence=yolov8_results.boxes.conf.cpu().numpy(),
             class_id=yolov8_results.boxes.cls.cpu().numpy().astype(int),
-            mask=masks
+            mask=mask_maps
         )
 
     @classmethod

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -187,10 +187,18 @@ class Detections:
             >>> detections = sv.Detections.from_yolov8(result)
             ```
         """
+        masks = None
+        if yolov8_results.masks:
+            from ultralytics.yolo.utils.ops import scale_image
+            masks = yolov8_results.masks.masks.cpu().numpy()  # masks, (N, H, W)
+            masks = np.moveaxis(masks, 0, -1)  # masks, (H, W, N)
+            masks = scale_image(masks, yolov8_results.masks.orig_shape)
+            masks = np.moveaxis(masks, -1, 0)  # masks, (N, H, W)
         return cls(
             xyxy=yolov8_results.boxes.xyxy.cpu().numpy(),
             confidence=yolov8_results.boxes.conf.cpu().numpy(),
             class_id=yolov8_results.boxes.cls.cpu().numpy().astype(int),
+            mask=masks
         )
 
     @classmethod


### PR DESCRIPTION
# Description

Current `Detection` class only support for yolov8 object detection. Segmentation masks information are missing.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

```
model = YOLO(model="yolov8s.pt")
results = model.predict(img)[0]
detections = sv.Detections.from_yolov8(results)

mask_annotator = sv.MaskAnnotator()
box_annotator = sv.BoxAnnotator()

img = box_annotator.annotate(scene=img, detections=detections)
img = mask_annotator.annotate(scene=img, detections=detections)
```

## Docs

-   [ ] Docs updated? What were the changes:
