### PR TITLE
fix vectorize function error with 0 length input

### DIFF
--- a/examples/traffic_analysis/inference_example.py
+++ b/examples/traffic_analysis/inference_example.py
@@ -48,10 +48,10 @@ class DetectionsManager:
                     self.counts.setdefault(zone_out_id, {})
                     self.counts[zone_out_id].setdefault(zone_in_id, set())
                     self.counts[zone_out_id][zone_in_id].add(tracker_id)
-
-        detections_all.class_id = np.vectorize(
-            lambda x: self.tracker_id_to_zone_id.get(x, -1)
-        )(detections_all.tracker_id)
+        if len(detections_all) > 0:
+            detections_all.class_id = np.vectorize(
+                lambda x: self.tracker_id_to_zone_id.get(x, -1)
+            )(detections_all.tracker_id)
         return detections_all[detections_all.class_id != -1]
 
 

--- a/examples/traffic_analysis/ultralytics_example.py
+++ b/examples/traffic_analysis/ultralytics_example.py
@@ -47,10 +47,10 @@ class DetectionsManager:
                     self.counts.setdefault(zone_out_id, {})
                     self.counts[zone_out_id].setdefault(zone_in_id, set())
                     self.counts[zone_out_id][zone_in_id].add(tracker_id)
-
-        detections_all.class_id = np.vectorize(
-            lambda x: self.tracker_id_to_zone_id.get(x, -1)
-        )(detections_all.tracker_id)
+        if len(detections_all) > 0:
+            detections_all.class_id = np.vectorize(
+                lambda x: self.tracker_id_to_zone_id.get(x, -1)
+            )(detections_all.tracker_id)
         return detections_all[detections_all.class_id != -1]
 
 


### PR DESCRIPTION
This pull request addresses an issue within the vectorize function in my specific use case, where sometimes there are no detections on certain frames, leading to errors with inputs of length 0. The fix involves incorporating a pre-check for the input's length to prevent such errors from occurring.
