### PR TITLE
Linezone.trigger returns bool nparray

### DIFF
--- a/supervision/detection/line_counter.py
+++ b/supervision/detection/line_counter.py
@@ -26,9 +26,8 @@ class LineZone:
         self.tracker_state: Dict[str, bool] = {}
         self.in_count: int = 0
         self.out_count: int = 0
-        self.crossed = []
 
-    def trigger(self, detections: Detections):
+    def trigger(self, detections: Detections) -> np.ndarray:
         """
         Update the in_count and out_count for the detections that cross the line.
 
@@ -39,7 +38,7 @@ class LineZone:
             np.ndarray: A boolean array indicating
             which detection has crossed the line on the either sides
         """
-        self.crossed = [False] * len(detections)
+        crossed = np.full(len(detections), False)
 
         for i, (xyxy, _, confidence, class_id, tracker_id) in enumerate(detections):
             # handle detections with no tracker_id
@@ -73,13 +72,13 @@ class LineZone:
             self.tracker_state[tracker_id] = tracker_state
             if tracker_state:
                 self.in_count += 1
-                self.crossed[i] = True
+                crossed[i] = True
 
             else:
                 self.out_count += 1
-                self.crossed[i] = True
+                crossed[i] = True
 
-        return self.crossed
+        return crossed
 
 
 class LineZoneAnnotator:

--- a/supervision/detection/line_counter.py
+++ b/supervision/detection/line_counter.py
@@ -34,7 +34,7 @@ class LineZone:
 
         Attributes:
             detections (Detections): The detections for which to update the counts.
-        
+
         Returns:
             np.ndarray: A boolean array indicating
             which detection has crossed the line on the either sides

--- a/supervision/detection/line_counter.py
+++ b/supervision/detection/line_counter.py
@@ -26,6 +26,7 @@ class LineZone:
         self.tracker_state: Dict[str, bool] = {}
         self.in_count: int = 0
         self.out_count: int = 0
+        self.crossed = []
 
     def trigger(self, detections: Detections):
         """
@@ -33,9 +34,14 @@ class LineZone:
 
         Attributes:
             detections (Detections): The detections for which to update the counts.
-
+        
+        Returns:
+            np.ndarray: A boolean array indicating
+            which detection has crossed the line on the either sides
         """
-        for xyxy, _, confidence, class_id, tracker_id in detections:
+        self.crossed = [False] * len(detections)
+
+        for i, (xyxy, _, confidence, class_id, tracker_id) in enumerate(detections):
             # handle detections with no tracker_id
             if tracker_id is None:
                 continue
@@ -67,8 +73,13 @@ class LineZone:
             self.tracker_state[tracker_id] = tracker_state
             if tracker_state:
                 self.in_count += 1
+                self.crossed[i] = True
+
             else:
                 self.out_count += 1
+                self.crossed[i] = True
+
+        return self.crossed
 
 
 class LineZoneAnnotator:


### PR DESCRIPTION
# Description

As requested in the issue #464 , I have made the necessary changes. Now the [sv.LineZone.trigger](https://github.com/roboflow/supervision/blob/5b5e0eb88daec92643834b2284e750ad5a1c7dc6/supervision/detection/line_counter.py#L30) returns a bool nparray which indicates the object's state change (indicating it has crossed the line). The implementation is similar to that of [sv.PolygonZone.trigger](https://github.com/roboflow/supervision/blob/5b5e0eb88daec92643834b2284e750ad5a1c7dc6/supervision/detection/tools/polygon_zone.py#L45)

## Type of change

-   [ ] New feature (non-breaking change which adds functionality)

## Docs

-   [ ] Docs updated? What were the changes:
