### PR TITLE
Feature/make sv.mask annotator as fast as annotators in popular detection frameworks #472

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -170,9 +170,7 @@ class MaskAnnotator(BaseAnnotator):
             mask = detections.mask[detection_idx]
             colored_mask[mask] = color.as_bgr()
 
-        scene = cv2.addWeighted(
-            colored_mask, self.opacity, scene, 1 - self.opacity, 0
-        )
+        scene = cv2.addWeighted(colored_mask, self.opacity, scene, 1 - self.opacity, 0)
         return scene.astype(np.uint8)
 
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -156,6 +156,8 @@ class MaskAnnotator(BaseAnnotator):
         if detections.mask is None:
             return scene
 
+        colored_mask = np.array(scene, copy=True, dtype=np.uint8)
+
         for detection_idx in np.flip(np.argsort(detections.area)):
             color = resolve_color(
                 color=self.color,
@@ -166,13 +168,12 @@ class MaskAnnotator(BaseAnnotator):
                 else custom_color_lookup,
             )
             mask = detections.mask[detection_idx]
-            colored_mask = np.zeros_like(scene, dtype=np.uint8)
-            colored_mask[:] = color.as_bgr()
-            scene[mask] = cv2.addWeighted(
-                colored_mask, self.opacity, scene, 1 - self.opacity, 0
-            )[mask]
+            colored_mask[mask] = color.as_bgr()
 
-        return scene
+        scene = cv2.addWeighted(
+            colored_mask, self.opacity, scene, 1 - self.opacity, 0
+        )
+        return scene.astype(np.uint8)
 
 
 class PolygonAnnotator(BaseAnnotator):


### PR DESCRIPTION
# Description

* Combined all colored masks before applying them to the scene
* Made sure that returned ndarray is np.uint8 for video writer simplicity

https://github.com/roboflow/supervision/issues/472

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I profiled the code with VizTracer and compared outputs frame by frame and they are equal.

