### PR TITLE
Add centroid calculation for binary masks

### DIFF
--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -35,6 +35,7 @@ from supervision.detection.tools.inference_slicer import InferenceSlicer
 from supervision.detection.tools.polygon_zone import PolygonZone, PolygonZoneAnnotator
 from supervision.detection.utils import (
     box_iou_batch,
+    calculate_masks_centroids,
     filter_polygons_by_area,
     mask_to_polygons,
     mask_to_xyxy,

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -890,7 +890,7 @@ class LabelAnnotator:
         font = cv2.FONT_HERSHEY_SIMPLEX
         anchors_coordinates = detections.get_anchors_coordinates(
             anchor=self.text_anchor
-        )
+        ).astype(int)
         for detection_idx, center_coordinates in enumerate(anchors_coordinates):
             color = resolve_color(
                 color=self.color,

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -913,7 +913,7 @@ class LabelAnnotator:
             text_w_padded = text_w + 2 * self.text_padding
             text_h_padded = text_h + 2 * self.text_padding
             text_background_xyxy = self.resolve_text_background_xyxy(
-                center_coordinates=center_coordinates.totuple(),
+                center_coordinates=tuple(center_coordinates),
                 text_wh=(text_w_padded, text_h_padded),
                 position=self.text_anchor,
             )

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -890,7 +890,7 @@ class LabelAnnotator:
         font = cv2.FONT_HERSHEY_SIMPLEX
         anchors_coordinates = detections.get_anchors_coordinates(
             anchor=self.text_anchor)
-        for center_coordinates, detection_idx in enumerate(anchors_coordinates):
+        for detection_idx, center_coordinates in enumerate(anchors_coordinates):
             color = resolve_color(
                 color=self.color,
                 detections=detections,
@@ -912,7 +912,6 @@ class LabelAnnotator:
             )[0]
             text_w_padded = text_w + 2 * self.text_padding
             text_h_padded = text_h + 2 * self.text_padding
-
             text_background_xyxy = self.resolve_text_background_xyxy(
                 center_coordinates=center_coordinates.totuple(),
                 text_wh=(text_w_padded, text_h_padded),

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -19,10 +19,10 @@ class BoundingBoxAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        thickness: int = 2,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            thickness: int = 2,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -37,10 +37,10 @@ class BoundingBoxAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with bounding boxes based on the provided detections.
@@ -101,10 +101,10 @@ class MaskAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        opacity: float = 0.5,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            opacity: float = 0.5,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -119,10 +119,10 @@ class MaskAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with masks based on the provided detections.
@@ -185,10 +185,10 @@ class PolygonAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        thickness: int = 2,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            thickness: int = 2,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -203,10 +203,10 @@ class PolygonAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with polygons based on the provided detections.
@@ -267,10 +267,10 @@ class BoxMaskAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        opacity: float = 0.5,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            opacity: float = 0.5,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -285,10 +285,10 @@ class BoxMaskAnnotator(BaseAnnotator):
         self.opacity = opacity
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with box masks based on the provided detections.
@@ -353,11 +353,11 @@ class HaloAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        opacity: float = 0.8,
-        kernel_size: int = 40,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            opacity: float = 0.8,
+            kernel_size: int = 40,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -375,10 +375,10 @@ class HaloAnnotator(BaseAnnotator):
         self.kernel_size: int = kernel_size
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with halos based on the provided detections.
@@ -445,12 +445,12 @@ class EllipseAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        thickness: int = 2,
-        start_angle: int = -45,
-        end_angle: int = 235,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            thickness: int = 2,
+            start_angle: int = -45,
+            end_angle: int = 235,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -469,10 +469,10 @@ class EllipseAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with ellipses based on the provided detections.
@@ -535,11 +535,11 @@ class BoxCornerAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        thickness: int = 4,
-        corner_length: int = 15,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            thickness: int = 4,
+            corner_length: int = 15,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -556,10 +556,10 @@ class BoxCornerAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with box corners based on the provided detections.
@@ -621,10 +621,10 @@ class CircleAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        thickness: int = 2,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            thickness: int = 2,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -640,10 +640,10 @@ class CircleAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with circles based on the provided detections.
@@ -705,11 +705,11 @@ class DotAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        radius: int = 4,
-        position: Position = Position.CENTER,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            radius: int = 4,
+            position: Position = Position.CENTER,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -726,10 +726,10 @@ class DotAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with dots based on the provided detections.
@@ -760,7 +760,7 @@ class DotAnnotator(BaseAnnotator):
         ![dot-annotator-example](https://media.roboflow.com/
         supervision-annotator-examples/dot-annotator-example-purple.png)
         """
-        xy = detections.get_anchor_coordinates(anchor=self.position)
+        xy = detections.get_anchors_coordinates(anchor=self.position)
         for detection_idx in range(len(detections)):
             color = resolve_color(
                 color=self.color,
@@ -781,14 +781,14 @@ class LabelAnnotator:
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        text_color: Color = Color.black(),
-        text_scale: float = 0.5,
-        text_thickness: int = 1,
-        text_padding: int = 10,
-        text_position: Position = Position.TOP_LEFT,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            text_color: Color = Color.black(),
+            text_scale: float = 0.5,
+            text_thickness: int = 1,
+            text_padding: int = 10,
+            text_position: Position = Position.TOP_LEFT,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -808,57 +808,54 @@ class LabelAnnotator:
         self.text_scale: float = text_scale
         self.text_thickness: int = text_thickness
         self.text_padding: int = text_padding
-        self.text_position: Position = text_position
+        self.text_anchor: Position = text_position
         self.color_lookup: ColorLookup = color_lookup
 
     @staticmethod
     def resolve_text_background_xyxy(
-        detection_xyxy: Tuple[int, int, int, int],
-        text_wh: Tuple[int, int],
-        text_padding: int,
-        position: Position,
+            center_coordinates: Tuple[int, int],
+            text_wh: Tuple[int, int],
+            position: Position,
     ) -> Tuple[int, int, int, int]:
-        padded_text_wh = (text_wh[0] + 2 * text_padding, text_wh[1] + 2 * text_padding)
-        x1, y1, x2, y2 = detection_xyxy
-        center_x = (x1 + x2) // 2
-        center_y = (y1 + y2) // 2
+        center_x, center_y = center_coordinates
+        text_w, text_h = text_wh
 
         if position == Position.TOP_LEFT:
-            return x1, y1 - padded_text_wh[1], x1 + padded_text_wh[0], y1
+            return center_x, center_y - text_h, center_x + text_w, center_y
         elif position == Position.TOP_RIGHT:
-            return x2 - padded_text_wh[0], y1 - padded_text_wh[1], x2, y1
+            return center_x - text_w, center_y - text_h, center_x, center_y
         elif position == Position.TOP_CENTER:
             return (
-                center_x - padded_text_wh[0] // 2,
-                y1 - padded_text_wh[1],
-                center_x + padded_text_wh[0] // 2,
-                y1,
+                center_x - text_w // 2,
+                center_y - text_h,
+                center_x + text_w // 2,
+                center_y
             )
-        elif position == Position.CENTER:
+        elif position == Position.CENTER or position == Position.CENTER_OF_MASS:
             return (
-                center_x - padded_text_wh[0] // 2,
-                center_y - padded_text_wh[1] // 2,
-                center_x + padded_text_wh[0] // 2,
-                center_y + padded_text_wh[1] // 2,
+                center_x - text_w // 2,
+                center_y - text_h // 2,
+                center_x + text_w // 2,
+                center_y + text_h // 2
             )
         elif position == Position.BOTTOM_LEFT:
-            return x1, y2, x1 + padded_text_wh[0], y2 + padded_text_wh[1]
+            return center_x, center_y, center_x + text_w, center_y + text_h
         elif position == Position.BOTTOM_RIGHT:
-            return x2 - padded_text_wh[0], y2, x2, y2 + padded_text_wh[1]
+            return center_x - text_w, center_y, center_x, center_y + text_h
         elif position == Position.BOTTOM_CENTER:
             return (
-                center_x - padded_text_wh[0] // 2,
-                y2,
-                center_x + padded_text_wh[0] // 2,
-                y2 + padded_text_wh[1],
+                center_x - text_w // 2,
+                center_y,
+                center_x + text_w // 2,
+                center_y + text_h
             )
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        labels: List[str] = None,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            labels: List[str] = None,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with labels based on the provided detections.
@@ -891,8 +888,9 @@ class LabelAnnotator:
         supervision-annotator-examples/label-annotator-example-purple.png)
         """
         font = cv2.FONT_HERSHEY_SIMPLEX
-        for detection_idx in range(len(detections)):
-            detection_xyxy = detections.xyxy[detection_idx].astype(int)
+        anchors_coordinates = detections.get_anchors_coordinates(
+            anchor=self.text_anchor)
+        for center_coordinates, detection_idx in enumerate(anchors_coordinates):
             color = resolve_color(
                 color=self.color,
                 detections=detections,
@@ -906,22 +904,23 @@ class LabelAnnotator:
                 if (labels is None or len(detections) != len(labels))
                 else labels[detection_idx]
             )
-            text_wh = cv2.getTextSize(
+            text_w, text_h = cv2.getTextSize(
                 text=text,
                 fontFace=font,
                 fontScale=self.text_scale,
                 thickness=self.text_thickness,
             )[0]
+            text_w_padded = text_w + 2 * self.text_padding
+            text_h_padded = text_h + 2 * self.text_padding
 
             text_background_xyxy = self.resolve_text_background_xyxy(
-                detection_xyxy=detection_xyxy,
-                text_wh=text_wh,
-                text_padding=self.text_padding,
-                position=self.text_position,
+                center_coordinates=center_coordinates.totuple(),
+                text_wh=(text_w_padded, text_h_padded),
+                position=self.text_anchor,
             )
 
             text_x = text_background_xyxy[0] + self.text_padding
-            text_y = text_background_xyxy[1] + self.text_padding + text_wh[1]
+            text_y = text_background_xyxy[1] + self.text_padding + text_h
 
             cv2.rectangle(
                 img=scene,
@@ -956,9 +955,9 @@ class BlurAnnotator(BaseAnnotator):
         self.kernel_size: int = kernel_size
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
     ) -> np.ndarray:
         """
         Annotates the given scene by blurring regions based on the provided detections.
@@ -1012,12 +1011,12 @@ class TraceAnnotator:
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        position: Position = Position.CENTER,
-        trace_length: int = 30,
-        thickness: int = 2,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            position: Position = Position.CENTER,
+            trace_length: int = 30,
+            thickness: int = 2,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -1038,10 +1037,10 @@ class TraceAnnotator:
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Draws trace paths on the frame based on the detection coordinates provided.
@@ -1115,13 +1114,13 @@ class HeatMapAnnotator:
     """
 
     def __init__(
-        self,
-        position: Position = Position.BOTTOM_CENTER,
-        opacity: float = 0.2,
-        radius: int = 40,
-        kernel_size: int = 25,
-        top_hue: int = 0,
-        low_hue: int = 125,
+            self,
+            position: Position = Position.BOTTOM_CENTER,
+            opacity: float = 0.2,
+            radius: int = 40,
+            kernel_size: int = 25,
+            top_hue: int = 0,
+            low_hue: int = 125,
     ):
         """
         Args:
@@ -1181,7 +1180,7 @@ class HeatMapAnnotator:
         if self.heat_mask is None:
             self.heat_mask = np.zeros(scene.shape[:2])
         mask = np.zeros(scene.shape[:2])
-        for xy in detections.get_anchor_coordinates(self.position):
+        for xy in detections.get_anchors_coordinates(self.position):
             cv2.circle(mask, (int(xy[0]), int(xy[1])), self.radius, 1, -1)
         self.heat_mask = mask + self.heat_mask
         temp = self.heat_mask.copy()

--- a/supervision/annotators/utils.py
+++ b/supervision/annotators/utils.py
@@ -102,7 +102,7 @@ class Trace:
         frame_id = np.full(len(detections), self.current_frame_id, dtype=int)
         self.frame_id = np.concatenate([self.frame_id, frame_id])
         self.xy = np.concatenate(
-            [self.xy, detections.get_anchor_coordinates(self.anchor)]
+            [self.xy, detections.get_anchors_coordinates(self.anchor)]
         )
         self.tracker_id = np.concatenate([self.tracker_id, detections.tracker_id])
 

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -9,7 +9,7 @@ from supervision.detection.utils import (
     extract_ultralytics_masks,
     non_max_suppression,
     process_roboflow_result,
-    xywh_to_xyxy,
+    xywh_to_xyxy, calculate_centroids,
 )
 from supervision.geometry.core import Position
 
@@ -627,6 +627,15 @@ class Detections:
                     (self.xyxy[:, 1] + self.xyxy[:, 3]) / 2,
                 ]
             ).transpose()
+        if anchor == Position.CENTER_OF_MASS:
+            if self.mask is None:
+                return np.array(
+                    [
+                        (self.xyxy[:, 0] + self.xyxy[:, 2]) / 2,
+                        (self.xyxy[:, 1] + self.xyxy[:, 3]) / 2,
+                    ]
+                ).transpose()
+            return calculate_centroids(masks=self.mask)
         elif anchor == Position.CENTER_LEFT:
             return np.array(
                 [

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -6,10 +6,11 @@ from typing import Any, Iterator, List, Optional, Tuple, Union
 import numpy as np
 
 from supervision.detection.utils import (
+    calculate_centroids,
     extract_ultralytics_masks,
     non_max_suppression,
     process_roboflow_result,
-    xywh_to_xyxy, calculate_centroids,
+    xywh_to_xyxy,
 )
 from supervision.geometry.core import Position
 

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -6,7 +6,7 @@ from typing import Any, Iterator, List, Optional, Tuple, Union
 import numpy as np
 
 from supervision.detection.utils import (
-    calculate_centroids,
+    calculate_masks_centroids,
     extract_ultralytics_masks,
     non_max_suppression,
     process_roboflow_result,
@@ -601,7 +601,7 @@ class Detections:
             tracker_id=tracker_id,
         )
 
-    def get_anchor_coordinates(self, anchor: Position) -> np.ndarray:
+    def get_anchors_coordinates(self, anchor: Position) -> np.ndarray:
         """
         Calculates and returns the coordinates of a specific anchor point
         within the bounding boxes defined by the `xyxy` attribute. The anchor
@@ -628,15 +628,12 @@ class Detections:
                     (self.xyxy[:, 1] + self.xyxy[:, 3]) / 2,
                 ]
             ).transpose()
-        if anchor == Position.CENTER_OF_MASS:
+        elif anchor == Position.CENTER_OF_MASS:
             if self.mask is None:
-                return np.array(
-                    [
-                        (self.xyxy[:, 0] + self.xyxy[:, 2]) / 2,
-                        (self.xyxy[:, 1] + self.xyxy[:, 3]) / 2,
-                    ]
-                ).transpose()
-            return calculate_centroids(masks=self.mask)
+                raise ValueError(
+                    "Cannot use `Position.CENTER_OF_MASS` without a detection mask."
+                )
+            return calculate_masks_centroids(masks=self.mask)
         elif anchor == Position.CENTER_LEFT:
             return np.array(
                 [

--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -60,7 +60,7 @@ class PolygonZone:
         )
         clipped_detections = replace(detections, xyxy=clipped_xyxy)
         clipped_anchors = np.ceil(
-            clipped_detections.get_anchor_coordinates(anchor=self.triggering_position)
+            clipped_detections.get_anchors_coordinates(anchor=self.triggering_position)
         ).astype(int)
         is_in_zone = self.mask[clipped_anchors[:, 1], clipped_anchors[:, 0]]
         self.current_count = int(np.sum(is_in_zone))

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -393,3 +393,33 @@ def move_boxes(xyxy: np.ndarray, offset: np.ndarray) -> np.ndarray:
         (np.ndarray) repositioned bounding boxes
     """
     return xyxy + np.hstack([offset, offset])
+
+
+def calculate_centroids(masks: np.ndarray) -> np.ndarray:
+    """
+    Calculate the centroids of binary masks in a tensor.
+
+    Parameters:
+        masks (np.ndarray): A 3D NumPy array of shape (num_masks, height, width).
+            Each 2D array in the tensor represents a binary mask.
+
+    Returns:
+        A 2D NumPy array of shape (num_masks, 2), where each row contains the x and y
+            coordinates (in that order) of the centroid of the corresponding mask.
+    """
+    num_masks, height, width = masks.shape
+    total_pixels = masks.sum(axis=(1, 2))
+
+    # offset for 1-based indexing
+    vertical_indices, horizontal_indices = np.indices((height, width)) + 0.5
+    # avoid division by zero for empty masks
+    total_pixels[total_pixels == 0] = 1
+
+    def sum_over_mask(indices: np.ndarray, axis: tuple) -> np.ndarray:
+        return np.tensordot(masks, indices, axes=axis)
+
+    aggregation_axis = ([1, 2], [0, 1])
+    centroid_x = sum_over_mask(horizontal_indices, aggregation_axis) / total_pixels
+    centroid_y = sum_over_mask(vertical_indices, aggregation_axis) / total_pixels
+
+    return np.column_stack((centroid_x, centroid_y)).astype(int)

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -395,7 +395,7 @@ def move_boxes(xyxy: np.ndarray, offset: np.ndarray) -> np.ndarray:
     return xyxy + np.hstack([offset, offset])
 
 
-def calculate_centroids(masks: np.ndarray) -> np.ndarray:
+def calculate_masks_centroids(masks: np.ndarray) -> np.ndarray:
     """
     Calculate the centroids of binary masks in a tensor.
 

--- a/supervision/geometry/core.py
+++ b/supervision/geometry/core.py
@@ -19,6 +19,7 @@ class Position(Enum):
     BOTTOM_LEFT = "BOTTOM_LEFT"
     BOTTOM_CENTER = "BOTTOM_CENTER"
     BOTTOM_RIGHT = "BOTTOM_RIGHT"
+    CENTER_OF_MASS = "CENTER_OF_MASS"
 
     @classmethod
     def list(cls):

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -270,6 +270,6 @@ def test_get_anchor_coordinates(
     expected_result: np.ndarray,
     exception: Exception,
 ) -> None:
-    result = detections.get_anchor_coordinates(anchor)
+    result = detections.get_anchors_coordinates(anchor)
     with exception:
         assert np.array_equal(result, expected_result)

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -10,6 +10,7 @@ from supervision.detection.utils import (
     move_boxes,
     non_max_suppression,
     process_roboflow_result,
+    calculate_centroids,
 )
 
 TEST_MASK = np.zeros((1, 1000, 1000), dtype=bool)
@@ -498,5 +499,98 @@ def test_move_boxes(
     expected_result: np.ndarray,
     exception: Exception,
 ) -> None:
-    result = move_boxes(xyxy=xyxy, offset=offset)
-    assert np.array_equal(result, expected_result)
+    with exception:
+        result = move_boxes(xyxy=xyxy, offset=offset)
+        assert np.array_equal(result, expected_result)
+
+
+@pytest.mark.parametrize(
+    "masks, expected_result, exception",
+    [
+        (
+            np.array([
+                [
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                ]
+            ]),
+            np.array([
+                [0, 0]
+            ]),
+            DoesNotRaise(),
+        ),  # single mask with all zeros
+        (
+            np.array([
+                [
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                ]
+            ]),
+            np.array([
+                [2, 2]
+            ]),
+            DoesNotRaise(),
+        ),  # single mask with all ones
+        (
+            np.array([
+                [
+                    [0, 1, 1, 0],
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                    [0, 1, 1, 0],
+                ]
+            ]),
+            np.array([
+                [2, 2]
+            ]),
+            DoesNotRaise(),
+        ),  # single mask with symmetric ones
+        (
+            np.array([
+                [
+                    [0, 0, 0, 0],
+                    [0, 0, 1, 1],
+                    [0, 0, 1, 1],
+                    [0, 0, 0, 0],
+                ]
+            ]),
+            np.array([
+                [3, 2]
+            ]),
+            DoesNotRaise(),
+        ),  # single mask with asymmetric ones
+        (
+            np.array([
+                [
+                    [0, 1, 1, 0],
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                    [0, 1, 1, 0],
+                ],
+                [
+                    [0, 0, 0, 0],
+                    [0, 0, 1, 1],
+                    [0, 0, 1, 1],
+                    [0, 0, 0, 0],
+                ]
+            ]),
+            np.array([
+                [2, 2],
+                [3, 2]
+            ]),
+            DoesNotRaise(),
+        ),  # two masks
+    ]
+)
+def test_calculate_centroids(
+    masks: np.ndarray,
+    expected_result: np.ndarray,
+    exception: Exception,
+) -> None:
+    with exception:
+        result = calculate_centroids(masks=masks)
+        assert np.array_equal(result, expected_result)

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from supervision.detection.utils import (
-    calculate_centroids,
+    calculate_masks_centroids,
     clip_boxes,
     filter_polygons_by_area,
     move_boxes,
@@ -585,11 +585,11 @@ def test_move_boxes(
         ),  # two masks
     ],
 )
-def test_calculate_centroids(
+def test_calculate_masks_centroids(
     masks: np.ndarray,
     expected_result: np.ndarray,
     exception: Exception,
 ) -> None:
     with exception:
-        result = calculate_centroids(masks=masks)
+        result = calculate_masks_centroids(masks=masks)
         assert np.array_equal(result, expected_result)

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -5,12 +5,12 @@ import numpy as np
 import pytest
 
 from supervision.detection.utils import (
+    calculate_centroids,
     clip_boxes,
     filter_polygons_by_area,
     move_boxes,
     non_max_suppression,
     process_roboflow_result,
-    calculate_centroids,
 )
 
 TEST_MASK = np.zeros((1, 1000, 1000), dtype=bool)
@@ -508,83 +508,82 @@ def test_move_boxes(
     "masks, expected_result, exception",
     [
         (
-            np.array([
+            np.array(
                 [
-                    [0, 0, 0, 0],
-                    [0, 0, 0, 0],
-                    [0, 0, 0, 0],
-                    [0, 0, 0, 0],
+                    [
+                        [0, 0, 0, 0],
+                        [0, 0, 0, 0],
+                        [0, 0, 0, 0],
+                        [0, 0, 0, 0],
+                    ]
                 ]
-            ]),
-            np.array([
-                [0, 0]
-            ]),
+            ),
+            np.array([[0, 0]]),
             DoesNotRaise(),
         ),  # single mask with all zeros
         (
-            np.array([
+            np.array(
                 [
-                    [1, 1, 1, 1],
-                    [1, 1, 1, 1],
-                    [1, 1, 1, 1],
-                    [1, 1, 1, 1],
+                    [
+                        [1, 1, 1, 1],
+                        [1, 1, 1, 1],
+                        [1, 1, 1, 1],
+                        [1, 1, 1, 1],
+                    ]
                 ]
-            ]),
-            np.array([
-                [2, 2]
-            ]),
+            ),
+            np.array([[2, 2]]),
             DoesNotRaise(),
         ),  # single mask with all ones
         (
-            np.array([
+            np.array(
                 [
-                    [0, 1, 1, 0],
-                    [1, 1, 1, 1],
-                    [1, 1, 1, 1],
-                    [0, 1, 1, 0],
+                    [
+                        [0, 1, 1, 0],
+                        [1, 1, 1, 1],
+                        [1, 1, 1, 1],
+                        [0, 1, 1, 0],
+                    ]
                 ]
-            ]),
-            np.array([
-                [2, 2]
-            ]),
+            ),
+            np.array([[2, 2]]),
             DoesNotRaise(),
         ),  # single mask with symmetric ones
         (
-            np.array([
+            np.array(
                 [
-                    [0, 0, 0, 0],
-                    [0, 0, 1, 1],
-                    [0, 0, 1, 1],
-                    [0, 0, 0, 0],
+                    [
+                        [0, 0, 0, 0],
+                        [0, 0, 1, 1],
+                        [0, 0, 1, 1],
+                        [0, 0, 0, 0],
+                    ]
                 ]
-            ]),
-            np.array([
-                [3, 2]
-            ]),
+            ),
+            np.array([[3, 2]]),
             DoesNotRaise(),
         ),  # single mask with asymmetric ones
         (
-            np.array([
+            np.array(
                 [
-                    [0, 1, 1, 0],
-                    [1, 1, 1, 1],
-                    [1, 1, 1, 1],
-                    [0, 1, 1, 0],
-                ],
-                [
-                    [0, 0, 0, 0],
-                    [0, 0, 1, 1],
-                    [0, 0, 1, 1],
-                    [0, 0, 0, 0],
+                    [
+                        [0, 1, 1, 0],
+                        [1, 1, 1, 1],
+                        [1, 1, 1, 1],
+                        [0, 1, 1, 0],
+                    ],
+                    [
+                        [0, 0, 0, 0],
+                        [0, 0, 1, 1],
+                        [0, 0, 1, 1],
+                        [0, 0, 0, 0],
+                    ],
                 ]
-            ]),
-            np.array([
-                [2, 2],
-                [3, 2]
-            ]),
+            ),
+            np.array([[2, 2], [3, 2]]),
             DoesNotRaise(),
         ),  # two masks
-    ]
+    ],
 )
 def test_calculate_centroids(
     masks: np.ndarray,


### PR DESCRIPTION
# Description

Added `calculate_centroids` function to compute center of mass for binary mask representations. Method added to `utils.py` and method import added to `core.py`. `Position` enumeration updated with `CENTER_OF_MASS` constant. Test function is added with test cases covering different mask scenarios. Update allows for masks to carry center of mass information too, useful in object detection.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## Docs

-   [x] Docs updated? What were the changes:
