### PR TITLE
Add timm data loader for `sv.Classifications`

### DIFF
--- a/supervision/classification/core.py
+++ b/supervision/classification/core.py
@@ -82,10 +82,9 @@ class Classifications:
 
         Example:
             ```python
-            >>> import timm
             >>> from PIL import Image
-            >>> from timm.data import resolve_data_config
-            >>> from timm.data.transforms_factory import create_transform
+            >>> import timm
+            >>> from timm.data import resolve_data_config, create_transform
             >>> import supervision as sv
 
             >>> model = timm.create_model(

--- a/supervision/classification/core.py
+++ b/supervision/classification/core.py
@@ -88,7 +88,10 @@ class Classifications:
             >>> from timm.data import resolve_data_config
             >>> from timm.data.transforms_factory import create_transform
 
-            >>> model = timm.create_model('hf-hub:nateraw/resnet50-oxford-iiit-pet', pretrained=True)
+            >>> model = timm.create_model(
+            ...     'hf-hub:nateraw/resnet50-oxford-iiit-pet',
+            ...     pretrained=True
+            ... )
             >>> model.eval()
 
             >>> config = resolve_data_config({}, model=model)


### PR DESCRIPTION
# Description

This PR adds a data loader for classifications from the `timm` Python package.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can test the API using the following code:

```python
import timm
import torch
from PIL import Image
from timm.data import resolve_data_config
from timm.data.transforms_factory import create_transform
import supervision as sv

# Load from Hub 🔥
model = timm.create_model(
    'hf-hub:nateraw/resnet50-oxford-iiit-pet',
    pretrained=True
)

# Set model to eval mode for inference
model.eval()

# Create Transform
transform = create_transform(**resolve_data_config(model.pretrained_cfg, model=model))

# Get the labels from the model config
labels = model.pretrained_cfg['label_names']
top_k = min(len(labels), 5)

# Use your own image file here...
image = Image.open('./annotated_image.jpg').convert('RGB')

# Process PIL image with transforms and add a batch dimension
x = transform(image).unsqueeze(0)

# Pass inputs to model forward function to get outputs
out = model(x)

results = sv.Classifications.from_timm(out)

print(results)
```

## Any specific deployment considerations

N/A

## Docs

This PR does not yet contain a docs update, but I will add documentation for the method as part of this PR.