### PR TITLE
Assets fix

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -3,7 +3,7 @@ that you can use in your demos.
 
 ## install extra
 
-To install the Supervision assets utility, you can use pip. This utility is available
+To install the Supervision assets utility, you can use `pip`. This utility is available
 as an extra within the Supervision package.
 
 !!! example "pip install"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "supervision"
-version = "0.17.0rc1"
+version = "0.17.0rc2"
 description = "A set of easy-to-use utils that will come in handy in any Computer Vision project"
 authors = ["Piotr Skalski <piotr.skalski92@gmail.com>"]
 maintainers = ["Piotr Skalski <piotr.skalski92@gmail.com>"]

--- a/supervision/assets/__init__.py
+++ b/supervision/assets/__init__.py
@@ -1,2 +1,2 @@
-from .downloader import download_assets
-from .list import VideoAssets
+from supervision.assets.downloader import download_assets
+from supervision.assets.list import VideoAssets

--- a/supervision/assets/downloader.py
+++ b/supervision/assets/downloader.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from shutil import copyfileobj
 from typing import Union
 
-from supervision.assets import VideoAssets
-from supervision.assets.list import VIDEO_ASSETS
+from supervision.assets.list import VIDEO_ASSETS, VideoAssets
 
 try:
     from requests import get
@@ -51,6 +50,14 @@ def download_assets(asset_name: Union[VideoAssets, str]) -> str:
 
     Returns:
         str: The filename of the downloaded asset.
+
+    Example:
+        ```python
+        >>> from supervision.assets import download_assets, VideoAssets
+
+        >>> download_assets(VideoAssets.VEHICLES)
+        "vehicles.mp4"
+        ```
     """
 
     filename = asset_name.value if isinstance(asset_name, VideoAssets) else asset_name

--- a/supervision/assets/list.py
+++ b/supervision/assets/list.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import Dict, Tuple
 
-
 BASE_VIDEO_URL = "https://media.roboflow.com/supervision/video-examples/"
 
 

--- a/supervision/assets/list.py
+++ b/supervision/assets/list.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Dict, Tuple
 
+
 BASE_VIDEO_URL = "https://media.roboflow.com/supervision/video-examples/"
 
 


### PR DESCRIPTION
# Description

Fix: `from supervision.assets import download_assets`

```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
[<ipython-input-3-989c1cade8ed>](https://localhost:8080/#) in <cell line: 1>()
----> 1 from supervision.assets import download_assets

1 frames
[/usr/local/lib/python3.10/dist-packages/supervision/assets/downloader.py](https://localhost:8080/#) in <module>
      5 from typing import Union
      6 
----> 7 from supervision.assets import VideoAssets
      8 from supervision.assets.list import VIDEO_ASSETS
      9 

ImportError: cannot import name 'VideoAssets' from partially initialized module 'supervision.assets' (most likely due to a circular import) (/usr/local/lib/python3.10/dist-packages/supervision/assets/__init__.py)

---------------------------------------------------------------------------
NOTE: If your import is failing due to a missing package, you can
manually install dependencies using either !pip or !apt.

To view examples of installing some common dependencies, click the
"Open Examples" button below.
---------------------------------------------------------------------------
```
