### PR TITLE
Fix inconsistent force_masks across dataset formats

### DIFF
--- a/supervision/dataset/formats/coco.py
+++ b/supervision/dataset/formats/coco.py
@@ -160,10 +160,14 @@ def load_coco_annotations(
         image_path = os.path.join(images_directory_path, image_name)
 
         image = cv2.imread(str(image_path))
+
+        with_masks = _with_mask(image_annotations[0])
+        with_masks = force_masks if force_masks else with_masks
+
         annotation = coco_annotations_to_detections(
             image_annotations=image_annotations,
             resolution_wh=(image_width, image_height),
-            with_masks=force_masks,
+            with_masks=with_masks,
         )
         annotation = map_detections_class_id(
             source_to_target_mapping=class_index_mapping,
@@ -174,6 +178,10 @@ def load_coco_annotations(
         annotations[image_name] = annotation
 
     return classes, images, annotations
+
+
+def _with_mask(annotation: dict) -> bool:
+    return "segmentation" in annotation
 
 
 def save_coco_annotations(

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -221,7 +221,7 @@ def detections_from_xml_obj(
 
         xyxy.append([x1, y1, x2, y2])
 
-        with_masks = obj.find("polygon") is not None
+        with_masks = _with_mask(obj)
         with_masks = force_masks if force_masks else with_masks
 
         for polygon in obj.findall("polygon"):
@@ -248,6 +248,10 @@ def detections_from_xml_obj(
     else:
         annotation = Detections(xyxy=xyxy, class_id=class_id)
     return annotation, extended_classes
+
+
+def _with_mask(obj: Element):
+    return obj.find("polygon") is not None
 
 
 def parse_polygon_points(polygon: Element) -> List[List[int]]:


### PR DESCRIPTION
# Description

`load_coco_annotations` used `force_masks` as a flag that indicates if masks should be parsed or not. On the contrary, YOLO and VOC enforce parsing masks if this flag is set, or parse masks in case they are present in annotations. Current change homogenizes the behavior, setting it to the second option.

## Type of change

Please delete options that are not relevant.

-   [+] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Does not impact anything.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
