### PR TITLE
Format coco output data as per standard

### DIFF
--- a/supervision/dataset/formats/coco.py
+++ b/supervision/dataset/formats/coco.py
@@ -124,7 +124,7 @@ def detections_to_coco_annotations(
             "category_id": int(class_id),
             "bbox": [xyxy[0], xyxy[1], box_width, box_height],
             "area": box_width * box_height,
-            "segmentation": polygon,
+            "segmentation": [polygon],
             "iscrowd": 0,
         }
         coco_annotations.append(coco_annotation)

--- a/supervision/dataset/formats/coco.py
+++ b/supervision/dataset/formats/coco.py
@@ -124,7 +124,7 @@ def detections_to_coco_annotations(
             "category_id": int(class_id),
             "bbox": [xyxy[0], xyxy[1], box_width, box_height],
             "area": box_width * box_height,
-            "segmentation": [polygon],
+            "segmentation": [polygon] if polygon else [],
             "iscrowd": 0,
         }
         coco_annotations.append(coco_annotation)


### PR DESCRIPTION
# Description

Fixes https://github.com/roboflow/supervision/issues/205

The issue was compatible with supervision because even though supervision exports data in the wrong format, its function to read coco dataset works for both the correct and malformed output format 
Refer: https://github.com/roboflow/supervision/blob/20954a299660a1f227a772a0a7cd253761ddb9da/supervision/dataset/formats/coco.py#L87
```
        polygons = [
            np.reshape(
                np.asarray(image_annotation["segmentation"], dtype=np.int32), (-1, 2)
            )
            for image_annotation in image_annotations
        ]
```
Regardless of the format of `image_annotation["segmentation"]`, data is loaded in expected shape 

With this fix, data stored will be in expected format. 


## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

While I have not tested it by loading exported format in a third party tool, I have gone through the exported annotations file and validated the format. 
If we have a specific third party tool/ coco format validator in mind, we can make sure the updated file works well with it. 
Gist of exported json: https://gist.github.com/mayankagarwals/3fb243c7a776ee5b8986386aef60b76d

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
