### PR TITLE
add #a351fb as first default color into sv.draw.color.ColorPalette

### DIFF
--- a/supervision/draw/color.py
+++ b/supervision/draw/color.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import List, Tuple
 
 DEFAULT_COLOR_PALETTE = [
+    "#a351fb",
     "#e6194b",
     "#3cb44b",
     "#ffe119",


### PR DESCRIPTION
# Description

Added #a351fb as the first default color in `sv.draw.color.ColorPalette`

Fix: #424 

## Type of change

-   [x] Enhancement/ Bug fix (non-breaking change which fixes an issue) 
