### PR TITLE
Add Polygon Simplification Method

### DIFF
--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -178,12 +178,13 @@ def simplify_polygon(polygon: np.ndarray, epsilon: float) -> np.ndarray:
 
     return approximated_polygon_np
 
+
 def object_to_yolo(
     xyxy: np.ndarray,
     class_id: int,
     image_shape: Tuple[int, int, int],
     polygon: Optional[np.ndarray] = None,
-    simplified_polygon_epsilon: float = 0
+    simplified_polygon_epsilon: float = 0,
 ) -> str:
     h, w, _ = image_shape
     if polygon is None:
@@ -195,7 +196,9 @@ def object_to_yolo(
         height = y_max - y_min
         return f"{int(class_id)} {x_center:.5f} {y_center:.5f} {width:.5f} {height:.5f}"
     else:
-        simplified_polygon = simplify_polygon(polygon, epsilon = simplified_polygon_epsilon)
+        simplified_polygon = simplify_polygon(
+            polygon, epsilon=simplified_polygon_epsilon
+        )
         polygon_relative = simplified_polygon / np.array([w, h], dtype=np.float32)
         polygon_relative = polygon_relative.reshape(-1)
         polygon_parsed = " ".join([f"{value:.5f}" for value in polygon_relative])
@@ -208,7 +211,7 @@ def detections_to_yolo_annotations(
     min_image_area_percentage: float = 0.0,
     max_image_area_percentage: float = 1.0,
     approximation_percentage: float = 0.75,
-    simplified_polygon_epsilon: float = 0
+    simplified_polygon_epsilon: float = 0,
 ) -> List[str]:
     annotation = []
     for xyxy, mask, _, class_id, _ in detections:
@@ -226,7 +229,7 @@ def detections_to_yolo_annotations(
                     class_id=class_id,
                     image_shape=image_shape,
                     polygon=polygon,
-                    simplified_polygon_epsilon=simplified_polygon_epsilon
+                    simplified_polygon_epsilon=simplified_polygon_epsilon,
                 )
                 annotation.append(next_object)
         else:
@@ -244,7 +247,7 @@ def save_yolo_annotations(
     min_image_area_percentage: float = 0.0,
     max_image_area_percentage: float = 1.0,
     approximation_percentage: float = 0.75,
-    simplified_polygon_epsilon: float = 0
+    simplified_polygon_epsilon: float = 0,
 ) -> None:
     Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
     for image_path, image in images.items():
@@ -260,7 +263,7 @@ def save_yolo_annotations(
             min_image_area_percentage=min_image_area_percentage,
             max_image_area_percentage=max_image_area_percentage,
             approximation_percentage=approximation_percentage,
-            simplified_polygon_epsilon=simplified_polygon_epsilon
+            simplified_polygon_epsilon=simplified_polygon_epsilon,
         )
         save_text_file(lines=lines, file_path=yolo_annotations_path)
 


### PR DESCRIPTION
# Description

I have introduced a new method called simplify_polygon to facilitate the simplification of polygons within the existing codebase. This function takes a NumPy array representing a polygon and an epsilon value as parameters. Internally, it converts the input polygon to the required format, applies the cv2.approxPolyDP method for polygon simplification, and then returns the simplified polygon as a NumPy array.

## Type of change
Before:
![image](https://github.com/roboflow/supervision/assets/5433346/d6f01f6b-83fa-4793-a6cf-63d1b15bcea5)
After:
![image](https://github.com/roboflow/supervision/assets/5433346/9a46d660-3ae6-4654-bf15-fa4f397472cf)


Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [+] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a test case or example of how you tested the change?

I have tested the new simplify_polygon method with various polygon inputs, ensuring that it correctly produces simplified polygons as expected.

## Any specific deployment considerations

No specific deployment considerations at the moment. The new feature is designed to seamlessly integrate with the existing codebase.

## Docs

-   [ ] Docs updated? What were the changes:
