### PR TITLE
fix: #540 bug blur annotator

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -892,7 +892,7 @@ class BlurAnnotator(BaseAnnotator):
         supervision-annotator-examples/blur-annotator-example-purple.png)
         """
         for detection_idx in range(len(detections)):
-            x1, y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
+            x1, y1, x2, y2 = np.maximum(detections.xyxy[detection_idx].astype(int),0)
             roi = scene[y1:y2, x1:x2]
 
             roi = cv2.blur(roi, (self.kernel_size, self.kernel_size))

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -7,6 +7,7 @@ import numpy as np
 from supervision.annotators.base import BaseAnnotator
 from supervision.annotators.utils import ColorLookup, Trace, resolve_color
 from supervision.detection.core import Detections
+from supervision.detection.utils import clip_boxes
 from supervision.draw.color import Color, ColorPalette
 from supervision.geometry.core import Position
 
@@ -891,10 +892,13 @@ class BlurAnnotator(BaseAnnotator):
         ![blur-annotator-example](https://media.roboflow.com/
         supervision-annotator-examples/blur-annotator-example-purple.png)
         """
-        for detection_idx in range(len(detections)):
-            x1, y1, x2, y2 = np.maximum(detections.xyxy[detection_idx].astype(int), 0)
-            roi = scene[y1:y2, x1:x2]
+        image_height, image_width = scene.shape[:2]
+        clipped_xyxy = clip_boxes(
+            xyxy=detections.xyxy,
+            resolution_wh=(image_width, image_height)).astype(int)
 
+        for x1, y1, x2, y2 in clipped_xyxy:
+            roi = scene[y1:y2, x1:x2]
             roi = cv2.blur(roi, (self.kernel_size, self.kernel_size))
             scene[y1:y2, x1:x2] = roi
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -894,8 +894,8 @@ class BlurAnnotator(BaseAnnotator):
         """
         image_height, image_width = scene.shape[:2]
         clipped_xyxy = clip_boxes(
-            xyxy=detections.xyxy,
-            resolution_wh=(image_width, image_height)).astype(int)
+            xyxy=detections.xyxy, resolution_wh=(image_width, image_height)
+        ).astype(int)
 
         for x1, y1, x2, y2 in clipped_xyxy:
             roi = scene[y1:y2, x1:x2]

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -892,7 +892,7 @@ class BlurAnnotator(BaseAnnotator):
         supervision-annotator-examples/blur-annotator-example-purple.png)
         """
         for detection_idx in range(len(detections)):
-            x1, y1, x2, y2 = np.maximum(detections.xyxy[detection_idx].astype(int),0)
+            x1, y1, x2, y2 = np.maximum(detections.xyxy[detection_idx].astype(int), 0)
             roi = scene[y1:y2, x1:x2]
 
             roi = cv2.blur(roi, (self.kernel_size, self.kernel_size))

--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -56,7 +56,7 @@ class PolygonZone:
         """
 
         clipped_xyxy = clip_boxes(
-            boxes_xyxy=detections.xyxy, frame_resolution_wh=self.frame_resolution_wh
+            xyxy=detections.xyxy, resolution_wh=self.frame_resolution_wh
         )
         clipped_detections = replace(detections, xyxy=clipped_xyxy)
         clipped_anchors = np.ceil(

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -110,17 +110,15 @@ def non_max_suppression(
     return keep[sort_index.argsort()]
 
 
-def clip_boxes(
-    boxes_xyxy: np.ndarray, frame_resolution_wh: Tuple[int, int]
-) -> np.ndarray:
+def clip_boxes(xyxy: np.ndarray, resolution_wh: Tuple[int, int]) -> np.ndarray:
     """
     Clips bounding boxes coordinates to fit within the frame resolution.
 
     Args:
-        boxes_xyxy (np.ndarray): A numpy array of shape `(N, 4)` where each
+        xyxy (np.ndarray): A numpy array of shape `(N, 4)` where each
             row corresponds to a bounding box in
         the format `(x_min, y_min, x_max, y_max)`.
-        frame_resolution_wh (Tuple[int, int]): A tuple of the form `(width, height)`
+        resolution_wh (Tuple[int, int]): A tuple of the form `(width, height)`
             representing the resolution of the frame.
 
     Returns:
@@ -128,8 +126,8 @@ def clip_boxes(
             corresponds to a bounding box with coordinates clipped to fit
             within the frame resolution.
     """
-    result = np.copy(boxes_xyxy)
-    width, height = frame_resolution_wh
+    result = np.copy(xyxy)
+    width, height = resolution_wh
     result[:, [0, 2]] = result[:, [0, 2]].clip(0, width)
     result[:, [1, 3]] = result[:, [1, 3]].clip(0, height)
     return result

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -122,7 +122,7 @@ def test_non_max_suppression(
 
 
 @pytest.mark.parametrize(
-    "boxes_xyxy, frame_resolution_wh, expected_result",
+    "xyxy, resolution_wh, expected_result",
     [
         (
             np.empty(shape=(0, 4)),
@@ -157,11 +157,11 @@ def test_non_max_suppression(
     ],
 )
 def test_clip_boxes(
-    boxes_xyxy: np.ndarray,
-    frame_resolution_wh: Tuple[int, int],
+    xyxy: np.ndarray,
+    resolution_wh: Tuple[int, int],
     expected_result: np.ndarray,
 ) -> None:
-    result = clip_boxes(boxes_xyxy=boxes_xyxy, frame_resolution_wh=frame_resolution_wh)
+    result = clip_boxes(xyxy=xyxy, resolution_wh=resolution_wh)
     assert np.array_equal(result, expected_result)
 
 


### PR DESCRIPTION
# Description

The coordinates of the detections object were found to have negative values in some cases, probably due to the trajectory prediction obtained with ByteTrack. Because of these negative coordinates, the ROI object was becoming null, which caused problems when calling cv2.blur(), as a valid array was expected.

The solution implemented for this bug was adjustment the command:
`detections.xyxy[detection_idx].astype(int)`

To:
`np.maximum(detections.xyxy[detection_idx].astype(int), 0)`

This way, whenever there is a negative coordinate, it will be mapped to 0.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

[Google Colab Notebook: Example of the error occurring](https://colab.research.google.com/drive/1g-hOAe3jsgY_24yNszWblWWjV9lPkLxv?usp=sharing)

[Google Colab Notebook: Test with adjustment made](https://colab.research.google.com/drive/1-sVDlsxxNNShPVJ-p9X1cPvAnmncwyNf?usp=sharing)

## Any specific deployment considerations

I chose to make the adjustment within the BlurAnnotator.annotate() method because I imagine that in some scenarios ByteTrack returning negative coordinates may be interesting, such as multiple cameras and an object moving from one to another. However, this error may also occur for other annotators when using ByteTrack together.

I created two notebooks in colab, because after it imports a library it is not possible to make adjustments to it without resetting the environment, apparently it is preloaded in cache and the adjustments do not take effect.


Fix #540 