### PR TITLE
Add code snippet copy feature to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,8 @@ theme:
   font:
     text: Roboto
     code: Roboto Mono
+  features:
+    - content.code.copy
 
 plugins:
   - mkdocstrings


### PR DESCRIPTION
# Description

This PR adds a button that enables users to copy code snippets from the `supervision` documentation.

Before:

<img width="709" alt="Screenshot 2023-12-04 at 13 19 43" src="https://github.com/roboflow/supervision/assets/37276661/a970f532-6ca4-4aff-958f-99711b01974d">

After:

<img width="714" alt="Screenshot 2023-12-04 at 13 19 48" src="https://github.com/roboflow/supervision/assets/37276661/381da4ef-d7c0-4dcb-a8ae-c543077ae1e8">

## Type of change

Documentation.

## How has this change been tested, please provide a testcase or example of how you tested the change?

This was tested by opening a code snippet and checking for the presence of the copy button in the top right corner of the code box.

## Any specific deployment considerations

N/A

## Docs

N/A
