### PR TITLE
fix(docs): 📚🐛 deprecated for "from_yolov8" desc fix for detection

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -180,8 +180,8 @@ class Detections:
     @classmethod
     @deprecated(
         """
-        This method is deprecated and removed in 0.16.0 release.
-        Use sv.Classifications.from_ultralytics() instead as it is more generic and
+        This method is deprecated and removed in 0.15.0 release.
+        Use sv.Detections.from_ultralytics() instead as it is more generic and
         can be used for detections from any ultralytics.engine.results.Results Object
         """
     )


### PR DESCRIPTION
### Description

`sv.Detections.from_ultralytics() ` and `sv.Classifications.from_ultralytics()`  have different outputs I think it is a overlook part in documentation in https://github.com/roboflow/supervision/pull/281. If I missing something please let me know. 

Thank you.

### Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [X] This change requires a documentation update

### Docs

-   [X] Docs updated? What were the changes:
