### PR TITLE
[NMS] - add segmentation models support

### DIFF
--- a/docs/detection/utils.md
+++ b/docs/detection/utils.md
@@ -11,6 +11,12 @@ comments: true
 :::supervision.detection.utils.box_iou_batch
 
 <div class="md-typeset">
+  <h2>mask_iou_batch</h2>
+</div>
+
+:::supervision.detection.utils.mask_iou_batch
+
+<div class="md-typeset">
   <h2>box_non_max_suppression</h2>
 </div>
 

--- a/docs/detection/utils.md
+++ b/docs/detection/utils.md
@@ -11,10 +11,16 @@ comments: true
 :::supervision.detection.utils.box_iou_batch
 
 <div class="md-typeset">
-  <h2>non_max_suppression</h2>
+  <h2>box_non_max_suppression</h2>
 </div>
 
-:::supervision.detection.utils.non_max_suppression
+:::supervision.detection.utils.box_non_max_suppression
+
+<div class="md-typeset">
+  <h2>mask_non_max_suppression</h2>
+</div>
+
+:::supervision.detection.utils.mask_non_max_suppression
 
 <div class="md-typeset">
     <h2>polygon_to_mask</h2>

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -42,12 +42,13 @@ from supervision.detection.tools.polygon_zone import PolygonZone, PolygonZoneAnn
 from supervision.detection.tools.smoother import DetectionsSmoother
 from supervision.detection.utils import (
     box_iou_batch,
+    box_non_max_suppression,
     calculate_masks_centroids,
     filter_polygons_by_area,
+    mask_non_max_suppression,
     mask_to_polygons,
     mask_to_xyxy,
     move_boxes,
-    non_max_suppression,
     polygon_to_mask,
     polygon_to_xyxy,
     scale_boxes,

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -45,6 +45,7 @@ from supervision.detection.utils import (
     box_non_max_suppression,
     calculate_masks_centroids,
     filter_polygons_by_area,
+    mask_iou_batch,
     mask_non_max_suppression,
     mask_to_polygons,
     mask_to_xyxy,

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1002,7 +1002,7 @@ class Detections:
         self, threshold: float = 0.5, class_agnostic: bool = False
     ) -> Detections:
         """
-        Performs non-max suppression on detection set. If the detections result 
+        Performs non-max suppression on detection set. If the detections result
         from a segmentation model, the IoU mask is applied. Otherwise, box IoU is used.
 
         Args:

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1033,14 +1033,22 @@ class Detections:
             assert self.class_id is not None, (
                 "Detections class_id must be given for NMS to be executed. If you intended"
                 " to perform class agnostic NMS set class_agnostic=True."
-            )   
+            )
             predictions = np.hstack(
-                (self.xyxy, self.confidence.reshape(-1, 1), self.class_id.reshape(-1, 1))
+                (
+                    self.xyxy,
+                    self.confidence.reshape(-1, 1),
+                    self.class_id.reshape(-1, 1),
+                )
             )
 
-        if hasattr(self, 'mask') and self.mask is not None:
-            indices = mask_non_max_suppression(predictions=predictions, masks=self.mask, iou_threshold=threshold)
+        if hasattr(self, "mask") and self.mask is not None:
+            indices = mask_non_max_suppression(
+                predictions=predictions, masks=self.mask, iou_threshold=threshold
+            )
         else:
-            indices = box_non_max_suppression(predictions=predictions, iou_threshold=threshold)
+            indices = box_non_max_suppression(
+                predictions=predictions, iou_threshold=threshold
+            )
 
         return self[indices]

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1002,7 +1002,7 @@ class Detections:
         self, threshold: float = 0.5, class_agnostic: bool = False
     ) -> Detections:
         """
-        Perform non-maximum suppression on the current set 
+        Perform non-maximum suppression on the current set
         of object detections or segmentation prediction.
 
         Args:

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1002,8 +1002,8 @@ class Detections:
         self, threshold: float = 0.5, class_agnostic: bool = False
     ) -> Detections:
         """
-        Perform non-maximum suppression on the current set
-        of object detections or segmentation prediction.
+        Performs non-max suppression on detection set. If the detections result 
+        from a segmentation model, the IoU mask is applied. Otherwise, box IoU is used.
 
         Args:
             threshold (float, optional): The intersection-over-union threshold
@@ -1043,7 +1043,7 @@ class Detections:
                 )
             )
 
-        if hasattr(self, "mask") and self.mask is not None:
+        if self.mask is not None:
             indices = mask_non_max_suppression(
                 predictions=predictions, masks=self.mask, iou_threshold=threshold
             )

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1002,7 +1002,8 @@ class Detections:
         self, threshold: float = 0.5, class_agnostic: bool = False
     ) -> Detections:
         """
