### PR TITLE
fix: :memo: typo in from_mmdetection docstring

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -324,7 +324,7 @@ class Detections:
 
             >>> inferencer = DetInferencer(model_name, checkpoint, device)
             >>> mmdet_result = inferencer(SOURCE_IMAGE_PATH, out_dir='./output',
-            ...                           return_datasample=True)["predictions"][0]
+            ...                           return_datasamples=True)["predictions"][0]
             >>> detections = sv.Detections.from_mmdet(mmdet_result)
             ```
         """


### PR DESCRIPTION
# Description

This PR fixes a typo in the from_mmdetection method's docstring. The parameter name return_datasample has been corrected to return_datasamples to match the actual parameter used in the method.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

The change was verified by ensuring that the docstring correctly reflects the method's parameters and usage. No additional tests were necessary as this is a documentation fix.

## Any specific deployment considerations

No deployment considerations are necessary as this is a documentation update.

## Docs

-   [x] Docs updated? What were the changes:
The change was made in the docstring of the from_mmdetection method in supervision/detection/core.py