### PR TITLE
Change domain to supervision.roboflow.com in mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Supervision
-site_url: https://roboflow.github.io/supervision/
+site_url: https://supervision.roboflow.com/
 site_author: Roboflow
 site_description: A set of easy-to-use utils that will come in handy in any Computer Vision project
 repo_name: roboflow/supervision


### PR DESCRIPTION
This PR should fix the continued issues with 404 pages. `mkdocs` is particular when it comes to URL paths.

The 404 page right now is trying to request:

```
https://supervision.roboflow.com/supervision/assets/_mkdocstrings.css
```

The `/supervision` part is taken from our `mkdocs` config and is now redundant since we deploy on `supervision.roboflow.com`.