### PR TITLE
Mmdetection support

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -229,7 +229,7 @@ class Detections:
         )
 
     @classmethod
-    def from_mmdet(cls, mmdet_results) -> Detections:
+    def from_mmdetection(cls, mmdet_results) -> Detections:
         """
         Creates a Detections instance from a [mmdetection](https://github.com/open-mmlab/mmdetection) inference result.
         Also supported for [mmyolo](https://github.com/open-mmlab/mmyolo)
@@ -258,7 +258,7 @@ class Detections:
         return cls(
             xyxy=mmdet_results.pred_instances.bboxes.xyxy.cpu().numpy(),
             confidence=mmdet_results.pred_instances.scores.cpu().numpy(),
-            class_id=mmdet_results.pred_instances.labels.cpu().numpy().astype(int)
+            class_id=mmdet_results.pred_instances.labels.cpu().numpy().astype(int),
         )
 
     @classmethod

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -229,6 +229,39 @@ class Detections:
         )
 
     @classmethod
+    def from_mmdet(cls, mmdet_results) -> Detections:
+        """
+        Creates a Detections instance from a [mmdetection](https://github.com/open-mmlab/mmdetection) inference result.
+        Also supported for [mmyolo](https://github.com/open-mmlab/mmyolo)
+
+        Args:
+        mmdet_results (mmdet.structures.DetDataSample): The output Results instance from MMDetection
+
+        Returns:
+        Detections: A new Detections object.
+
+        Example:
+            ```python
+            >>> import cv2
+            >>> import supervision as sv
+            >>> from mmdet.apis import inference_detector, init_detector
+            >>> from mmengine.config import Config
+
+            >>> image = cv2.imread(SOURCE_IMAGE_PATH)
+            >>> config = Config.fromfile(CONFIG)
+            >>> model = init_detector(config, CHECKPOINT, device=device, cfg_options={})
+            >>> img_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            >>> mmdet_result = inference_detector(model, img_rgb)
+            >>> detections = sv.Detections.from_mmdet(mmdet_result)
+            ```
+        """
+        return cls(
+            xyxy=mmdet_results.pred_instances.bboxes.xyxy.cpu().numpy(),
+            confidence=mmdet_results.pred_instances.scores.cpu().numpy(),
+            class_id=mmdet_results.pred_instances.labels.cpu().numpy().astype(int)
+        )
+
+    @classmethod
     def from_transformers(cls, transformers_results: dict) -> Detections:
         """
         Creates a Detections instance from object detection [transformer](https://github.com/huggingface/transformers) inference result.


### PR DESCRIPTION
# Description

Support for [MMDetection](https://github.com/open-mmlab/mmdetection) inference result. This method also supports for [mmyolo](https://github.com/open-mmlab/mmyolo)

Get more information on inference datatype from [here](https://mmdetection.readthedocs.io/en/latest/api.html#mmdet-structures)


## Type of change

-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## Docs

-   [ ] Docs updated? What were the changes:
