### PR TITLE
Add mkdocs-material[imaging] dependency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,4 +16,5 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material
       - run: pip install "mkdocstrings[python]"
+      - run: pip install "mkdocs-material[imaging]"
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
This PR adds the `mkdocs-material[imaging]` dependency to the documentation build step.