### PR TITLE
Better Polygons from Masks

### DIFF
--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -240,7 +240,6 @@ def mask_to_polygons(mask: np.ndarray) -> List[np.ndarray]:
     )
 
     contours_approx = []
-    polygons = []
     for contour in contours:
         epsilon = 0.001 * cv2.arcLength(contour, True)
         contour_approx = cv2.approxPolyDP(contour, epsilon, True)

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -175,8 +175,9 @@ def is_clockwise(contour):
             p2 = contour[i + 1]
         else:
             p2 = contour[0]
-        value += (p2[0][0] - p1[0][0]) * (p2[0][1] + p1[0][1]);
+        value += (p2[0][0] - p1[0][0]) * (p2[0][1] + p1[0][1])
     return value < 0
+
 
 def get_merge_point_idx(contour1, contour2):
     idx1 = 0
@@ -184,7 +185,7 @@ def get_merge_point_idx(contour1, contour2):
     distance_min = -1
     for i, p1 in enumerate(contour1):
         for j, p2 in enumerate(contour2):
-            distance = pow(p2[0][0] - p1[0][0], 2) + pow(p2[0][1] - p1[0][1], 2);
+            distance = pow(p2[0][0] - p1[0][0], 2) + pow(p2[0][1] - p1[0][1], 2)
             if distance_min < 0:
                 distance_min = distance
                 idx1 = i
@@ -194,6 +195,7 @@ def get_merge_point_idx(contour1, contour2):
                 idx1 = i
                 idx2 = j
     return idx1, idx2
+
 
 def merge_contours(contour1, contour2, idx1, idx2):
     contour = []
@@ -208,6 +210,7 @@ def merge_contours(contour1, contour2, idx1, idx2):
     contour = np.array(contour)
     return contour
 
+
 def merge_with_parent(contour_parent, contour):
     if not is_clockwise(contour_parent):
         contour_parent = contour_parent[::-1]
@@ -215,6 +218,7 @@ def merge_with_parent(contour_parent, contour):
         contour = contour[::-1]
     idx1, idx2 = get_merge_point_idx(contour_parent, contour)
     return merge_contours(contour_parent, contour, idx1, idx2)
+
 
 def mask_to_polygons(mask: np.ndarray) -> List[np.ndarray]:
     """
@@ -231,7 +235,9 @@ def mask_to_polygons(mask: np.ndarray) -> List[np.ndarray]:
             of the points. Polygons with fewer points than `MIN_POLYGON_POINT_COUNT = 3`
             are excluded from the output.
     """
-    contours, hierarchies = cv2.findContours(mask.astype(np.uint8), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_TC89_KCOS)
+    contours, hierarchies = cv2.findContours(
+        mask.astype(np.uint8), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_TC89_KCOS
+    )
 
     contours_approx = []
     polygons = []
@@ -261,7 +267,7 @@ def mask_to_polygons(mask: np.ndarray) -> List[np.ndarray]:
         if len(contour) == 0:
             continue
         contours_parent_tmp.append(contour)
