### PR TITLE
Add color mapping strategy to InferenceSlicer

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -582,7 +582,7 @@ class TraceAnnotator:
         position: Optional[Position] = Position.CENTER,
         trace_length: int = 30,
         thickness: int = 2,
-        color_map: str = "class"
+        color_map: str = "class",
     ):
         """
         Args:


### PR DESCRIPTION
# Description

Added a new argument, 'color_map' in InferenceSlicer to provide more options for color coding while annotating. This includes mapping colors by 'index', 'class' or 'track'. Also refactored the way colors are resolved by separating the responsibility into a new function 'resolve_color_idx' and 'resolve_color'.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update
