### PR TITLE
Add `/` to mkdocs site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Supervision
-site_url: https://roboflow.github.io/supervision
+site_url: https://roboflow.github.io/supervision/
 site_author: Roboflow
 site_description: A set of easy-to-use utils that will come in handy in any Computer Vision project
 repo_name: roboflow/supervision


### PR DESCRIPTION
This PR adds a `/` to the end of our mkdocs site URL, required for custom pages to resolve paths correctly.