-    
+
     return [
         np.squeeze(contour, axis=1)
         for contour in contours_parent_tmp

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -166,9 +166,59 @@ def mask_to_xyxy(masks: np.ndarray) -> np.ndarray:
     return bboxes
 
 
+def is_clockwise(contour):
+    value = 0
+    num = len(contour)
+    for i, point in enumerate(contour):
+        p1 = contour[i]
+        if i < num - 1:
+            p2 = contour[i + 1]
+        else:
+            p2 = contour[0]
+        value += (p2[0][0] - p1[0][0]) * (p2[0][1] + p1[0][1]);
+    return value < 0
+
+def get_merge_point_idx(contour1, contour2):
+    idx1 = 0
+    idx2 = 0
+    distance_min = -1
+    for i, p1 in enumerate(contour1):
+        for j, p2 in enumerate(contour2):
+            distance = pow(p2[0][0] - p1[0][0], 2) + pow(p2[0][1] - p1[0][1], 2);
+            if distance_min < 0:
+                distance_min = distance
+                idx1 = i
+                idx2 = j
+            elif distance < distance_min:
+                distance_min = distance
+                idx1 = i
+                idx2 = j
+    return idx1, idx2
+
+def merge_contours(contour1, contour2, idx1, idx2):
+    contour = []
+    for i in list(range(0, idx1 + 1)):
+        contour.append(contour1[i])
+    for i in list(range(idx2, len(contour2))):
+        contour.append(contour2[i])
+    for i in list(range(0, idx2 + 1)):
+        contour.append(contour2[i])
+    for i in list(range(idx1, len(contour1))):
+        contour.append(contour1[i])
+    contour = np.array(contour)
+    return contour
+
+def merge_with_parent(contour_parent, contour):
+    if not is_clockwise(contour_parent):
+        contour_parent = contour_parent[::-1]
+    if is_clockwise(contour):
+        contour = contour[::-1]
+    idx1, idx2 = get_merge_point_idx(contour_parent, contour)
+    return merge_contours(contour_parent, contour, idx1, idx2)
+
 def mask_to_polygons(mask: np.ndarray) -> List[np.ndarray]:
     """
-    Converts a binary mask to a list of polygons.
+    Converts a binary mask to a list of connected polygons.
 
     Parameters:
         mask (np.ndarray): A binary mask represented as a 2D NumPy array of
@@ -181,13 +231,40 @@ def mask_to_polygons(mask: np.ndarray) -> List[np.ndarray]:
             of the points. Polygons with fewer points than `MIN_POLYGON_POINT_COUNT = 3`
             are excluded from the output.
     """
+    contours, hierarchies = cv2.findContours(mask.astype(np.uint8), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_TC89_KCOS)
 
-    contours, _ = cv2.findContours(
-        mask.astype(np.uint8), cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
-    )
+    contours_approx = []
+    polygons = []
+    for contour in contours:
+        epsilon = 0.001 * cv2.arcLength(contour, True)
+        contour_approx = cv2.approxPolyDP(contour, epsilon, True)
+        contours_approx.append(contour_approx)
+
+    contours_parent = []
+    for i, contour in enumerate(contours_approx):
+        parent_idx = hierarchies[0][i][3]
+        if parent_idx < 0 and len(contour) >= 3:
+            contours_parent.append(contour)
+        else:
+            contours_parent.append([])
+
+    for i, contour in enumerate(contours_approx):
+        parent_idx = hierarchies[0][i][3]
+        if parent_idx >= 0 and len(contour) >= 3:
+            contour_parent = contours_parent[parent_idx]
+            if len(contour_parent) == 0:
+                continue
+            contours_parent[parent_idx] = merge_with_parent(contour_parent, contour)
+
+    contours_parent_tmp = []
+    for contour in contours_parent:
+        if len(contour) == 0:
+            continue
+        contours_parent_tmp.append(contour)
+    
     return [
         np.squeeze(contour, axis=1)
-        for contour in contours
+        for contour in contours_parent_tmp
         if contour.shape[0] >= MIN_POLYGON_POINT_COUNT
     ]
 

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -82,7 +82,7 @@ def draw_filled_rectangle(scene: np.ndarray, rect: Rect, color: Color) -> np.nda
 
 
 def draw_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color, thickness: int = 2
+    scene: np.ndarray, polygon: np.ndarray, color: Color, thickness: int = 2, fill: bool = True, opacity: float = 0.5
 ) -> np.ndarray:
     """Draw a polygon on a scene.
 
@@ -98,8 +98,11 @@ def draw_polygon(
     cv2.polylines(
         scene, [polygon], isClosed=True, color=color.as_bgr(), thickness=thickness
     )
+    if fill:
+        colored_mask = np.array(scene, copy=True, dtype=np.uint8)
+        cv2.fillPoly(colored_mask, [polygon], color=color.as_bgr())
+        scene = cv2.addWeighted(colored_mask, opacity, scene, 1 - opacity, 0)
     return scene
-
 
 def draw_text(
     scene: np.ndarray,

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -82,7 +82,12 @@ def draw_filled_rectangle(scene: np.ndarray, rect: Rect, color: Color) -> np.nda
 
 
 def draw_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color, thickness: int = 2, fill: bool = True, opacity: float = 0.5
+    scene: np.ndarray,
+    polygon: np.ndarray,
+    color: Color,
+    thickness: int = 2,
+    fill: bool = True,
+    opacity: float = 0.5,
 ) -> np.ndarray:
     """Draw a polygon on a scene.
 
@@ -103,6 +108,7 @@ def draw_polygon(
         cv2.fillPoly(colored_mask, [polygon], color=color.as_bgr())
         scene = cv2.addWeighted(colored_mask, opacity, scene, 1 - opacity, 0)
     return scene
+
 
 def draw_text(
     scene: np.ndarray,


### PR DESCRIPTION
# Description

Improved the mask_to_polygons function to handle masks that have exclusions and Masks that do not align

Example:
Detections of Doughnut: Even if the Model correctly detects the Doughnut, the Polygon always was only the outer shape. With this change the hole in the middle is excluded from the Polygon
Person behind a table: When the Model identifies the Person correctly, the Part above and below the Table would have been two separate Polygons. With this change, it would be one Polygon connected.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [X] Somewhere in between between Bug fix and New feature (non-breaking change which adds functionality)
-> Arguably brings the Polygon functions closer to expected behavior

## How has this change been tested, please provide a testcase or example of how you tested the change?

Example:

Mask Annotator: (unchanged)
![person_mask](https://github.com/roboflow/supervision/assets/937467/446b9856-cc41-4382-848b-566643b66967)

Polygon Conversion before PR:
![person_polygon](https://github.com/roboflow/supervision/assets/937467/1c4c40e5-8d15-4c39-94e8-fd3a6903b41c)

Polygon Conversion after PR:
![person_polygon2](https://github.com/roboflow/supervision/assets/937467/e601accd-0989-4731-8ad2-c70bc6f59e15)


## Any specific deployment considerations

Also changed the Polygon Annotator to display a filled Polygon

## Docs

The original issue is not Documented. If the change to draw_polygon is accepted as well, the documentation for the function needs to be updated.
