### PR TITLE
[LineZone] - flip in/out line crossing directions #838

### DIFF
--- a/supervision/detection/line_counter.py
+++ b/supervision/detection/line_counter.py
@@ -137,7 +137,7 @@ class LineZone:
                 continue
 
             triggers = [
-                self.vector.cross_product(point=anchor) > 0 for anchor in box_anchors
+                self.vector.cross_product(point=anchor) < 0 for anchor in box_anchors
             ]
 
             if len(set(triggers)) == 2:


### PR DESCRIPTION
# Description

When version 0.18.0 was released, the calculated in/out values in LineZoneAnnotator had been swapped. This issue has been fixed.

resolve #838 

For testing purposes, please refer to the provided [Colab link](https://colab.research.google.com/drive/1ChKBEtA3ij-Cezf3DKOBoX5rs2VhXGdf?usp=sharing).

Example Output: [Google Drive Link](https://drive.google.com/file/d/1d1rImXd0T5zUOnZVPTAU7mvaRidQZD-c/view?usp=sharing)


Please review thank you :)