### PR TITLE
Add `TriangleAnnotator` to annotators

### DIFF
--- a/docs/annotators.md
+++ b/docs/annotators.md
@@ -103,6 +103,27 @@
 
     </div>
 
+=== "Triangle"
+
+    ```python
+    >>> import supervision as sv
+
+    >>> image = ...
+    >>> detections = sv.Detections(...)
+
+    >>> triangle_annotator = sv.TriangleAnnotator()
+    >>> annotated_frame = triangle_annotator.annotate(
+    ...     scene=image.copy(),
+    ...     detections=detections
+    ... )
+    ```
+
+    <div class="result" markdown>
+
+    ![triangle-annotator-example](https://media.roboflow.com/supervision-annotator-examples/triangle-annotator-example.png){ align=center width="800" }
+
+    </div>
+
 === "Ellipse"
 
     ```python
@@ -329,6 +350,10 @@
 ## DotAnnotator
 
 :::supervision.annotators.core.DotAnnotator
+
+## TriangleAnnotator
+
+:::supervision.annotators.core.TriangleAnnotator
 
 ## EllipseAnnotator
 

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -21,6 +21,7 @@ from supervision.annotators.core import (
     PixelateAnnotator,
     PolygonAnnotator,
     TraceAnnotator,
+    TriangleAnnotator
 )
 from supervision.annotators.utils import ColorLookup
 from supervision.classification.core import Classifications

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1322,15 +1322,12 @@ class TriangleAnnotator(BaseAnnotator):
                 if custom_color_lookup is None
                 else custom_color_lookup,
             )
-            center_x, center_y = int(xy[detection_idx, 0]), int(xy[detection_idx, 1])
-            vertices = np.array(
-                [
-                    [center_x - self.base // 2, center_y - self.height // 2],
-                    [center_x + self.base // 2, center_y - self.height // 2],
-                    [center_x, center_y + self.height // 2],
-                ],
-                np.int32,
-            )
+            tip_x, tip_y = int(xy[detection_idx, 0]), int(xy[detection_idx, 1])
+            vertices = np.array([
+                [tip_x - self.base // 2, tip_y - self.height],
+                [tip_x + self.base // 2, tip_y - self.height],
+                [tip_x, tip_y]
+            ], np.int32)
 
             cv2.fillPoly(scene, [vertices], color.as_bgr())
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1271,12 +1271,12 @@ class TriangleAnnotator(BaseAnnotator):
     """
 
     def __init__(
-        self,
-        color: Union[Color, ColorPalette] = ColorPalette.default(),
-        base: int = 10,
-        height: int = 10,
-        position: Position = Position.CENTER,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+            self,
+            color: Union[Color, ColorPalette] = ColorPalette.default(),
+            base: int = 10,
+            height: int = 10,
+            position: Position = Position.TOP_CENTER,
+            color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -1295,10 +1295,10 @@ class TriangleAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-        self,
-        scene: np.ndarray,
-        detections: Detections,
-        custom_color_lookup: Optional[np.ndarray] = None,
+            self,
+            scene: np.ndarray,
+            detections: Detections,
+            custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with triangles based on the provided detections.
@@ -1323,14 +1323,11 @@ class TriangleAnnotator(BaseAnnotator):
                 else custom_color_lookup,
             )
             center_x, center_y = int(xy[detection_idx, 0]), int(xy[detection_idx, 1])
-            vertices = np.array(
-                [
-                    [center_x - self.base // 2, center_y - self.height // 2],
-                    [center_x + self.base // 2, center_y - self.height // 2],
-                    [center_x, center_y + self.height // 2],
-                ],
-                np.int32,
-            )
+            vertices = np.array([
+                [center_x - self.base // 2, center_y - self.height // 2],
+                [center_x + self.base // 2, center_y - self.height // 2],
+                [center_x, center_y + self.height // 2]
+            ], np.int32)
 
             cv2.fillPoly(scene, [vertices], color.as_bgr())
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1271,12 +1271,12 @@ class TriangleAnnotator(BaseAnnotator):
     """
 
     def __init__(
-            self,
-            color: Union[Color, ColorPalette] = ColorPalette.default(),
-            base: int = 10,
-            height: int = 10,
-            position: Position = Position.TOP_CENTER,
-            color_lookup: ColorLookup = ColorLookup.CLASS,
+        self,
+        color: Union[Color, ColorPalette] = ColorPalette.default(),
+        base: int = 10,
+        height: int = 10,
+        position: Position = Position.TOP_CENTER,
+        color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -1295,10 +1295,10 @@ class TriangleAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-            self,
-            scene: np.ndarray,
-            detections: Detections,
-            custom_color_lookup: Optional[np.ndarray] = None,
+        self,
+        scene: np.ndarray,
+        detections: Detections,
+        custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with triangles based on the provided detections.
@@ -1323,11 +1323,14 @@ class TriangleAnnotator(BaseAnnotator):
                 else custom_color_lookup,
             )
             center_x, center_y = int(xy[detection_idx, 0]), int(xy[detection_idx, 1])
-            vertices = np.array([
-                [center_x - self.base // 2, center_y - self.height // 2],
-                [center_x + self.base // 2, center_y - self.height // 2],
-                [center_x, center_y + self.height // 2]
-            ], np.int32)
+            vertices = np.array(
+                [
+                    [center_x - self.base // 2, center_y - self.height // 2],
+                    [center_x + self.base // 2, center_y - self.height // 2],
+                    [center_x, center_y + self.height // 2],
+                ],
+                np.int32,
+            )
 
             cv2.fillPoly(scene, [vertices], color.as_bgr())
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1311,6 +1311,23 @@ class TriangleAnnotator(BaseAnnotator):
 
         Returns:
             np.ndarray: The annotated image.
+
+        Example:
+            ```python
+            >>> import supervision as sv
+
+            >>> image = ...
+            >>> detections = sv.Detections(...)
+
+            >>> triangle_annotator = sv.TriangleAnnotator()
+            >>> annotated_frame = triangle_annotator.annotate(
+            ...     scene=image.copy(),
+            ...     detections=detections
+            ... )
+            ```
+
+        ![triangle-annotator-example](https://media.roboflow.com/
+        supervision-annotator-examples/triangle-annotator-example.png)
         """
         xy = detections.get_anchors_coordinates(anchor=self.position)
         for detection_idx in range(len(detections)):

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1324,9 +1324,9 @@ class TriangleAnnotator(BaseAnnotator):
             )
             center_x, center_y = int(xy[detection_idx, 0]), int(xy[detection_idx, 1])
             vertices = np.array([
-                [center_x, center_y - self.height // 2],
-                [center_x - self.base // 2, center_y + self.height // 2],
-                [center_x + self.base // 2, center_y + self.height // 2]
+                [center_x - self.base // 2, center_y - self.height // 2],
+                [center_x + self.base // 2, center_y - self.height // 2],
+                [center_x, center_y + self.height // 2]
             ], np.int32)
 
             cv2.fillPoly(scene, [vertices], color.as_bgr())

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1271,12 +1271,12 @@ class TriangleAnnotator(BaseAnnotator):
     """
 
     def __init__(
-            self,
-            color: Union[Color, ColorPalette] = ColorPalette.default(),
-            base: int = 10,
-            height: int = 10,
-            position: Position = Position.CENTER,
-            color_lookup: ColorLookup = ColorLookup.CLASS,
+        self,
+        color: Union[Color, ColorPalette] = ColorPalette.default(),
+        base: int = 10,
+        height: int = 10,
+        position: Position = Position.CENTER,
+        color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:
@@ -1295,10 +1295,10 @@ class TriangleAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def annotate(
-            self,
-            scene: np.ndarray,
-            detections: Detections,
-            custom_color_lookup: Optional[np.ndarray] = None,
+        self,
+        scene: np.ndarray,
+        detections: Detections,
+        custom_color_lookup: Optional[np.ndarray] = None,
     ) -> np.ndarray:
         """
         Annotates the given scene with triangles based on the provided detections.
@@ -1323,11 +1323,14 @@ class TriangleAnnotator(BaseAnnotator):
                 else custom_color_lookup,
             )
             center_x, center_y = int(xy[detection_idx, 0]), int(xy[detection_idx, 1])
-            vertices = np.array([
-                [center_x - self.base // 2, center_y - self.height // 2],
-                [center_x + self.base // 2, center_y - self.height // 2],
-                [center_x, center_y + self.height // 2]
-            ], np.int32)
+            vertices = np.array(
+                [
+                    [center_x - self.base // 2, center_y - self.height // 2],
+                    [center_x + self.base // 2, center_y - self.height // 2],
+                    [center_x, center_y + self.height // 2],
+                ],
+                np.int32,
+            )
 
             cv2.fillPoly(scene, [vertices], color.as_bgr())
 


### PR DESCRIPTION
# Description

Added the ability to draw triangle markers on an image based on the provided detections with the TriangleAnnotator class. This is useful when needing to specifically mark or highlight certain areas of an image. The user can now specify both the color of the annotation and the metrics of the triangle such as base and height, as well as its position.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## Docs

-   [x] Docs updated? What were the changes:
