### PR TITLE
Fix return value when sv.Detections is empty

### DIFF
--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -249,6 +249,8 @@ class ByteTrack:
             detections.confidence = np.array(
                 [t.score for t in tracks], dtype=np.float32
             )
+        else:
+            return np.array([], dtype=int)
 
         return detections
 

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -250,7 +250,7 @@ class ByteTrack:
                 [t.score for t in tracks], dtype=np.float32
             )
         else:
-            return np.array([], dtype=int)
+            detections.tracker_id = np.array([], dtype=int)
 
         return detections
 


### PR DESCRIPTION
# Description

Fixes #429. When `sv.Detections` is empty (`len(detections) == 0`) `sv.ByteTrack` returns `np.array([], dtype=int)`

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
