### PR TITLE
Fix top_k processing in as_folder_structure

### DIFF
--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -584,7 +584,7 @@ class ClassificationDataset(BaseDataset):
             class_id = (
                 classification.class_id[0]
                 if classification.confidence is None
-                else classification.get_top_k(1)[0]
+                else classification.get_top_k(1)[0][0]
             )
             class_name = self.classes[class_id]
             image_path = os.path.join(root_directory_path, class_name, image_name)


### PR DESCRIPTION
This PR fixes a bug where, if the `classification.get_top_k(1)[0][0]` line of code is called in the `as_folder_structure` function, an error is returned.