### PR TITLE
Add PolygonAnnotator and update documentation

### DIFF
--- a/docs/annotators.md
+++ b/docs/annotators.md
@@ -166,6 +166,27 @@
 
     </div>
 
+=== "Polygon"
+
+    ```python
+    >>> import supervision as sv
+
+    >>> image = ...
+    >>> detections = sv.Detections(...)
+
+    >>> polygon_annotator = sv.PolygonAnnotator()
+    >>> annotated_frame = polygon_annotator.annotate(
+    ...     scene=image.copy(),
+    ...     detections=detections
+    ... )
+    ```
+
+    <div class="result" markdown>
+
+    ![polygon-annotator-example](https://media.roboflow.com/supervision-annotator-examples/polygon-annotator-example-purple.png){ align=center width="800" }
+
+    </div>
+
 === "Label"
 
     ```python

--- a/docs/annotators.md
+++ b/docs/annotators.md
@@ -304,6 +304,10 @@
 
 :::supervision.annotators.core.MaskAnnotator
 
+## PolygonAnnotator
+
+:::supervision.annotators.core.PolygonAnnotator
+
 ## LabelAnnotator
 
 :::supervision.annotators.core.LabelAnnotator

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -18,6 +18,7 @@ from supervision.annotators.core import (
     HeatMapAnnotator,
     LabelAnnotator,
     MaskAnnotator,
+    PolygonAnnotator,
     TraceAnnotator,
 )
 from supervision.annotators.utils import ColorLookup

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -233,6 +233,9 @@ class PolygonAnnotator(BaseAnnotator):
             ...     detections=detections
             ... )
             ```
+
+        ![polygon-annotator-example](https://media.roboflow.com/
+        supervision-annotator-examples/polygon-annotator-example-purple.png)
         """
         if detections.mask is None:
             return scene
@@ -343,6 +346,10 @@ class BoxMaskAnnotator(BaseAnnotator):
 class HaloAnnotator(BaseAnnotator):
     """
     A class for drawing Halos on an image using provided detections.
+
+    !!! warning
+
+        This annotator utilizes the `sv.Detections.mask`.
     """
 
     def __init__(

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -206,7 +206,7 @@ class PolygonAnnotator(BaseAnnotator):
         self,
         scene: np.ndarray,
         detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None
+        custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with polygons based on the provided detections.


### PR DESCRIPTION
# Description

It implemented the PolygonAnnotator class in the core.py file under the supervision/annotators directory to support drawing polygons over detected objects. This was done by dividing the masks into multiple polygons and drawing them on the image.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## Docs

-   [x] Docs updated? What were the changes:
