### PR TITLE
Add concurrent processing for `sv.InferenceSlicer`

### DIFF
--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -6,6 +6,8 @@ from supervision.detection.core import Detections, validate_inference_callback
 from supervision.detection.utils import move_boxes
 from supervision.utils.image import crop_image
 
+import concurrent.futures
+
 
 def move_detections(detections: Detections, offset: np.array) -> Detections:
     """
@@ -97,14 +99,33 @@ class InferenceSlicer:
             overlap_ratio_wh=self.overlap_ratio_wh,
         )
 
-        for offset in offsets:
-            image_slice = crop_image(image=image, xyxy=offset)
-            detections = self.callback(image_slice)
-            detections = move_detections(detections=detections, offset=offset[:2])
-            detections_list.append(detections)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [
+                executor.submit(self._run_callback, image, offset) for offset in offsets
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                detections_list.append(future.result())
+
         return Detections.merge(detections_list=detections_list).with_nms(
             threshold=self.iou_threshold
         )
+
+    def _run_callback(self, image, offset) -> Detections:
+        """
+        Run the provided callback on a slice of an image.
+
+        Args:
+            image (np.ndarray): The input image on which inference needs to run
+            offset (np.ndarray): An array of shape `(4,)` containing coordinates for the slice.
+
+        Returns:
+            Detections: A collection of detections for the slice.
+        """
+        image_slice = crop_image(image=image, xyxy=offset)
+        detections = self.callback(image_slice)
+        detections = move_detections(detections=detections, offset=offset[:2])
+
+        return detections
 
     @staticmethod
     def _generate_offset(

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -51,11 +51,13 @@ class InferenceSlicer:
         slice_wh: Tuple[int, int] = (320, 320),
         overlap_ratio_wh: Tuple[float, float] = (0.2, 0.2),
         iou_threshold: Optional[float] = 0.5,
+        thread_workers: int = 1,
     ):
         self.slice_wh = slice_wh
         self.overlap_ratio_wh = overlap_ratio_wh
         self.iou_threshold = iou_threshold
         self.callback = callback
+        self.thread_workers = thread_workers
         validate_inference_callback(callback=callback)
 
     def __call__(self, image: np.ndarray) -> Detections:
@@ -98,7 +100,7 @@ class InferenceSlicer:
             overlap_ratio_wh=self.overlap_ratio_wh,
         )
 
-        with ThreadPoolExecutor(max_workers=8) as executor:
+        with ThreadPoolExecutor(max_workers=self.thread_workers) as executor:
             futures = [
                 executor.submit(self._run_callback, image, offset) for offset in offsets
             ]

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -117,7 +117,8 @@ class InferenceSlicer:
 
         Args:
             image (np.ndarray): The input image on which inference needs to run
-            offset (np.ndarray): An array of shape `(4,)` containing coordinates for the slice.
+            offset (np.ndarray): An array of shape `(4,)` containing coordinates
+                for the slice.
 
         Returns:
             Detections: A collection of detections for the slice.

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -1,4 +1,4 @@
-from concurrent.futures import ThreadPoolExecutor,as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Optional, Tuple
 
 import numpy as np

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 from typing import Callable, Optional, Tuple
 
 import numpy as np
@@ -5,8 +6,6 @@ import numpy as np
 from supervision.detection.core import Detections, validate_inference_callback
 from supervision.detection.utils import move_boxes
 from supervision.utils.image import crop_image
-
-import concurrent.futures
 
 
 def move_detections(detections: Detections, offset: np.array) -> Detections:

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -28,15 +28,16 @@ class InferenceSlicer:
     larger image into smaller slices, performing inference on each slice, and then
     merging the detections.
 
-    Attributes:
+    Args:
         slice_wh (Tuple[int, int]): Dimensions of each slice in the format
             `(width, height)`.
         overlap_ratio_wh (Tuple[float, float]): Overlap ratio between consecutive
             slices in the format `(width_ratio, height_ratio)`.
-        iou_threshold (Optional[float]): Intersection over Union (IoU) threshold used
-            for non-max suppression.
-        callback (Callable): A function that performs inference on a given image slice
-            and returns detections.
+        iou_threshold (Optional[float]): Intersection over Union (IoU) threshold
+            used for non-max suppression.
+        callback (Callable): A function that performs inference on a given image
+            slice and returns detections.
+        thread_workers (int): Number of threads for parallel execution.
 
     Note:
         The class ensures that slices do not exceed the boundaries of the original

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -1,4 +1,4 @@
-import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor,as_completed
 from typing import Callable, Optional, Tuple
 
 import numpy as np
@@ -98,11 +98,11 @@ class InferenceSlicer:
             overlap_ratio_wh=self.overlap_ratio_wh,
         )
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        with ThreadPoolExecutor(max_workers=8) as executor:
             futures = [
                 executor.submit(self._run_callback, image, offset) for offset in offsets
             ]
-            for future in concurrent.futures.as_completed(futures):
+            for future in as_completed(futures):
                 detections_list.append(future.result())
 
         return Detections.merge(detections_list=detections_list).with_nms(


### PR DESCRIPTION
# Description

This PR adds concurrent processing with the `concurrent.futures` threading method (part of the [Python standard library](https://docs.python.org/3/library/concurrent.futures.html)) to `sv.InferenceSlicer` processing.

This PR drastically reduces inference times with the slicer.

Without concurrent processing:

```
Detections w/o SAHI: 127
--- 1.460580825805664 seconds ---
Detections w/ SAHI: 146
--- 13.294042110443115 seconds ---
``` 

With concurrent processing slicer:

```
Detections w/o SAHI: 127
--- 1.4807708263397217 seconds ---
Detections w/ SAHI: 146
--- 2.305016040802002 seconds ---
```

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

This change has been tested using the following code to validate the number of predictions with and without concurrent processing is the same.

```python
import supervision as sv
import numpy as np
import cv2
import time
import roboflow

roboflow.login()

rf = roboflow.Roboflow()
workspace = rf.workspace()
project = workspace.project("vehicle-count-in-drone-video")
version = project.version(6)
model = version.model

def callback(x: np.ndarray) -> sv.Detections:
    result = model.predict(x).json()
    return sv.Detections.from_roboflow(result, class_list=list(project.classes.keys()))

image = cv2.imread("./original.jpg")
image_width = image.shape[1]
image_height = image.shape[0]

print("starting test...")

start_time = time.time()

slicer = callback(image)

print("Detections w/o SAHI:", len(slicer.xyxy))
print("--- %s seconds ---" % (time.time() - start_time))

start_time = time.time()

slicer = sv.InferenceSlicer(callback=callback)
sliced_detections = slicer(image=image)

prediction_num = len(sliced_detections.xyxy)

# sv.plot_image(sliced_image)
print("Detections w/ SAHI:", prediction_num)

print("--- %s seconds ---" % (time.time() - start_time))
```

## Any specific deployment considerations

N/A

## Docs

N/A