### PR TITLE
🛠️ #212 bug fix

### DIFF
--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -69,7 +69,10 @@ def _with_mask(lines: List[str]) -> bool:
 
 def _extract_class_names(file_path: str) -> List[str]:
     data = read_yaml_file(file_path=file_path)
-    return data["names"]
+    names = data["names"]
+    if isinstance(names, dict):
+        names = [names[key] for key in sorted(names.keys())]
+    return names
 
 
 def _image_name_to_annotation_name(image_name: str) -> str:

--- a/supervision/metrics/detection.py
+++ b/supervision/metrics/detection.py
@@ -85,10 +85,10 @@ class ConfusionMatrix:
         target_tensors = []
         for prediction, target in zip(predictions, targets):
             prediction_tensors.append(
-                cls.detections_to_tensor(prediction, with_confidence=True)
+                ConfusionMatrix.detections_to_tensor(prediction, with_confidence=True)
             )
             target_tensors.append(
-                cls.detections_to_tensor(target, with_confidence=False)
+                ConfusionMatrix.detections_to_tensor(target, with_confidence=False)
             )
         return cls.from_tensors(
             predictions=prediction_tensors,
@@ -98,9 +98,9 @@ class ConfusionMatrix:
             iou_threshold=iou_threshold,
         )
 
-    @classmethod
+    @staticmethod
     def detections_to_tensor(
-        cls, detections: Detections, with_confidence: bool = False
+        detections: Detections, with_confidence: bool = False
     ) -> np.ndarray:
         if detections.class_id is None:
             raise ValueError(


### PR DESCRIPTION
# Description

It is the fix for #212. Turns out that the problem is not with the confusion matrix but with the loading of the YOLO dataset. I thought that `names` value in `data.yaml` can only be `List[str]` but it can also be `Dict[int, str]`. I added some logic to handle that.

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Tested in Google Colab

## Docs

-   [ ] Docs updated? What were the changes:
