### PR TITLE
Add `ColorAnnotator`

### DIFF
--- a/docs/annotators.md
+++ b/docs/annotators.md
@@ -229,6 +229,27 @@
 
     </div>
 
+=== "Color"
+
+    ```python
+    >>> import supervision as sv
+
+    >>> image = ...
+    >>> detections = sv.Detections(...)
+
+    >>> color_annotator = sv.ColorAnnotator()
+    >>> annotated_frame = color_annotator.annotate(
+    ...     scene=image.copy(),
+    ...     detections=detections
+    ... )
+    ```
+
+    <div class="result" markdown>
+
+    ![color-annotator-example](https://media.roboflow.com/supervision-annotator-examples/color-annotator-example-purple.png){ align=center width="800" }
+
+    </div>
+
 === "Trace"
 
     ```python
@@ -336,6 +357,10 @@
 ## BlurAnnotator
 
 :::supervision.annotators.core.BlurAnnotator
+
+## ColorAnnotator
+
+:::supervision.annotators.core.ColorAnnotator
 
 ## TraceAnnotator
 

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -20,6 +20,7 @@ from supervision.annotators.core import (
     MaskAnnotator,
     PolygonAnnotator,
     TraceAnnotator,
+    ColorAnnotator
 )
 from supervision.annotators.utils import ColorLookup
 from supervision.classification.core import Classifications

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -12,6 +12,7 @@ from supervision.annotators.core import (
     BoxCornerAnnotator,
     BoxMaskAnnotator,
     CircleAnnotator,
+    ColorAnnotator,
     DotAnnotator,
     EllipseAnnotator,
     HaloAnnotator,
@@ -20,7 +21,6 @@ from supervision.annotators.core import (
     MaskAnnotator,
     PolygonAnnotator,
     TraceAnnotator,
-    ColorAnnotator
 )
 from supervision.annotators.utils import ColorLookup
 from supervision.classification.core import Classifications

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1218,7 +1218,7 @@ class ColorAnnotator(BaseAnnotator):
         detections: Detections,
     ) -> np.ndarray:
         """
-        Annotates the given scene by replacing regions with a 
+        Annotates the given scene by replacing regions with a
         color based on the provided detections.
 
         Args:
@@ -1254,4 +1254,3 @@ class ColorAnnotator(BaseAnnotator):
             scene[y1:y2, x1:x2] = self.color.as_bgr()
 
         return scene
-

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1205,10 +1205,10 @@ class ColorAnnotator(BaseAnnotator):
     using provided detections.
     """
 
-    def __init__(self, color: Color = Color(r=0, g=0, b=0)):
+    def __init__(self, color: Color = Color.black()):
         """
         Args:
-            color (Color): The color to replace the regions with.
+            color (Color): The color to paint the regions with.
         """
         self.color: Color = color
 
@@ -1235,7 +1235,7 @@ class ColorAnnotator(BaseAnnotator):
             >>> image = ...
             >>> detections = sv.Detections(...)
 
-            >>> blur_annotator = sv.ColorAnnotator()
+            >>> color_annotator = sv.ColorAnnotator()
             >>> annotated_frame = color_annotator.annotate(
             ...     scene=image.copy(),
             ...     detections=detections

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1197,3 +1197,61 @@ class HeatMapAnnotator:
             mask
         ]
         return scene
+
+
+class ColorAnnotator(BaseAnnotator):
+    """
+    A class for replacing regions in an image with a color
+    using provided detections.
+    """
+
+    def __init__(self, color: Color = Color[255, 255, 255]):
+        """
+        Args:
+            color (Color): The color to replace the regions with.
+        """
+        self.color: Color = color
+
+    def annotate(
+        self,
+        scene: np.ndarray,
+        detections: Detections,
+    ) -> np.ndarray:
+        """
+        Annotates the given scene by replacing regions with a 
+        color based on the provided detections.
+
+        Args:
+            scene (np.ndarray): The image where regions will be replaced with a color.
+            detections (Detections): Object detections to annotate.
+
+        Returns:
+            The annotated image.
+
+        Example:
+            ```python
+            >>> import supervision as sv
+
+            >>> image = ...
+            >>> detections = sv.Detections(...)
+
+            >>> blur_annotator = sv.ColorAnnotator()
+            >>> annotated_frame = color_annotator.annotate(
+            ...     scene=image.copy(),
+            ...     detections=detections
+            ... )
+            ```
+
+        ![color-annotator-example](https://media.roboflow.com/
+        supervision-annotator-examples/color-annotator-example-purple.png)
+        """
+        image_height, image_width = scene.shape[:2]
+        clipped_xyxy = clip_boxes(
+            xyxy=detections.xyxy, resolution_wh=(image_width, image_height)
+        ).astype(int)
+
+        for x1, y1, x2, y2 in clipped_xyxy:
+            scene[y1:y2, x1:x2] = self.color.as_bgr()
+
+        return scene
+

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1205,7 +1205,7 @@ class ColorAnnotator(BaseAnnotator):
     using provided detections.
     """
 
-    def __init__(self, color: Color = Color[255, 255, 255]):
+    def __init__(self, color: Color = Color(r=0, g=0, b=0)):
         """
         Args:
             color (Color): The color to replace the regions with.


### PR DESCRIPTION
# Description

This PR adds the `ColorAnnotator` class to the `supervision` annotator suite.

Example:

<img width="332" alt="Screenshot 2023-12-04 at 14 15 22" src="https://github.com/roboflow/supervision/assets/37276661/276b80c0-5c66-4996-9e41-5a6f75335aa9">

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Use the following Notebook to test the feature:

https://colab.research.google.com/drive/1X6KDQB2mw52JBDBibowU7cREA82bFZxs?usp=sharing

## Any specific deployment considerations

N/A

## Docs

-   [ ] Docs updated? What were the changes:
