### PR TITLE
#418 Make sv.ByteTrack work with segmentation model 

### DIFF
--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -11,7 +11,7 @@ from supervision.tracker.byte_tracker.kalman_filter import KalmanFilter
 class STrack(BaseTrack):
     shared_kalman = KalmanFilter()
 
-    def __init__(self, tlwh, score, class_ids, mask:Optional[np.array] = None):
+    def __init__(self, tlwh, score, class_ids, mask: Optional[np.array] = None):
         # wait activate
         self._tlwh = np.asarray(tlwh, dtype=np.float32)
         self.kalman_filter = None
@@ -305,7 +305,9 @@ class ByteTrack:
             """Detections"""
             detections = [
                 STrack(STrack.tlbr_to_tlwh(tlbr), s, c, m)
-                for (tlbr, s, c, m) in zip(dets, scores_keep, class_ids_keep, masks_keep)
+                for (tlbr, s, c, m) in zip(
+                    dets, scores_keep, class_ids_keep, masks_keep
+                )
             ]
         else:
             detections = []

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -75,7 +75,7 @@ class STrack(BaseTrack):
         if new_id:
             self.track_id = self.next_id()
         self.score = new_track.score
-        self.mask = new_track.mask if new_track.mask is not None else None
+        self.mask = new_track.mask
 
     def update(self, new_track, frame_id):
         """
@@ -97,8 +97,7 @@ class STrack(BaseTrack):
 
         self.score = new_track.score
 
-        self.mask = new_track.mask if new_track.mask is not None else None
-
+        self.mask = new_track.mask 
     @property
     def tlwh(self):
         """Get current position in bounding box format `(top left x, top left y,


### PR DESCRIPTION
**Description:**

This pull request addresses the following changes:

1. **ByteTrack Enhancement:**
   - Modified the `ByteTrack` module to retain information about the mask  #418 .

2. **Base Code Modification:**
   - Made adjustments to the base code to resolve the issue.

**Changes Made:**

- Added the attribute "mask" to the `STrack` class, initialized to `None` by default.
- Modified the `update` and `reactivate` methods of the `STrack` class to update the `mask` attribute with the new detection.

**Testing:**

Successfully tested the code with both object-detection and segmentation-models using the provided testing code:

```python
import supervision as sv
from tqdm import tqdm
from ultralytics import YOLO

# model = YOLO('yolov8x-seg.pt')
model = YOLO('yolov8x.pt')
video_info = sv.VideoInfo.from_video_path(video_path='walking.mp4')
frame_generator = sv.get_video_frames_generator(source_path='walking.mp4')
byte_tracker = sv.ByteTrack()
mask_annotator = sv.MaskAnnotator()
track_annotator = sv.TraceAnnotator()

with sv.VideoSink('walking-result.mp4', video_info=video_info) as sink:
    i = 0
    for frame in tqdm(frame_generator, total=video_info.total_frames):
        
        # Segmentation info is created
        result = model.track(frame, imgsz=1280, verbose=False)[0]
        detections = sv.Detections.from_ultralytics(result)
        detections = byte_tracker.update_with_detections(detections)

        # Segmentation info is no longer here
        annotated_frame = mask_annotator.annotate(
            scene=frame.copy(),
            detections=detections)
        annotated_frame = track_annotator.annotate(
            scene=annotated_frame.copy(),
            detections=detections)

        sink.write_frame(frame=annotated_frame)
        if i == 200:
            break
        i += 1

