### PR TITLE
Update README.md example for looping through dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ pip install -e ".[dev]"
 - Loop over dataset entries
 
     ```python
-    >>> for image, labels in dataset:
+    >>> for name, image, labels in dataset:
     ...     print(labels.xyxy)
 
     array([[404.      , 719.      , 538.      , 884.5     ],


### PR DESCRIPTION
Example in README documentation out of date for v.0.8.0.  __iter__() yields a length 3 tuple.  Example shows a length 2 tuple. 

Change proposed: add image_name to example to align with current version of DetectorDataset objects.

Reference: From API docs

```
__iter__() ¶
Iterate over the images and annotations in the dataset.

Yields:

Type	Description
Iterator[Tuple[str, np.ndarray, Detections]]	
Iterator[Tuple[str, np.ndarray, Detections]]: An iterator that yields tuples containing the image name, the image data, and its corresponding annotation.
```

# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

List any dependencies that are required for this change.

## Type of change
[X] Documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Example in README yields error 
```python
for image, label in dataset:
    print(label.xyxy)
    
ValueError: too many values to unpack (expected 2)
```

Changed example does not yield error:
```python
for image_name, image, label in dataset:
    print(label.xyxy)
```

## Any specific deployment considerations

Did not check all other documents for instances of this change not being updated.

## Docs

-   [X] Docs updated? What were the changes: Change to example in README.md file.
