### PR TITLE
Image Path as keys for DetectionDataset

### DIFF
--- a/supervision/dataset/formats/coco.py
+++ b/supervision/dataset/formats/coco.py
@@ -157,9 +157,9 @@ def load_coco_annotations(
             coco_image["height"],
         )
         image_annotations = coco_annotations_groups.get(coco_image["id"], [])
-        image_path = os.path.join(images_directory_path, image_name)
+        image_path = str(os.path.join(images_directory_path, image_name))
 
-        image = cv2.imread(str(image_path))
+        image = cv2.imread(image_path)
         annotation = coco_annotations_to_detections(
             image_annotations=image_annotations,
             resolution_wh=(image_width, image_height),
@@ -170,8 +170,8 @@ def load_coco_annotations(
             detections=annotation,
         )
 
-        images[image_name] = image
-        annotations[image_name] = annotation
+        images[image_path] = image
+        annotations[image_path] = annotation
 
     return classes, images, annotations
 

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -168,7 +168,8 @@ def load_pascal_voc_annotations(
 
     for image_path in image_paths:
         image_name = Path(image_path).stem
-        image = cv2.imread(str(image_path))
+        image_path = str(image_path)
+        image = cv2.imread(image_path)
 
         annotation_path = os.path.join(annotations_directory_path, f"{image_name}.xml")
         if not os.path.exists(annotation_path):
@@ -184,8 +185,8 @@ def load_pascal_voc_annotations(
             root, classes, resolution_wh, force_masks
         )
 
-        images[image_path.name] = image
-        annotations[image_path.name] = annotation
+        images[image_path] = image
+        annotations[image_path] = annotation
 
     return classes, images, annotations
 

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -173,8 +173,8 @@ def load_pascal_voc_annotations(
 
         annotation_path = os.path.join(annotations_directory_path, f"{image_name}.xml")
         if not os.path.exists(annotation_path):
-            images[image_path.name] = image
-            annotations[image_path.name] = Detections.empty()
+            images[image_path] = image
+            annotations[image_path] = Detections.empty()
             continue
 
         tree = parse(annotation_path)

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -140,12 +140,13 @@ def load_yolo_annotations(
 
     for image_path in image_paths:
         image_name = Path(image_path).stem
-        image = cv2.imread(str(image_path))
+        image_path = str(image_path)
+        image = cv2.imread(image_path)
 
         annotation_path = os.path.join(annotations_directory_path, f"{image_name}.txt")
         if not os.path.exists(annotation_path):
-            images[image_path.name] = image
-            annotations[image_path.name] = Detections.empty()
+            images[image_path] = image
+            annotations[image_path] = Detections.empty()
             continue
 
         lines = read_txt_file(str(annotation_path))
@@ -158,8 +159,8 @@ def load_yolo_annotations(
             lines=lines, resolution_wh=resolution_wh, with_masks=with_masks
         )
 
-        images[image_path.name] = image
-        annotations[image_path.name] = annotation
+        images[image_path] = image
+        annotations[image_path] = annotation
     return classes, images, annotations
 
 


### PR DESCRIPTION
# Description

`sv.DetectionDatasets` is using `image_name` as keys for `Dict`. This can be leading to create issues like same there can be possibility of having same name in multiple dataset. Also, saving `image_path` can be useful for not loading the whole image dataset but only load when necessary.

This PR is only redesigning the existing code.
