### PR TITLE
fix: 🐛 package version control if PackageNotFoundError occured

### DIFF
--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -1,6 +1,10 @@
 import importlib.metadata as importlib_metadata
 
-__version__ = importlib_metadata.version(__package__)
+try:
+    # This will read version from pyproject.toml
+    __version__ = importlib_metadata.version(__package__ or __name__)
+except importlib_metadata.PackageNotFoundError:
+    __version__ = "development"
 
 
 from supervision.classification.core import Classifications


### PR DESCRIPTION
# Description

Fix #213 for no install method (poetry or pip install .  "install package" so we can find version If none happen __version__ check will fail, to prevent that changed in to "development" tag for set to version.

-   [X] Bug fix (non-breaking change which fixes an issue)



