### PR TITLE
Add AWS Rekognition CustomLabels data loader

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -503,7 +503,7 @@ class Detections:
             >>> from PIL import Image
 
             >>> session = boto3.Session()
-            >>> client = self.session.client("rekognition")
+            >>> client = session.client("rekognition")
 
             >>> with Image.open(input) as image:
             >>>    buffered = io.BytesIO()

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -538,8 +538,10 @@ class Detections:
 
                 if class_map.get(label_name) is None:
                     class_map[label_name] = len(class_map)
+                else:
+                    class_map[label_name] = class_map[label_name]
 
-                class_map.append(class_map[label_name])
+                class_ids.append(class_map[label_name])
 
         if len(xyxys) == 0:
             return cls.empty()

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -517,7 +517,9 @@ class Detections:
             ```
         """
 
-        xyxys, confidences, class_ids = [], [], {}
+        xyxys, confidences, class_ids = [], [], []
+
+        class_map = {}
 
         for label in rekognition_det["Labels"]:
             if len(label["Instances"]) == 0:
@@ -534,10 +536,10 @@ class Detections:
 
                 label_name = label["Name"]
 
-                if class_ids.get(label_name) is None:
-                    class_ids[label_name] = len(class_ids)
+                if class_map.get(label_name) is None:
+                    class_map[label_name] = len(class_map)
 
-                class_ids.append(class_ids[label_name])
+                class_map.append(class_map[label_name])
 
         if len(xyxys) == 0:
             return cls.empty()

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -487,7 +487,8 @@ class Detections:
     def from_rekognition_detectlabels(cls, rekognition_det) -> Detections:
         """
         Creates a Detections instance from
-            [AWS Rekognition DetectLabels](https://docs.aws.amazon.com/rekognition/latest/dg/labels-detect-labels-image.html)
+            AWS Rekognition DetectLabels
+            (https://docs.aws.amazon.com/rekognition/latest/dg/labels-detect-labels-image.html)
             inference result.
 
         Args:

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -482,7 +482,7 @@ class Detections:
 
         xyxy = xywh_to_xyxy(boxes_xywh=xywh)
         return cls(xyxy=xyxy, mask=mask)
-    
+
     @classmethod
     def from_rekognition_detectlabels(cls, rekognition_det) -> Detections:
         """

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -484,7 +484,7 @@ class Detections:
         return cls(xyxy=xyxy, mask=mask)
     
     @classmethod
-    def from_rekognition(cls, rekognition_det) -> Detections:
+    def from_rekognition_detectlabels(cls, rekognition_det) -> Detections:
         """
         Creates a Detections instance from
             [AWS Rekognition DetectLabels](https://docs.aws.amazon.com/rekognition/latest/dg/labels-detect-labels-image.html)
@@ -512,7 +512,7 @@ class Detections:
 
             >>> response = client.detect_labels(Image={"Bytes": image_bytes})
 
-            >>> detections = sv.Detections.from_rekognition(response)
+            >>> detections = sv.Detections.from_rekognition_detectlabels(response)
             ```
         """
 


### PR DESCRIPTION
# Description

This PR adds a new data loader that enables loading CustomLabels predictions from AWS Rekognition. This will be useful for people who want to plot bounding boxes or filter predictions with Rekognition CustomLabels.

Note that CustomLabels does not have the concept of a `class_id` in the output, so my code includes logic to assign those when predictions are ingested into supervision.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

First, you need to download and install the `aws` CLI.

[How to install the aws CLI](https://aws.amazon.com/cli/).

Then you need to authenticate with the CLI. 

[Authenticate with the aws CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html).

Then you can run the following code snippet, included in the docstring:

```python
import supervision as sv
import boto3
from PIL import Image

session = boto3.Session()
client = session.client("rekognition")
with Image.open(input) as image:
    buffered = io.BytesIO()
    image.save(buffered, format=image.format)
    image_bytes = buffered.getvalue()

esponse = client.detect_labels(Image={"Bytes": image_bytes})
detections = sv.Detections.from_rekognition_detectlabels(response)
```

## Any specific deployment considerations

N/A

## Docs

N/A