-        Perform non-maximum suppression on the current set of object detections or segmentation prediction.
+        Perform non-maximum suppression on the current set 
+        of object detections or segmentation prediction.
 
         Args:
             threshold (float, optional): The intersection-over-union threshold
@@ -1031,8 +1032,8 @@ class Detections:
             predictions = np.hstack((self.xyxy, self.confidence.reshape(-1, 1)))
         else:
             assert self.class_id is not None, (
-                "Detections class_id must be given for NMS to be executed. If you intended"
-                " to perform class agnostic NMS set class_agnostic=True."
+                "Detections class_id must be given for NMS to be executed. If you"
+                " intended to perform class agnostic NMS set class_agnostic=True."
             )
             predictions = np.hstack(
                 (

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -1,8 +1,8 @@
+import time
 from itertools import chain
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import cv2
-import time
 import numpy as np
 
 from supervision.config import CLASS_NAME_DATA_FIELD

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -168,7 +168,7 @@ def mask_non_max_suppression(
             condition = (ious[i] > iou_threshold) & (categories[i] == categories)
             keep[i + 1 :] = np.where(condition[i + 1 :], False, keep[i + 1 :])
 
-    return keep
+    return keep[sort_index.argsort()]
 
 
 def box_non_max_suppression(

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -120,7 +120,7 @@ def mask_non_max_suppression(
     predictions: np.ndarray,
     masks: np.ndarray,
     iou_threshold: float = 0.5,
-    mask_dimension: int = 640
+    mask_dimension: int = 640,
 ) -> np.ndarray:
     """
     Perform Non-Maximum Suppression (NMS) on segmentation predictions.

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -113,7 +113,8 @@ def mask_non_max_suppression(
             non-maximum suppression.
 
     Raises:
-        AssertionError: If `iou_threshold` is not within the closed range from `0` to `1`.
+        AssertionError: If `iou_threshold` is not within the closed 
+        range from `0` to `1`.
     """
     assert 0 <= iou_threshold <= 1, (
         "Value of `iou_threshold` must be in the closed range from 0 to 1, "

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -58,6 +58,7 @@ def box_iou_batch(boxes_true: np.ndarray, boxes_detection: np.ndarray) -> np.nda
     area_inter = np.prod(np.clip(bottom_right - top_left, a_min=0, a_max=None), 2)
     return area_inter / (area_true[:, None] + area_detection - area_inter)
 
+
 def mask_iou_batch(masks_true: np.ndarray, masks_detection: np.ndarray) -> np.ndarray:
     """
     Compute Intersection over Union (IoU) of two sets of masks -
@@ -82,13 +83,14 @@ def mask_iou_batch(masks_true: np.ndarray, masks_detection: np.ndarray) -> np.nd
     masks_detection = masks_detection.astype(bool)
 
     intersection = np.logical_and(masks_true[:, None], masks_detection)
-    intersection_area = intersection.sum(axis=(2, 3))  
+    intersection_area = intersection.sum(axis=(2, 3))
 
     union = np.logical_or(masks_true[:, None], masks_detection)
-    union_area = union.sum(axis=(2, 3)) 
+    union_area = union.sum(axis=(2, 3))
 
     iou = intersection_area / union_area
     return iou
+
 
 def mask_non_max_suppression(
     predictions: np.ndarray, masks: np.ndarray, iou_threshold: float = 0.5
@@ -125,7 +127,7 @@ def mask_non_max_suppression(
     sort_index = predictions[:, 4].argsort()[::-1]
     predictions_sorted = predictions[sort_index]
     masks_sorted = masks[sort_index]
-  
+
     ious = mask_iou_batch(masks_sorted, masks_sorted)
 
     keep = np.ones(num_predictions, dtype=bool)
@@ -134,10 +136,15 @@ def mask_non_max_suppression(
             continue
 
         for j in range(i + 1, num_predictions):
-            if keep[j] and ious[i, j] > iou_threshold and predictions_sorted[i, 5] == predictions_sorted[j, 5]:
+            if (
+                keep[j]
+                and ious[i, j] > iou_threshold
+                and predictions_sorted[i, 5] == predictions_sorted[j, 5]
+            ):
                 keep[j] = False
 
-    return keep[sort_index.argsort()] 
+    return keep[sort_index.argsort()]
+
 
 def box_non_max_suppression(
     predictions: np.ndarray, iou_threshold: float = 0.5
@@ -191,6 +198,7 @@ def box_non_max_suppression(
         keep = keep & ~condition
 
     return keep[sort_index.argsort()]
+
 
 def clip_boxes(xyxy: np.ndarray, resolution_wh: Tuple[int, int]) -> np.ndarray:
     """

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -2,6 +2,7 @@ from itertools import chain
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import cv2
+import time
 import numpy as np
 
 from supervision.config import CLASS_NAME_DATA_FIELD
@@ -129,7 +130,11 @@ def mask_non_max_suppression(
     predictions_sorted = predictions[sort_index]
     masks_sorted = masks[sort_index]
 
+    start_time = time.time()
     ious = mask_iou_batch(masks_sorted, masks_sorted)
+    end_time = time.time()
+    execution_time = end_time - start_time
+    print(f"mask_iou_batch execution time: {execution_time} seconds")
 
     keep = np.ones(num_predictions, dtype=bool)
     for i in range(num_predictions):

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -199,10 +199,10 @@ def mask_non_max_suppression_2(
         "Value of `iou_threshold` must be in the closed range from 0 to 1, "
         f"{iou_threshold} given."
     )
-    num_predictions, columns = predictions.shape
+    rows, columns = predictions.shape
 
     if columns == 5:
-        predictions = np.c_[predictions, np.zeros(num_predictions)]
+        predictions = np.c_[predictions, np.zeros(rows)]
 
     sort_index = predictions[:, 4].argsort()[::-1]
     predictions = predictions[sort_index]
@@ -212,7 +212,7 @@ def mask_non_max_suppression_2(
     categories = predictions[:, 5]
 
     keep = np.ones(rows, dtype=bool)
-    for i in range(num_predictions):
+    for i in range(rows):
         if keep[i]:
             condition = (ious[i] > iou_threshold) & (categories == category)
             keep[i + 1:] = np.where(condition[i + 1:], False, keep[i + 1:])

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -113,7 +113,7 @@ def mask_non_max_suppression(
             non-maximum suppression.
 
     Raises:
-        AssertionError: If `iou_threshold` is not within the closed 
+        AssertionError: If `iou_threshold` is not within the closed
         range from `0` to `1`.
     """
     assert 0 <= iou_threshold <= 1, (

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -211,18 +211,13 @@ def mask_non_max_suppression_2(
     ious = mask_iou_batch(masks_resized, masks_resized)
     categories = predictions[:, 5]
 
-    keep = np.ones(num_predictions, dtype=bool)
+    keep = np.ones(rows, dtype=bool)
+    for i in range(num_predictions):
+        if keep[i]:
+            condition = (ious[i] > iou_threshold) & (categories == category)
+            keep[i + 1:] = np.where(condition[i + 1:], False, keep[i + 1:])
 
-    for index, (iou, category) in enumerate(zip(ious, categories)):
-        if not keep[index]:
-            continue
-
-        # drop detections with iou > iou_threshold and
-        # same category as current detections
-        condition = (iou > iou_threshold) & (categories == category)
-        keep = keep & ~condition
-
-    return keep[sort_index.argsort()]
+    return keep
 
 
 def box_non_max_suppression(

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -72,13 +72,21 @@ def mask_iou_batch(masks_true: np.ndarray, masks_detection: np.ndarray) -> np.nd
     Returns:
         np.ndarray: Pairwise IoU of masks from `masks_true` and `masks_detection`.
     """
-    intersection_area = np.logical_and(masks_true[:, None], masks_detection).sum(axis=(2, 3))
-    masks_true_area = masks_true.sum(axis=(1, 2)) 
+    intersection_area = np.logical_and(masks_true[:, None], masks_detection).sum(
+        axis=(2, 3)
+    )
+    masks_true_area = masks_true.sum(axis=(1, 2))
     masks_detection_area = masks_detection.sum(axis=(1, 2))
 
     union_area = masks_true_area[:, None] + masks_detection_area - intersection_area
 
-    return np.divide(intersection_area, union_area, out=np.zeros_like(intersection_area, dtype=float), where=union_area != 0)
+    return np.divide(
+        intersection_area,
+        union_area,
+        out=np.zeros_like(intersection_area, dtype=float),
+        where=union_area != 0,
+    )
+
 
 def resize_masks(masks: np.ndarray, max_dimension: int = 640) -> np.ndarray:
     """
@@ -107,6 +115,7 @@ def resize_masks(masks: np.ndarray, max_dimension: int = 640) -> np.ndarray:
 
     resized_masks = resized_masks.reshape(masks.shape[0], new_height, new_width)
     return resized_masks
+
 
 def mask_non_max_suppression(
     predictions: np.ndarray, masks: np.ndarray, iou_threshold: float = 0.5

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -214,7 +214,7 @@ def mask_non_max_suppression_2(
     keep = np.ones(rows, dtype=bool)
     for i in range(rows):
         if keep[i]:
-            condition = (ious[i] > iou_threshold) & (category[i] == categories)
+            condition = (ious[i] > iou_threshold) & (categories[i] == categories)
             keep[i + 1 :] = np.where(condition[i + 1 :], False, keep[i + 1 :])
 
     return keep

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -136,9 +136,9 @@ def test_box_non_max_suppression(
             0.5,
             np.array([]),
             DoesNotRaise(),
-        ),  # single box with no category
+        ),  # empty predictions and masks
         (
-            np.array([[10, 10, 40, 40, 0.8]]),
+            np.array([[0, 0, 0, 0, 0.8]]),
             np.array(
                 [
                     [
@@ -153,9 +153,9 @@ def test_box_non_max_suppression(
             0.5,
             np.array([True]),
             DoesNotRaise(),
-        ),  # single box with no category
+        ),  # single mask with no category
         (
-            np.array([[10, 10, 40, 40, 0.8, 0]]),
+            np.array([[0, 0, 0, 0, 0.8, 0]]),
             np.array(
                 [
                     [
@@ -170,9 +170,9 @@ def test_box_non_max_suppression(
             0.5,
             np.array([True]),
             DoesNotRaise(),
-        ),  # single box with category
+        ),  # single mask with category
         (
-            np.array([[0, 0, 20, 20, 0.8], [50, 50, 70, 70, 0.9]]),
+            np.array([[0, 0, 0, 0, 0.8], [0, 0, 0, 0, 0.9]]),
             np.array(
                 [
                     [
@@ -194,9 +194,9 @@ def test_box_non_max_suppression(
             0.5,
             np.array([True, True]),
             DoesNotRaise(),
-        ),  # two boxes with no category
+        ),  # two masks non-overlapping with no category
         (
-            np.array([[0, 0, 30, 30, 0.8], [20, 20, 50, 50, 0.9]]),
+            np.array([[0, 0, 0, 0, 0.8], [0, 0, 0, 0, 0.9]]),
             np.array(
                 [
                     [
@@ -218,9 +218,9 @@ def test_box_non_max_suppression(
             0.4,
             np.array([False, True]),
             DoesNotRaise(),
-        ),  # two boxes with different category
+        ),  # two masks partially overlapping with no category
         (
-            np.array([[0, 0, 30, 30, 0.8, 0], [20, 20, 50, 50, 0.9, 1]]),
+            np.array([[0, 0, 0, 0, 0.8, 0], [0, 0, 0, 0, 0.9, 1]]),
             np.array(
                 [
                     [
@@ -242,13 +242,13 @@ def test_box_non_max_suppression(
             0.5,
             np.array([True, True]),
             DoesNotRaise(),
-        ),  # two boxes with same category
+        ),  # two masks partially overlapping with different category
         (
             np.array(
                 [
-                    [0, 0, 30, 30, 0.8, 0],
-                    [15, 15, 45, 45, 0.85, 0],
-                    [30, 30, 60, 60, 0.9, 1],
+                    [0, 0, 0, 0, 0.8],
+                    [0, 0, 0, 0, 0.85],
+                    [0, 0, 0, 0, 0.9],
                 ]
             ),
             np.array(
@@ -258,7 +258,7 @@ def test_box_non_max_suppression(
                         [False, True, True, False, False],
                         [False, True, True, False, False],
                         [False, False, False, False, False],
-                        [False, False, False, True, False],
+                        [False, False, False, False, False],
                     ],
                     [
                         [False, False, False, False, False],
@@ -279,7 +279,44 @@ def test_box_non_max_suppression(
             0.5,
             np.array([False, True, True]),
             DoesNotRaise(),
-        ),  # three boxes with no category
+        ),  # three masks with no category
+        (
+            np.array(
+                [
+                    [0, 0, 0, 0, 0.8, 0],
+                    [0, 0, 0, 0, 0.85, 1],
+                    [0, 0, 0, 0, 0.9, 2],
+                ]
+            ),
+            np.array(
+                [
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, False, False],
+                        [False, True, True, False, False],
+                        [False, False, False, False, False],
+                        [False, False, False, False, False],
+                    ],
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, False, False],
+                        [False, True, True, False, False],
+                        [False, True, True, False, False],
+                        [False, False, False, False, False],
+                    ],
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, False, False],
+                        [False, True, True, False, False],
+                        [False, False, False, False, False],
+                        [False, False, False, False, False],
+                    ],
+                ]
+            ),
+            0.5,
+            np.array([True, True, True]),
+            DoesNotRaise(),
+        ),  # three masks with different category
     ],
 )
 def test_mask_non_max_suppression(

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -126,110 +126,162 @@ def test_box_non_max_suppression(
         )
         assert np.array_equal(result, expected_result)
 
+
 @pytest.mark.parametrize(
     "predictions, masks, iou_threshold, expected_result, exception",
     [
         (
-            np.empty((0, 6)), 
-            np.empty((0, 5, 5)), 
+            np.empty((0, 6)),
+            np.empty((0, 5, 5)),
             0.5,
             np.array([]),
             DoesNotRaise(),
         ),  # single box with no category
         (
-            np.array([[10, 10, 40, 40, 0.8]]), 
-            np.array([[[False, False, False, False, False],
-                       [False, True, True, True, False],
-                       [False, True, True, True, False],
-                       [False, True, True, True, False],
-                       [False, False, False, False, False]]]), 
+            np.array([[10, 10, 40, 40, 0.8]]),
+            np.array(
+                [
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, True, False],
+                        [False, True, True, True, False],
+                        [False, True, True, True, False],
+                        [False, False, False, False, False],
+                    ]
+                ]
+            ),
             0.5,
             np.array([True]),
             DoesNotRaise(),
         ),  # single box with no category
         (
-            np.array([[10, 10, 40, 40, 0.8, 0]]), 
-            np.array([[[False, False, False, False, False],
-                       [False, True, True, True, False],
-                       [False, True, True, True, False],
-                       [False, True, True, True, False],
-                       [False, False, False, False, False]]]), 
+            np.array([[10, 10, 40, 40, 0.8, 0]]),
+            np.array(
+                [
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, True, False],
+                        [False, True, True, True, False],
+                        [False, True, True, True, False],
+                        [False, False, False, False, False],
+                    ]
+                ]
+            ),
             0.5,
             np.array([True]),
             DoesNotRaise(),
         ),  # single box with category
         (
-            np.array([[0, 0, 20, 20, 0.8], [50, 50, 70, 70, 0.9]]), 
-            np.array([[[False, False, False, False, False],
-                       [False, True, True, False, False],
-                       [False, True, True, False, False],
-                       [False, False, False, False, False],
-                       [False, False, False, False, False]],
-                      [[False, False, False, False, False],
-                       [False, False, False, False, False],
-                       [False, False, False, True, True],
-                       [False, False, False, True, True],
-                       [False, False, False, False, False]]]), 
+            np.array([[0, 0, 20, 20, 0.8], [50, 50, 70, 70, 0.9]]),
+            np.array(
+                [
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, False, False],
+                        [False, True, True, False, False],
+                        [False, False, False, False, False],
+                        [False, False, False, False, False],
+                    ],
+                    [
+                        [False, False, False, False, False],
+                        [False, False, False, False, False],
+                        [False, False, False, True, True],
+                        [False, False, False, True, True],
+                        [False, False, False, False, False],
+                    ],
+                ]
+            ),
             0.5,
             np.array([True, True]),
             DoesNotRaise(),
         ),  # two boxes with no category
         (
-            np.array([[0, 0, 30, 30, 0.8], [20, 20, 50, 50, 0.9]]),  
-            np.array([[[False, False, False, False, False],
-                       [False, True, True, True, False],
-                       [False, True, True, True, False],
-                       [False, True, True, True, False],
-                       [False, False, False, False, False]],
-                      [[False, False, False, False, False],
-                       [False, False, True, True, True],
-                       [False, False, True, True, True],
-                       [False, False, True, True, True],
-                       [False, False, False, False, False]]]),  
+            np.array([[0, 0, 30, 30, 0.8], [20, 20, 50, 50, 0.9]]),
+            np.array(
+                [
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, True, False],
+                        [False, True, True, True, False],
+                        [False, True, True, True, False],
+                        [False, False, False, False, False],
+                    ],
+                    [
+                        [False, False, False, False, False],
+                        [False, False, True, True, True],
+                        [False, False, True, True, True],
+                        [False, False, True, True, True],
+                        [False, False, False, False, False],
+                    ],
+                ]
+            ),
             0.4,
             np.array([False, True]),
             DoesNotRaise(),
         ),  # two boxes with different category
         (
             np.array([[0, 0, 30, 30, 0.8, 0], [20, 20, 50, 50, 0.9, 1]]),
-            np.array([[[False, False, False, False, False],
-                       [False, True, True, True, False],
-                       [False, True, True, True, False],
-                       [False, True, True, True, False],
-                       [False, False, False, False, False]],
-                      [[False, False, False, False, False],
-                       [False, False, True, True, True],
-                       [False, False, True, True, True],
-                       [False, False, True, True, True],
-                       [False, False, False, False, False]]]),  
+            np.array(
+                [
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, True, False],
+                        [False, True, True, True, False],
+                        [False, True, True, True, False],
+                        [False, False, False, False, False],
+                    ],
+                    [
+                        [False, False, False, False, False],
+                        [False, False, True, True, True],
+                        [False, False, True, True, True],
+                        [False, False, True, True, True],
+                        [False, False, False, False, False],
+                    ],
+                ]
+            ),
             0.5,
             np.array([True, True]),
             DoesNotRaise(),
         ),  # two boxes with same category
         (
-            np.array([[0, 0, 30, 30, 0.8, 0], [15, 15, 45, 45, 0.85, 0], [30, 30, 60, 60, 0.9, 1]]), 
-            np.array([[[False, False, False, False, False],
-                       [False, True, True, False, False],
-                       [False, True, True, False, False],
-                       [False, False, False, False, False],
-                       [False, False, False, True, False]],
-                      [[False, False, False, False, False],
-                       [False, True, True, False, False],
-                       [False, True, True, False, False],
-                       [False, False, False, False, False],
-                       [False, False, False, False, False]],
-                      [[False, False, False, False, False],
-                       [False, False, False, True, True],
-                       [False, False, False, True, True],
-                       [False, False, False, False, False],
-                       [False, False, False, False, False]]]),
+            np.array(
+                [
+                    [0, 0, 30, 30, 0.8, 0],
+                    [15, 15, 45, 45, 0.85, 0],
+                    [30, 30, 60, 60, 0.9, 1],
+                ]
+            ),
+            np.array(
+                [
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, False, False],
+                        [False, True, True, False, False],
+                        [False, False, False, False, False],
+                        [False, False, False, True, False],
+                    ],
+                    [
+                        [False, False, False, False, False],
+                        [False, True, True, False, False],
+                        [False, True, True, False, False],
+                        [False, False, False, False, False],
+                        [False, False, False, False, False],
+                    ],
+                    [
+                        [False, False, False, False, False],
+                        [False, False, False, True, True],
+                        [False, False, False, True, True],
+                        [False, False, False, False, False],
+                        [False, False, False, False, False],
+                    ],
+                ]
+            ),
             0.5,
             np.array([False, True, True]),
             DoesNotRaise(),
         ),  # three boxes with no category
     ],
 )
-
 def test_mask_non_max_suppression(
     predictions: np.ndarray,
     masks: np.ndarray,
@@ -242,6 +294,7 @@ def test_mask_non_max_suppression(
             predictions=predictions, masks=masks, iou_threshold=iou_threshold
         )
         assert np.array_equal(result, expected_result)
+
 
 @pytest.mark.parametrize(
     "xyxy, resolution_wh, expected_result",


### PR DESCRIPTION
# Description

This PR introduces Non-Maximum Suppression (NMS) algorithm focused on segmentation, enhancing our object detection capabilities, particularly in segmentation tasks. We have renamed the traditional `non_max_suppression` function to `box_non_max_suppression` for better clarity regarding its application to bounding boxes. Furthermore, we've integrated a conditional mechanism within the `with_nms` function that utilizes segmentation masks for NMS when such masks are present in the predictions. This optimization leverages the spatial context provided by segmentation masks to improve the suppression process.

This enhancement is part of a task segmented into two parts for more focused development and review. This PR addresses the first part, as discussed in the related issue [here](https://github.com/roboflow/supervision/issues/678). Splitting the task ensures thorough implementation and testing of each component.

In addition, this PR encompasses comprehensive unit tests for the new NMS functionality and a demo that demonstrates the algorithm's application and effectiveness in real-world scenarios.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this change been tested

I created a demo to showcase this functionality [here](https://colab.research.google.com/drive/1lpJKXryY59FTrgZU85a3r0KK7gm1OTNh?usp=sharing)

## Docs

- [x] Docs updated? What were the changes: