### PR TITLE
fix(md5): 🐞 hash_new param fix for downloaded content check

### DIFF
--- a/supervision/assets/downloader.py
+++ b/supervision/assets/downloader.py
@@ -35,9 +35,10 @@ def is_md5_hash_matching(filename: str, original_md5_hash: str) -> bool:
 
     with open(filename, "rb") as file:
         file_contents = file.read()
-        computed_md5_hash = hash_new(file_contents, name="MD5").hexdigest()
+        computed_md5_hash = hash_new(name="MD5")
+        computed_md5_hash.update(file_contents)
 
-    return computed_md5_hash == original_md5_hash
+    return computed_md5_hash.hexdigest() == original_md5_hash
 
 
 def download_assets(asset_name: Union[VideoAssets, str]) -> str:


### PR DESCRIPTION
# Description

**MD5 Hashing**: I fixed the `hash_new` function call in the `is_md5_hash_matching` function. Previously, the function was called with two positional arguments, causing a TypeError. The function call has been corrected to first create the hash object and then update it with the file contents. 


-   [X] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested, please provide a testcase or example of how you tested the change?

Previous (We assume file already downloaded and we do re-check)

```python
from supervision.assets import download_assets, VideoAssets
download_assets(VideoAssets.PEOPLE_WALKING)
```

Error message

```python
>>> download_assets(VideoAssets.PEOPLE_WALKING)
,Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "supervision/supervision/assets/downloader.py", line 82, in download_assets
    if not is_md5_hash_matching(filename, VIDEO_ASSETS[filename][1]):
  File "supervision/supervision/assets/downloader.py", line 38, in is_md5_hash_matching
    md5_hash = hash_new(file_contents, name="MD5")
TypeError: __hash_new() got multiple values for argument 'name'

```

Fixed One (asset download complete message and skip download since hash is matched) 

```python
>>> from supervision.assets import download_assets, VideoAssets
>>> download_assets(VideoAssets.PEOPLE_WALKING)
Downloading people-walking.mp4 assets

100%|███| 7.25M/7.25M [00:01<00:00, 6.80MB/s]
'people-walking.mp4'

>>> download_assets(VideoAssets.PEOPLE_WALKING)
people-walking.mp4 asset download complete.

'people-walking.mp4'
>>>
```

Security wise also fine. 

I missed that part when I was fixing security side, please test and merge. 
Thank you.