### PR TITLE
Remove upper limit on Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers=[
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12.0"
+python = ">=3.8"
 numpy = ">=1.21.2"
 matplotlib = ">=3.5.0"
 pyyaml = ">=5.3,<=6.0.1"


### PR DESCRIPTION
# Description

See: https://discuss.python.org/t/requires-python-upper-limits/12663

The current upper limit breaks packages that depend on `supervision` and claim compatibility with a wider range of Python versions, like CPython 3.12.:

> 🔒 Lock failed
> Unable to find a resolution because the following dependencies don't work on all Python versions in the range of the project's `requires-python`: >=3.11,<3.13.
>   python>=3.8,<3.12 (from <Candidate supervision@0.16.0 from https://pypi.org/simple/supervision/>)
>   python>=3.8,<3.12 (from <Candidate supervision@0.17.0 from https://pypi.org/simple/supervision/>)
> A possible solution is to change the value of `requires-python` in pyproject.toml to >=3.11,<3.12.

However, these packages must sometimes set a wider range as on some Linux distributions, like Fedora, CPython 3.12 is the standard, and the package itself would refuse to install if `requires-python` were to satisfy `<3.12`.

Since `supervision` is actively maintained, should some future Python version be explictly unsupported, the upper limit can be set again. But then it would be informed and deliberate, rather than avoiding unknown modern Python versions.

## Type of change

<!--
Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update
-->

## How has this change been tested, please provide a testcase or example of how you tested the change?

It will be tested in CI.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
