### PR TITLE
docs: 📓 development virtualenv installation pip upgrade added

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ You can install `supervision` with pip in a
         # setup python environment and activate it
         python3 -m venv venv
         source venv/bin/activate
+        pip install --upgrade pip
 
         # headless install
         pip install -e "."


### PR DESCRIPTION
pip editable install for toml file require recent version pip so for python3.8 old pip version I added update to make sure user/developer has recent version and able to install editable install properly without error.  Fix: #467

Please delete options that are not relevant.

-   [X] This change requires a documentation update

## Docs

-   [X] Docs updated? What were the changes:
