### PR TITLE
Add `scale_boxes` function to detection utils

### DIFF
--- a/docs/detection/utils.md
+++ b/docs/detection/utils.md
@@ -33,4 +33,3 @@
 ## scale_boxes
 
 :::supervision.detection.utils.scale_boxes
-

--- a/docs/detection/utils.md
+++ b/docs/detection/utils.md
@@ -25,3 +25,12 @@
 ## filter_polygons_by_area
 
 :::supervision.detection.utils.filter_polygons_by_area
+
+## move_boxes
+
+:::supervision.detection.utils.move_boxes
+
+## scale_boxes
+
+:::supervision.detection.utils.scale_boxes
+

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -40,10 +40,10 @@ from supervision.detection.utils import (
     filter_polygons_by_area,
     mask_to_polygons,
     mask_to_xyxy,
+    move_boxes,
     non_max_suppression,
     polygon_to_mask,
     polygon_to_xyxy,
-    move_boxes,
     scale_boxes,
 )
 from supervision.draw.color import Color, ColorPalette

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -43,6 +43,8 @@ from supervision.detection.utils import (
     non_max_suppression,
     polygon_to_mask,
     polygon_to_xyxy,
+    move_boxes,
+    scale_boxes,
 )
 from supervision.draw.color import Color, ColorPalette
 from supervision.draw.utils import (

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -383,7 +383,7 @@ def process_roboflow_result(
 
 def move_boxes(xyxy: np.ndarray, offset: np.ndarray) -> np.ndarray:
     """
-    Args:
+    Parameters:
         xyxy (np.ndarray): An array of shape `(n, 4)` containing the bounding boxes
             coordinates in format `[x1, y1, x2, y2]`
         offset (np.array): An array of shape `(2,)` containing offset values in format
@@ -393,6 +393,25 @@ def move_boxes(xyxy: np.ndarray, offset: np.ndarray) -> np.ndarray:
         (np.ndarray) repositioned bounding boxes
     """
     return xyxy + np.hstack([offset, offset])
+
+
+def scale_boxes(xyxy: np.ndarray, factor: float) -> np.ndarray:
+    """
+    Scale the dimensions of bounding boxes.
+
+    Parameters:
+        xyxy (np.ndarray): An array of shape `(n, 4)` containing the bounding boxes
+            coordinates in format `[x1, y1, x2, y2]`
+        factor (float): A float value representing the factor by which the box
+            dimensions are scaled. A factor greater than 1 enlarges the boxes, while a
+            factor less than 1 shrinks them.
+
+    Returns:
+        (np.ndarray) scaled bounding boxes
+    """
+    centers = (xyxy[:, :2] + xyxy[:, 2:]) / 2
+    new_sizes = (xyxy[:, 2:] - xyxy[:, :2]) * factor
+    return np.concatenate((centers - new_sizes / 2, centers + new_sizes / 2), axis=1)
 
 
 def calculate_masks_centroids(masks: np.ndarray) -> np.ndarray:

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -390,7 +390,21 @@ def move_boxes(xyxy: np.ndarray, offset: np.ndarray) -> np.ndarray:
             is `[dx, dy]`.
 
     Returns:
-        (np.ndarray) repositioned bounding boxes
+        np.ndarray: Repositioned bounding boxes.
+
+    Example:
+        ```python
+        >>> import numpy as np
+        >>> import supervision as sv
+
+        >>> boxes = np.array([[10, 10, 20, 20], [30, 30, 40, 40]])
+        >>> offset = np.array([5, 5])
+        >>> sv.move_boxes(boxes, offset)
+        ... array([
+        ...     [15, 15, 25, 25],
+        ...     [35, 35, 45, 45]
+        ... ])
+        ```
     """
     return xyxy + np.hstack([offset, offset])
 
@@ -407,7 +421,21 @@ def scale_boxes(xyxy: np.ndarray, factor: float) -> np.ndarray:
             factor less than 1 shrinks them.
 
     Returns:
-        (np.ndarray) scaled bounding boxes
+        np.ndarray: Scaled bounding boxes.
+
+    Example:
+        ```python
+        >>> import numpy as np
+        >>> import supervision as sv
+
+        >>> boxes = np.array([[10, 10, 20, 20], [30, 30, 40, 40]])
+        >>> factor = 1.5
+        >>> sv.scale_boxes(boxes, factor)
+        ... array([
+        ...     [ 7.5,  7.5, 22.5, 22.5],
+        ...     [27.5, 27.5, 42.5, 42.5]
+        ... ])
+        ```
     """
     centers = (xyxy[:, :2] + xyxy[:, 2:]) / 2
     new_sizes = (xyxy[:, 2:] - xyxy[:, :2]) * factor

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -10,7 +10,7 @@ from supervision.detection.utils import (
     filter_polygons_by_area,
     move_boxes,
     non_max_suppression,
-    process_roboflow_result,
+    process_roboflow_result, scale_boxes,
 )
 
 TEST_MASK = np.zeros((1, 1000, 1000), dtype=bool)
@@ -502,6 +502,53 @@ def test_move_boxes(
     with exception:
         result = move_boxes(xyxy=xyxy, offset=offset)
         assert np.array_equal(result, expected_result)
+
+
+@pytest.mark.parametrize(
+    "xyxy, factor, expected_result, exception",
+    [
+        (
+            np.empty(shape=(0, 4)),
+            2.0,
+            np.empty(shape=(0, 4)),
+            DoesNotRaise(),
+        ),  # empty xyxy array
+        (
+            np.array([[0, 0, 10, 10]]),
+            1.0,
+            np.array([[0, 0, 10, 10]]),
+            DoesNotRaise(),
+        ),  # single box with factor equal to 1.0
+        (
+            np.array([[0, 0, 10, 10]]),
+            2.0,
+            np.array([[-5, -5, 15, 15]]),
+            DoesNotRaise(),
+        ),  # single box with factor equal to 2.0
+        (
+            np.array([[0, 0, 10, 10]]),
+            0.5,
+            np.array([[2.5, 2.5, 7.5, 7.5]]),
+            DoesNotRaise(),
+        ),  # single box with factor equal to 0.5
+        (
+            np.array([[0, 0, 10, 10], [10, 10, 30, 30]]),
+            2.0,
+            np.array([[-5, -5, 15, 15], [0, 0, 40, 40]]),
+            DoesNotRaise(),
+        ),  # two boxes with factor equal to 2.0
+    ]
+)
+def test_scale_boxes(
+    xyxy: np.ndarray,
+    factor: float,
+    expected_result: np.ndarray,
+    exception: Exception,
+) -> None:
+    with exception:
+        result = scale_boxes(xyxy=xyxy, factor=factor)
+        assert np.array_equal(result, expected_result)
+
 
 
 @pytest.mark.parametrize(

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -10,7 +10,8 @@ from supervision.detection.utils import (
     filter_polygons_by_area,
     move_boxes,
     non_max_suppression,
-    process_roboflow_result, scale_boxes,
+    process_roboflow_result,
+    scale_boxes,
 )
 
 TEST_MASK = np.zeros((1, 1000, 1000), dtype=bool)
@@ -537,7 +538,7 @@ def test_move_boxes(
             np.array([[-5, -5, 15, 15], [0, 0, 40, 40]]),
             DoesNotRaise(),
         ),  # two boxes with factor equal to 2.0
-    ]
+    ],
 )
 def test_scale_boxes(
     xyxy: np.ndarray,
@@ -548,7 +549,6 @@ def test_scale_boxes(
     with exception:
         result = scale_boxes(xyxy=xyxy, factor=factor)
         assert np.array_equal(result, expected_result)
-
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Added a new function `scale_boxes` to the detection utilities to scale the dimensions of bounding boxes. This function accepts bounding boxes and a scaling factor as input and returns the scaled bounding boxes. It can enlarge or shrink the input bounding boxes based on the value of the passed factor. The function was also documented in the utils.md file and necessary tests were added to assure its correctness.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## Docs

-   [x] Docs updated? What were the changes:
