### PR TITLE
Add sv.Keypoints method

### DIFF
--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -17,6 +17,7 @@ from supervision.annotators.core import (
     LabelAnnotator,
     MaskAnnotator,
     TraceAnnotator,
+    PoseAnnotator
 )
 from supervision.annotators.utils import ColorMap
 from supervision.classification.core import Classifications
@@ -27,6 +28,7 @@ from supervision.dataset.core import (
 )
 from supervision.detection.annotate import BoxAnnotator
 from supervision.detection.core import Detections
+from supervision.keypoint.core import Keypoints
 from supervision.detection.line_counter import LineZone, LineZoneAnnotator
 from supervision.detection.tools.inference_slicer import InferenceSlicer
 from supervision.detection.tools.polygon_zone import PolygonZone, PolygonZoneAnnotator

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -16,8 +16,8 @@ from supervision.annotators.core import (
     HaloAnnotator,
     LabelAnnotator,
     MaskAnnotator,
+    PoseAnnotator,
     TraceAnnotator,
-    PoseAnnotator
 )
 from supervision.annotators.utils import ColorMap
 from supervision.classification.core import Classifications
@@ -28,7 +28,6 @@ from supervision.dataset.core import (
 )
 from supervision.detection.annotate import BoxAnnotator
 from supervision.detection.core import Detections
-from supervision.keypoint.core import Keypoints
 from supervision.detection.line_counter import LineZone, LineZoneAnnotator
 from supervision.detection.tools.inference_slicer import InferenceSlicer
 from supervision.detection.tools.polygon_zone import PolygonZone, PolygonZoneAnnotator
@@ -45,6 +44,7 @@ from supervision.draw.color import Color, ColorPalette
 from supervision.draw.utils import draw_filled_rectangle, draw_polygon, draw_text
 from supervision.geometry.core import Point, Position, Rect
 from supervision.geometry.utils import get_polygon_center
+from supervision.keypoint.core import Keypoints
 from supervision.metrics.detection import ConfusionMatrix, MeanAveragePrecision
 from supervision.tracker.byte_tracker.core import ByteTrack
 from supervision.utils.file import list_files_with_extensions

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -914,8 +914,21 @@ class PoseAnnotator(BaseAnnotator):
         supervision-annotator-examples/bounding-box-annotator-example-purple.png)
         """
         for keypoint_idx in range(len(keypoints)):
-            for point in keypoints.keypoints[keypoint_idx].astype(int):
-                x, y = point.tolist()
+            for point in keypoints.keypoints[keypoint_idx]:
+                print(point)
+                if len(point) == 3:
+                    x, y, _ = point.tolist()
+                else:
+                    x, y = point.tolist()
+
+                # if points are 0-1 scale, convert to pixel coordinates
+                if x < 1:
+                    x = x * scene.shape[1]
+                if y < 1:
+                    y = y * scene.shape[0]
+
+                x, y = int(x), int(y)
+
                 color = resolve_color(color=self.color, idx=keypoint_idx)
 
                 cv2.circle(

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -864,7 +864,8 @@ class TraceAnnotator:
 
 class PoseAnnotator(BaseAnnotator):
     """
-    A class for drawing pose estimation keypoints on an image using provided keypoint detections.
+    A class for drawing pose estimation keypoints on an image using provided
+    keypoint detections.
     """
 
     def __init__(

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -12,9 +12,9 @@ from supervision.annotators.utils import (
     resolve_color_idx,
 )
 from supervision.detection.core import Detections
-from supervision.keypoint.core import Keypoints
 from supervision.draw.color import Color, ColorPalette
 from supervision.geometry.core import Position
+from supervision.keypoint.core import Keypoints
 
 
 class BoundingBoxAnnotator(BaseAnnotator):
@@ -860,6 +860,7 @@ class TraceAnnotator:
                     thickness=self.thickness,
                 )
         return scene
+
 
 class PoseAnnotator(BaseAnnotator):
     """

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -91,7 +91,7 @@ class Keypoints:
         MediaPipe result.
 
         Args:
-            mediapipe_results(mediapipe.pose_landmarker.PoseLandmarkerResult): 
+            mediapipe_results(mediapipe.pose_landmarker.PoseLandmarkerResult):
                 The output Results instance from MediaPipe model
 
         Returns:

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -88,10 +88,10 @@ class Keypoints:
         """
         Creates a Keypoints instance from a
         (https://developers.google.com/mediapipe/solutions/vision/pose_landmarker/python)
-        MediaPipe result. # noqa
+        MediaPipe result.
 
         Args:
-            mediapipe_results(mediapipe.tasks.python.vision.pose_landmarker.PoseLandmarkerResults): # noqa
+            mediapipe_results(mediapipe.pose_landmarker.PoseLandmarkerResult): 
                 The output Results instance from MediaPipe model
 
         Returns:

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -146,4 +146,3 @@ class Keypoints:
             keypoints=np.empty((0, 0, 2), dtype=np.float32),
             confidence=np.empty((0, 0), dtype=np.float32),
         )
-

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -87,10 +87,11 @@ class Keypoints:
     def from_mediapipe(cls, mediapipe_results) -> Keypoints:
         """
         Creates a Keypoints instance from a
-        (https://developers.google.com/mediapipe/solutions/vision/pose_landmarker/python) MediaPipe result.
+        (https://developers.google.com/mediapipe/solutions/vision/pose_landmarker/python)
+        MediaPipe result. # noqa
 
         Args:
-            mediapipe_results (mediapipe.tasks.python.vision.pose_landmarker.PoseLandmarkerResults):
+            mediapipe_results(mediapipe.tasks.python.vision.pose_landmarker.PoseLandmarkerResults): # noqa
                 The output Results instance from MediaPipe model
 
         Returns:
@@ -103,7 +104,9 @@ class Keypoints:
             >>> from mediapipe.tasks.python import vision
             >>> import supervision as sv
 
-            >>> base_options = python.BaseOptions(model_asset_path='pose_landmarker.task')
+            >>> base_options = python.BaseOptions(
+            ... model_asset_path='pose_landmarker.task'
+            >>> )
             >>> options = vision.PoseLandmarkerOptions(
             ...     base_options=base_options,
             ...     output_segmentation_masks=True

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+import numpy as np
+
+
+def _validate_keypoint_structure(keypoint: Any, n: int, m: int = 2) -> None:
+    """
+    Ensure that keypoint structure is a (N, M, 2) or (N, M, 3) shape.
+    """
+    is_valid = isinstance(keypoint, np.ndarray) and (keypoint.shape == (n, m, 2) or keypoint.shape == (n, m, 3))
+
+    if not is_valid:
+        raise ValueError("keypoint structure must be a (N, M, 2) or (N, M, 3) shape")
+    
+def _validate_confidence(confidence: Any, n: int, m: int) -> None:
+    """
+    Ensure that confidence is a (N, M) shape.
+    """
+
+    if confidence is not None:
+        is_valid = isinstance(confidence, np.ndarray) and confidence.shape == (n, m)
+        if not is_valid:
+            raise ValueError("confidence must be a (N, M) shape")
+
+@dataclass
+class Keypoints:
+    keypoints: np.ndarray
+    confidence: Optional[np.ndarray] = None
+
+    def __len__(self) -> int:
+        """
+        Return the number of keypoints.
+        """
+        return len(self.keypoints)
+
+    def __post_init__(self) -> None:
+        """
+        Validate the keypoints inputs.
+        """
+        n = len(self.keypoints)
+        m = len(self.keypoints[0]) if len(self.keypoints) > 0 else 0
+
+        _validate_keypoint_structure(self.keypoints, n, m)
+        _validate_confidence(self.confidence, n, m)
+        
+    @classmethod
+    def from_ultralytics(cls, ultralytics_results) -> Keypoints:
+        """
+        Creates a Keypoints instance from a
+        (https://github.com/ultralytics/ultralytics) inference result.
+
+        Args:
+            ultralytics_results (ultralytics.engine.results.Keypoints):
+                The output Results instance from ultralytics model
+
+        Returns:
+            Keypoints: A new Keypoints object.
+
+        Example:
+            ```python
+            >>> import cv2
+            >>> from ultralytics import YOLO
+            >>> import supervision as sv
+
+            >>> image = cv2.imread(SOURCE_IMAGE_PATH)
+            >>> model = YOLO('yolov8n-pose.pt')
+
+            >>> result = model(image)[0]
+            >>> classifications = sv.Classifications.from_ultralytics(result)
+            ```
+        """
+        xy = [item.keypoints.xy.data.cpu().numpy() for item in ultralytics_results]
+        confidence = [item.keypoints.conf.data.cpu().numpy() for item in ultralytics_results]
+
+        return cls(keypoints=np.array(xy)[0], confidence=np.array(confidence)[0])
+
+    @classmethod
+    def empty(cls) -> Keypoints:
+        """
+        Create an empty Keypoints object with no keypoints.
+
+        Returns:
+            (Keypoints): An empty Keypoints object.
+
+        Example:
+            ```python
+            >>> from supervision import Keypoints
+
+            >>> empty_keypoints = Keypoints.empty()
+            ```
+        """
+        return cls(
+            keypoints=np.empty((0, 0, 2), dtype=np.float32),
+            confidence=np.empty((0, 0), dtype=np.float32),
+        )

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -82,7 +82,7 @@ class Keypoints:
         ]
 
         return cls(keypoints=np.array(xy)[0], confidence=np.array(confidence)[0])
-    
+
     @classmethod
     def from_mediapipe(cls, mediapipe_results) -> Keypoints:
         """
@@ -117,7 +117,7 @@ class Keypoints:
             >>> pose_landmarks = sv.Keypoints.from_mediapipe(detection_result)
             ```
         """
-        
+
         xyz = []
         confidence = []
 

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -146,3 +146,4 @@ class Keypoints:
             keypoints=np.empty((0, 0, 2), dtype=np.float32),
             confidence=np.empty((0, 0), dtype=np.float32),
         )
+

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 import numpy as np
 
@@ -10,11 +10,14 @@ def _validate_keypoint_structure(keypoint: Any, n: int, m: int = 2) -> None:
     """
     Ensure that keypoint structure is a (N, M, 2) or (N, M, 3) shape.
     """
-    is_valid = isinstance(keypoint, np.ndarray) and (keypoint.shape == (n, m, 2) or keypoint.shape == (n, m, 3))
+    is_valid = isinstance(keypoint, np.ndarray) and (
+        keypoint.shape == (n, m, 2) or keypoint.shape == (n, m, 3)
+    )
 
     if not is_valid:
         raise ValueError("keypoint structure must be a (N, M, 2) or (N, M, 3) shape")
-    
+
+
 def _validate_confidence(confidence: Any, n: int, m: int) -> None:
     """
     Ensure that confidence is a (N, M) shape.
@@ -24,6 +27,7 @@ def _validate_confidence(confidence: Any, n: int, m: int) -> None:
         is_valid = isinstance(confidence, np.ndarray) and confidence.shape == (n, m)
         if not is_valid:
             raise ValueError("confidence must be a (N, M) shape")
+
 
 @dataclass
 class Keypoints:
@@ -45,7 +49,7 @@ class Keypoints:
 
         _validate_keypoint_structure(self.keypoints, n, m)
         _validate_confidence(self.confidence, n, m)
-        
+
     @classmethod
     def from_ultralytics(cls, ultralytics_results) -> Keypoints:
         """
@@ -73,7 +77,9 @@ class Keypoints:
             ```
         """
         xy = [item.keypoints.xy.data.cpu().numpy() for item in ultralytics_results]
-        confidence = [item.keypoints.conf.data.cpu().numpy() for item in ultralytics_results]
+        confidence = [
+            item.keypoints.conf.data.cpu().numpy() for item in ultralytics_results
+        ]
 
         return cls(keypoints=np.array(xy)[0], confidence=np.array(confidence)[0])
 

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -82,6 +82,50 @@ class Keypoints:
         ]
 
         return cls(keypoints=np.array(xy)[0], confidence=np.array(confidence)[0])
+    
+    @classmethod
+    def from_mediapipe(cls, mediapipe_results) -> Keypoints:
+        """
+        Creates a Keypoints instance from a
+        (https://developers.google.com/mediapipe/solutions/vision/pose_landmarker/python) MediaPipe result.
+
+        Args:
+            mediapipe_results (mediapipe.tasks.python.vision.pose_landmarker.PoseLandmarkerResults):
+                The output Results instance from MediaPipe model
+
+        Returns:
+            Keypoints: A new Keypoints object.
+
+        Example:
+            ```python
+            >>> import mediapipe as mp
+            >>> from mediapipe.tasks import python
+            >>> from mediapipe.tasks.python import vision
+            >>> import supervision as sv
+
+            >>> base_options = python.BaseOptions(model_asset_path='pose_landmarker.task')
+            >>> options = vision.PoseLandmarkerOptions(
+            ...     base_options=base_options,
+            ...     output_segmentation_masks=True
+            ... )
+            >>> detector = vision.PoseLandmarker.create_from_options(options)
+
+            >>> image = mp.Image.create_from_file("image.jpg")
+
+            >>> detection_result = detector.detect(image)
+
+            >>> pose_landmarks = sv.Keypoints.from_mediapipe(detection_result)
+            ```
+        """
+        
+        xyz = []
+        confidence = []
+
+        for pose_landmarks in mediapipe_results.pose_landmarks:
+            xyz.append([[item.x, item.y, item.z] for item in pose_landmarks])
+            confidence.append([item.visibility for item in pose_landmarks])
+
+        return cls(keypoints=np.array(xyz), confidence=np.array(confidence))
 
     @classmethod
     def empty(cls) -> Keypoints:


### PR DESCRIPTION
# Description

This PR adds the `sv.Keypoints` detection method. This method can accept keypoints in `(N, M, 2)` (for x, y points) or `(N, M, 3)` formats (for x, y, z points).

An `sv.PoseAnnotator` method is added for plotting poses.

`sv.Keypoints.from_ultralytics()` is supported for loading keypoints from `ultralytics` pose estimation models.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

This change was tested using the following code:

```python
from ultralytics import YOLO
import supervision as sv
import cv2

# test empty
print(sv.Keypoints.empty())

model = YOLO('yolov8n-pose.pt')
results = model('https://ultralytics.com/images/bus.jpg')

keypoints = sv.Keypoints.from_ultralytics(results)

image = cv2.imread("bus.jpg")

pose_annotator = sv.PoseAnnotator()
annotated_frame = pose_annotator.annotate(
    scene=image,
    keypoints=keypoints
)

sv.plot_image(annotated_frame)
```

## Any specific deployment considerations

N/A

## Docs

I will add documentation for `sv.Keypoint` when we finalize the API.