### PR TITLE
Add unicode label support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setuptools.setup(
         'numpy>=1.20.0',
         'opencv-python',
         'matplotlib',
-        'pyyaml'
+        'pyyaml',
+        'pillow'
     ],
     packages=find_packages(exclude=("tests",)),
     extras_require={


### PR DESCRIPTION
This PR solves the issue in rendering unicode label. For more details, please see issue #143
The unicode rendering issue is not caused by `Supervision` itself. Thus, I think this is a new feature. 

No breaking change added.

For not violating the framework layout, I leave the primitive code in the source with comment. I think it's better be an absolute layer of text rendering (maybe?)

I tested the code with my project in Chinese. It works fine.

With unicode label support, some fancy features can be achieved. Like drawing emoji in labels, or auto label translation with translation api. 