### PR TITLE
fix looping over detections in dataset loaders

### DIFF
--- a/supervision/dataset/formats/coco.py
+++ b/supervision/dataset/formats/coco.py
@@ -106,7 +106,7 @@ def detections_to_coco_annotations(
     approximation_percentage: float = 0.75,
 ) -> Tuple[List[Dict], int]:
     coco_annotations = []
-    for xyxy, mask, _, class_id, _ in detections:
+    for xyxy, mask, _, class_id, _, _ in detections:
         box_width, box_height = xyxy[2] - xyxy[0], xyxy[3] - xyxy[1]
         polygon = []
         if mask is not None:

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -109,7 +109,7 @@ def detections_to_pascal_voc(
     segmented.text = "0"
 
     # Add object elements
-    for xyxy, mask, _, class_id, _ in detections:
+    for xyxy, mask, _, class_id, _, _ in detections:
         name = classes[class_id]
         if mask is not None:
             polygons = approximate_mask_with_polygons(

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -194,7 +194,7 @@ def detections_to_yolo_annotations(
     approximation_percentage: float = 0.75,
 ) -> List[str]:
     annotation = []
-    for xyxy, mask, _, class_id, _ in detections:
+    for xyxy, mask, _, class_id, _, _ in detections:
         if mask is not None:
             polygons = approximate_mask_with_polygons(
                 mask=mask,


### PR DESCRIPTION
# Description

Fix looping over detections in supervision dataset loaders.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)