### PR TITLE
Remove class list dependency for roboflow to detection conversion

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -432,7 +432,7 @@ class Detections:
         )
 
     @classmethod
-    def from_roboflow(cls, roboflow_result: dict, class_list: List[str]) -> Detections:
+    def from_roboflow(cls, roboflow_result: dict) -> Detections:
         """
         Create a Detections object from the [Roboflow](https://roboflow.com/)
             API inference result.
@@ -440,8 +440,6 @@ class Detections:
         Args:
             roboflow_result (dict): The result from the
                 Roboflow API containing predictions.
-            class_list (List[str]): A list of class names
-                corresponding to the class IDs in the API result.
 
         Returns:
             (Detections): A Detections object containing the bounding boxes, class IDs,
@@ -464,13 +462,12 @@ class Detections:
             ...         # ... more predictions ...
             ...     ]
             ... }
-            >>> class_list = ["person", "car", "dog"]
 
-            >>> detections = sv.Detections.from_roboflow(roboflow_result, class_list)
+            >>> detections = sv.Detections.from_roboflow(roboflow_result)
             ```
         """
         xyxy, confidence, class_id, masks = process_roboflow_result(
-            roboflow_result=roboflow_result, class_list=class_list
+            roboflow_result=roboflow_result 
         )
 
         if np.asarray(xyxy).shape[0] == 0:

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -456,6 +456,7 @@ class Detections:
             ...             "y": 0.5,
             ...             "width": 0.2,
             ...             "height": 0.3,
+            ...             "class_id": 0,
             ...             "class": "person",
             ...             "confidence": 0.9
             ...         },

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -467,7 +467,7 @@ class Detections:
             ```
         """
         xyxy, confidence, class_id, masks = process_roboflow_result(
-            roboflow_result=roboflow_result 
+            roboflow_result=roboflow_result
         )
 
         if np.asarray(xyxy).shape[0] == 0:

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -332,7 +332,7 @@ def extract_ultralytics_masks(yolov8_results) -> Optional[np.ndarray]:
 
 
 def process_roboflow_result(
-    roboflow_result: dict
+    roboflow_result: dict,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Optional[np.ndarray]]:
     if not roboflow_result["predictions"]:
         return np.empty((0, 4)), np.empty(0), np.empty(0), None

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -357,7 +357,7 @@ def process_roboflow_result(
 
         if "points" not in prediction:
             xyxy.append([x_min, y_min, x_max, y_max])
-            class_id.append(int(prediction["class"]))
+            class_id.append(prediction["class_id"])
             confidence.append(prediction["confidence"])
         elif len(prediction["points"]) >= 3:
             polygon = np.array(
@@ -365,7 +365,7 @@ def process_roboflow_result(
             )
             mask = polygon_to_mask(polygon, resolution_wh=(image_width, image_height))
             xyxy.append([x_min, y_min, x_max, y_max])
-            class_id.append(int(prediction["class"]))
+            class_id.append(prediction["class_id"])
             confidence.append(prediction["confidence"])
             masks.append(mask)
 

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -332,7 +332,7 @@ def extract_ultralytics_masks(yolov8_results) -> Optional[np.ndarray]:
 
 
 def process_roboflow_result(
-    roboflow_result: dict, class_list: List[str]
+    roboflow_result: dict
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Optional[np.ndarray]]:
     if not roboflow_result["predictions"]:
         return np.empty((0, 4)), np.empty(0), np.empty(0), None
@@ -357,7 +357,7 @@ def process_roboflow_result(
 
         if "points" not in prediction:
             xyxy.append([x_min, y_min, x_max, y_max])
-            class_id.append(class_list.index(prediction["class"]))
+            class_id.append(int(prediction["class"]))
             confidence.append(prediction["confidence"])
         elif len(prediction["points"]) >= 3:
             polygon = np.array(
@@ -365,7 +365,7 @@ def process_roboflow_result(
             )
             mask = polygon_to_mask(polygon, resolution_wh=(image_width, image_height))
             xyxy.append([x_min, y_min, x_max, y_max])
-            class_id.append(class_list.index(prediction["class"]))
+            class_id.append(int(prediction["class"]))
             confidence.append(prediction["confidence"])
             masks.append(mask)
 

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -264,7 +264,6 @@ def test_filter_polygons_by_area(
     [
         (
             {"predictions": [], "image": {"width": 1000, "height": 1000}},
-            ["person", "car", "truck"],
             (np.empty((0, 4)), np.empty(0), np.empty(0), None),
             DoesNotRaise(),
         ),  # empty result
@@ -282,7 +281,6 @@ def test_filter_polygons_by_area(
                 ],
                 "image": {"width": 1000, "height": 1000},
             },
-            ["person", "car", "truck"],
             (
                 np.array([[175.0, 275.0, 225.0, 325.0]]),
                 np.array([0.9]),
@@ -313,7 +311,6 @@ def test_filter_polygons_by_area(
                 ],
                 "image": {"width": 1000, "height": 1000},
             },
-            ["person", "car", "truck"],
             (
                 np.array([[175.0, 275.0, 225.0, 325.0], [450.0, 450.0, 550.0, 550.0]]),
                 np.array([0.9, 0.8]),
@@ -337,7 +334,6 @@ def test_filter_polygons_by_area(
                 ],
                 "image": {"width": 1000, "height": 1000},
             },
-            ["person", "car", "truck"],
             (np.empty((0, 4)), np.empty(0), np.empty(0), None),
             DoesNotRaise(),
         ),  # single incorrect instance segmentation result with no points
@@ -356,7 +352,6 @@ def test_filter_polygons_by_area(
                 ],
                 "image": {"width": 1000, "height": 1000},
             },
-            ["person", "car", "truck"],
             (np.empty((0, 4)), np.empty(0), np.empty(0), None),
             DoesNotRaise(),
         ),  # single incorrect instance segmentation result with no enough points
@@ -380,7 +375,6 @@ def test_filter_polygons_by_area(
                 ],
                 "image": {"width": 1000, "height": 1000},
             },
-            ["person", "car", "truck"],
             (
                 np.array([[175.0, 275.0, 225.0, 325.0]]),
                 np.array([0.9]),
@@ -418,7 +412,6 @@ def test_filter_polygons_by_area(
                 ],
                 "image": {"width": 1000, "height": 1000},
             },
-            ["person", "car", "truck"],
             (
                 np.array([[175.0, 275.0, 225.0, 325.0]]),
                 np.array([0.9]),
@@ -437,7 +430,7 @@ def test_process_roboflow_result(
 ) -> None:
     with exception:
         result = process_roboflow_result(
-            roboflow_result=roboflow_result, class_list=class_list
+            roboflow_result=roboflow_result
         )
         assert np.array_equal(result[0], expected_result[0])
         assert np.array_equal(result[1], expected_result[1])

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -260,7 +260,7 @@ def test_filter_polygons_by_area(
 
 
 @pytest.mark.parametrize(
-    "roboflow_result, class_list, expected_result, exception",
+    "roboflow_result, expected_result, exception",
     [
         (
             {"predictions": [], "image": {"width": 1000, "height": 1000}},
@@ -276,6 +276,7 @@ def test_filter_polygons_by_area(
                         "width": 50.0,
                         "height": 50.0,
                         "confidence": 0.9,
+                        "class_id": 0,
                         "class": "person",
                     }
                 ],
@@ -298,6 +299,7 @@ def test_filter_polygons_by_area(
                         "width": 50.0,
                         "height": 50.0,
                         "confidence": 0.9,
+                        "class_id": 0,
                         "class": "person",
                     },
                     {
@@ -306,6 +308,7 @@ def test_filter_polygons_by_area(
                         "width": 100.0,
                         "height": 100.0,
                         "confidence": 0.8,
+                        "class_id": 7,
                         "class": "truck",
                     },
                 ],
@@ -314,7 +317,7 @@ def test_filter_polygons_by_area(
             (
                 np.array([[175.0, 275.0, 225.0, 325.0], [450.0, 450.0, 550.0, 550.0]]),
                 np.array([0.9, 0.8]),
-                np.array([0, 2]),
+                np.array([0, 7]),
                 None,
             ),
             DoesNotRaise(),
@@ -328,6 +331,7 @@ def test_filter_polygons_by_area(
                         "width": 50.0,
                         "height": 50.0,
                         "confidence": 0.9,
+                        "class_id": 0,
                         "class": "person",
                         "points": [],
                     }
@@ -346,6 +350,7 @@ def test_filter_polygons_by_area(
                         "width": 50.0,
                         "height": 50.0,
                         "confidence": 0.9,
+                        "class_id": 0,
                         "class": "person",
                         "points": [{"x": 200.0, "y": 300.0}, {"x": 250.0, "y": 300.0}],
                     }
@@ -364,6 +369,7 @@ def test_filter_polygons_by_area(
                         "width": 50.0,
                         "height": 50.0,
                         "confidence": 0.9,
+                        "class_id": 0,
                         "class": "person",
                         "points": [
                             {"x": 200.0, "y": 300.0},
@@ -392,6 +398,7 @@ def test_filter_polygons_by_area(
                         "width": 50.0,
                         "height": 50.0,
                         "confidence": 0.9,
+                        "class_id": 0,
                         "class": "person",
                         "points": [
                             {"x": 200.0, "y": 300.0},
@@ -406,6 +413,7 @@ def test_filter_polygons_by_area(
                         "width": 100.0,
                         "height": 100.0,
                         "confidence": 0.8,
+                        "class_id": 7,
                         "class": "truck",
                         "points": [],
                     },
@@ -424,7 +432,6 @@ def test_filter_polygons_by_area(
 )
 def test_process_roboflow_result(
     roboflow_result: dict,
-    class_list: List[str],
     expected_result: Tuple[np.ndarray, np.ndarray, np.ndarray, Optional[np.ndarray]],
     exception: Exception,
 ) -> None:

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -429,9 +429,7 @@ def test_process_roboflow_result(
     exception: Exception,
 ) -> None:
     with exception:
-        result = process_roboflow_result(
-            roboflow_result=roboflow_result
-        )
+        result = process_roboflow_result(roboflow_result=roboflow_result)
         assert np.array_equal(result[0], expected_result[0])
         assert np.array_equal(result[1], expected_result[1])
         assert np.array_equal(result[2], expected_result[2])


### PR DESCRIPTION
remoed class_list arg from core.py file

# Description

No need to ask user for providing  `class_list`
simplify the [sv.Detections.from_roboflow](https://supervision.roboflow.com/detection/core/#supervision.detection.core.Detections.from_roboflow) API and remove extra argument.

solved this issue : https://github.com/roboflow/supervision/issues/394



Please delete options that are not relevant.
-   [ x] New feature (non-breaking change which adds functionality)
-   [ x] This change requires a documentation update

## Docs

-   [ ] Docs updated? What were the changes:
- once this is perfect ill update docs
