### PR TITLE
Add from_multiclass_folder and as_multiclass_folder data loaders

### DIFF
--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -626,6 +627,26 @@ class ClassificationDataset(BaseDataset):
             image_path = os.path.join(root_directory_path, class_name, image_name)
             cv2.imwrite(image_path, image)
 
+    def as_multiclass_folder(self, root_directory_path: str) -> None:
+        """
+        Saves the dataset as a multi-class folder structure.
+
+        Args:
+            root_directory_path (str): The path to the directory
+                where the dataset will be saved.
+        """
+        os.makedirs(root_directory_path, exist_ok=True)
+
+        with open(os.path.join(root_directory_path, "_classes.csv"), "w") as f:
+            writer = csv.writer(f)
+            writer.writerow(["image_name"] + self.classes)
+
+            for image_path in self.images:
+                classification = self.annotations[image_path]
+                image_name = Path(image_path).name
+                class_ids = classification.class_id.tolist()
+                writer.writerow([image_name] + class_ids)
+
     @classmethod
     def from_folder_structure(cls, root_directory_path: str) -> ClassificationDataset:
         """
@@ -673,6 +694,64 @@ class ClassificationDataset(BaseDataset):
 
         return cls(
             classes=classes,
+            images=images,
+            annotations=annotations,
+        )
+
+    @classmethod
+    def from_multiclass_folder(cls, root_directory_path: str) -> ClassificationDataset:
+        """
+        Load data from a multiclass folder structure into a ClassificationDataset.
+
+        Args:
+            root_directory_path (str): The path to the dataset directory.
+
+        Returns:
+            ClassificationDataset: The dataset.
+
+        Example:
+            ```python
+            >>> import roboflow
+            >>> from roboflow import Roboflow
+            >>> import supervision as sv
+
+            >>> roboflow.login()
+
+            >>> rf = Roboflow()
+
+            >>> project = rf.workspace(WORKSPACE_ID).project(PROJECT_ID)
+            >>> dataset = project.version(PROJECT_VERSION).download("folder")
+
+            >>> cd = sv.ClassificationDataset.from_multiclass_folder(
+            ...     root_directory_path=f"{dataset.location}/train"
+            ... )
+            ```
+        """
+
+        images = {}
+        annotations = {}
+        class_names = {}
+
+        with open(os.path.join(root_directory_path, "_classes.csv")) as f:
+            reader = csv.reader(f)
+
+            header = next(reader)
+
+            for item in enumerate(header[1:]):
+                class_names[item[0]] = item[1]
+
+            for row in reader:
+                image_name = row[0]
+                image_path = os.path.join(root_directory_path, image_name)
+                images[image_path] = cv2.imread(image_path)
+
+                class_ids = np.array([int(x) for x in row[1:]])
+                annotations[image_path] = Classifications(
+                    class_id=class_ids,
+                )
+
+        return cls(
+            classes=list(class_names.values()),
             images=images,
             annotations=annotations,
         )

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -646,6 +646,7 @@ class ClassificationDataset(BaseDataset):
                 image_name = Path(image_path).name
                 class_ids = classification.class_id.tolist()
                 writer.writerow([image_name] + class_ids)
+                cv2.imwrite(os.path.join(root_directory_path, image_name), image)
 
     @classmethod
     def from_folder_structure(cls, root_directory_path: str) -> ClassificationDataset:


### PR DESCRIPTION
# Description

This PR adds two new data loaders to the `sv.ClassificationDataset` API:

- `from_multiclass_folder`: Load a multiclass classification dataset.
- `as_multiclass_folder`: Save a dataset into a multiclass classification dataset.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Here is a test case that shows the API in action:

```python
import supervision as sv

train_cd = sv.ClassificationDataset.from_multiclass_folder(
    root_directory_path='taylor-swift/train',
)

print(train_cd)

train_cd.as_multiclass_folder(
    root_directory_path='taylor-swift/train2',
)
```

Where `taylor-swift` is [this dataset](https://universe.roboflow.com/capjamesg/taylor-swift-records/dataset/3) exported as a multiclass classification folder dataset.

The `from_multiclass_folder` call will load the data from the `train/_classes.csv` file into supervision, then the `as_multiclass_folder` code will save the data out to a new multiclass folder.

## Any specific deployment considerations

N/A

## Docs

N/A