### PR TITLE
faster sv.MaskAnnotator

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -151,12 +151,14 @@ class MaskAnnotator(BaseAnnotator):
             colored_mask = np.zeros_like(scene, dtype=np.uint8)
             color_bgr = color.as_bgr()
             colored_mask[:] = color_bgr
-            colored_scene = cv2.addWeighted(colored_mask, self.opacity, scene, 1 - self.opacity, 0)
-            empty = np.zeros((mask.shape[0],mask.shape[1],1), dtype=np.uint8) 
-            empty[mask]=255
+            colored_scene = cv2.addWeighted(
+                colored_mask, self.opacity, scene, 1 - self.opacity, 0
+            )
+            empty = np.zeros((mask.shape[0], mask.shape[1], 1), dtype=np.uint8)
+            empty[mask] = 255
             scene = cv2.bitwise_and(scene, scene, mask=cv2.bitwise_not(empty))
             top = cv2.bitwise_and(colored_scene, colored_scene, mask=empty)
-            scene = cv2.add(top,scene)
+            scene = cv2.add(top, scene)
         return scene
 
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -95,6 +95,7 @@ class MaskAnnotator(BaseAnnotator):
         color: Union[Color, ColorPalette] = ColorPalette.default(),
         opacity: float = 0.5,
         color_map: str = "class",
+        ver: str = "v1",
     ):
         """
         Args:

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -94,7 +94,7 @@ class MaskAnnotator(BaseAnnotator):
         self,
         color: Union[Color, ColorPalette] = ColorPalette.default(),
         opacity: float = 0.5,
-        color_map: str = "class"
+        color_map: str = "class",
     ):
         """
         Args:
@@ -153,7 +153,7 @@ class MaskAnnotator(BaseAnnotator):
             scene[mask] = cv2.addWeighted(
                 colored_mask, self.opacity, scene, 1 - self.opacity, 0
             )[mask]
-            
+
         return scene
 
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -148,13 +148,14 @@ class MaskAnnotator(BaseAnnotator):
             color = resolve_color(color=self.color, idx=idx)
             mask = detections.mask[detection_idx]
             colored_mask = np.zeros_like(scene, dtype=np.uint8)
-            colored_mask[:] = color.as_bgr()
-
-            scene = np.where(
-                np.expand_dims(mask, axis=-1),
-                np.uint8(self.opacity * colored_mask + (1 - self.opacity) * scene),
-                scene,
-            )
+            color_bgr = color.as_bgr()
+            colored_mask[:] = color_bgr
+            colored_scene = cv2.addWeighted(colored_mask, self.opacity, scene, 1 - self.opacity, 0)
+            empty = np.zeros((mask.shape[0],mask.shape[1],1), dtype=np.uint8) 
+            empty[mask]=255
+            scene = cv2.bitwise_and(scene, scene, mask=cv2.bitwise_not(empty))
+            top = cv2.bitwise_and(colored_scene, colored_scene, mask=empty)
+            scene = cv2.add(top,scene)
         return scene
 
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -94,8 +94,7 @@ class MaskAnnotator(BaseAnnotator):
         self,
         color: Union[Color, ColorPalette] = ColorPalette.default(),
         opacity: float = 0.5,
-        color_map: str = "class",
-        ver: str = "v1",
+        color_map: str = "class"
     ):
         """
         Args:
@@ -151,14 +150,10 @@ class MaskAnnotator(BaseAnnotator):
             colored_mask = np.zeros_like(scene, dtype=np.uint8)
             color_bgr = color.as_bgr()
             colored_mask[:] = color_bgr
-            colored_scene = cv2.addWeighted(
+            scene[mask] = cv2.addWeighted(
                 colored_mask, self.opacity, scene, 1 - self.opacity, 0
-            )
-            empty = np.zeros((mask.shape[0], mask.shape[1], 1), dtype=np.uint8)
-            empty[mask] = 255
-            scene = cv2.bitwise_and(scene, scene, mask=cv2.bitwise_not(empty))
-            top = cv2.bitwise_and(colored_scene, colored_scene, mask=empty)
-            scene = cv2.add(top, scene)
+            )[mask]
+            
         return scene
 
 


### PR DESCRIPTION
### Description
This PR is related to https://github.com/roboflow/supervision/issues/417
I've made some enhancements to sv.MaskAnnotator.
1. calc bgr color once for color mask creation
2. replace np.where with cv2.add operation for scene with hole and colored object

### Result 
speed up two times


