### PR TITLE
fixed empty detections for deepsparse

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -324,15 +324,15 @@ class Detections:
             ...                  "ultralytics/coco/pruned80_quant-none"
             >>> pipeline_outputs = yolo_pipeline(SOURCE_IMAGE_PATH,
             ...                         iou_thres=0.6, conf_thres=0.001)
-            >>> result = list(pipeline_outputs.boxes[0])
-            >>> detections = sv.Detections.from_yolo_nas(result)
+            >>> detections = sv.Detections.from_deepsparse(result)
             ```
         """
-        return cls(
-            xyxy=np.array(deepsparse_results.boxes[0]),
-            confidence=np.array(deepsparse_results.scores[0]),
-            class_id=np.array(deepsparse_results.labels[0]).astype(float).astype(int),
-        )
+        if np.asarray(deepsparse_results.boxes[0]).shape[0] == 0:
+            return cls.empty()
+        else:
+            return cls(xyxy=np.array(deepsparse_results.boxes[0]),
+                        confidence=np.array(deepsparse_results.scores[0]),
+                        class_id=np.array(deepsparse_results.labels[0]).astype(float).astype(int))
 
     @classmethod
     def from_mmdetection(cls, mmdet_results) -> Detections:

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -330,9 +330,13 @@ class Detections:
         if np.asarray(deepsparse_results.boxes[0]).shape[0] == 0:
             return cls.empty()
         else:
-            return cls(xyxy=np.array(deepsparse_results.boxes[0]),
-                        confidence=np.array(deepsparse_results.scores[0]),
-                        class_id=np.array(deepsparse_results.labels[0]).astype(float).astype(int))
+            return cls(
+                xyxy=np.array(deepsparse_results.boxes[0]),
+                confidence=np.array(deepsparse_results.scores[0]),
+                class_id=np.array(deepsparse_results.labels[0])
+                .astype(float)
+                .astype(int),
+            )
 
     @classmethod
     def from_mmdetection(cls, mmdet_results) -> Detections:


### PR DESCRIPTION
# Description

This PR is for #347 . The main reason was that it was not able to handle empty detections. Also documentation is fixed now.


Colab link: https://colab.research.google.com/drive/17AROUpY_vHKXW0RG2_4VzXiDqPps09TI?usp=sharing
## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

