### PR TITLE
Add 404 page

### DIFF
--- a/custom_theme/404.html
+++ b/custom_theme/404.html
@@ -1,0 +1,7 @@
+{% extends "main.html" %} 
+
+{% block content %}
+    <h1>Page Not Found</h1> 
+    <p>The page you have requested was not found.</p>
+    <p><a href="/">Go back to the documentation home</a>.</p>
+{% endblock %} 

--- a/custom_theme/404.html
+++ b/custom_theme/404.html
@@ -1,7 +1,7 @@
-{% extends "main.html" %} 
+{% extends "main.html" %}
 
 {% block content %}
-    <h1>Page Not Found</h1> 
+    <h1>Page Not Found</h1>
     <p>The page you have requested was not found.</p>
     <p><a href="/">Go back to the documentation home</a>.</p>
-{% endblock %} 
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ theme:
   font:
     text: Roboto
     code: Roboto Mono
+  custom_dir: 'custom_theme'
 
 plugins:
   - mkdocstrings


### PR DESCRIPTION
This PR adds a 404 page to `supervision`.

Here is the current page someone sees when they navigate to a broken URL:

<img width="1375" alt="Screenshot 2023-10-16 at 09 02 43" src="https://github.com/roboflow/supervision/assets/37276661/c842b738-453c-4323-84c2-7d0527a368ca">

Here is the page this PR adds:

<img width="1227" alt="Screenshot 2023-10-16 at 09 03 06" src="https://github.com/roboflow/supervision/assets/37276661/4a79b38c-297a-4273-bf97-1cab1b65d616">
