### PR TITLE
Add support slice function, padding the mask to the full images and t…

### DIFF
--- a/docs/detection/utils.md
+++ b/docs/detection/utils.md
@@ -65,6 +65,12 @@ comments: true
 :::supervision.detection.utils.move_boxes
 
 <div class="md-typeset">
+    <h2>move_masks</h2>
+</div>
+
+:::supervision.detection.utils.move_masks
+
+<div class="md-typeset">
     <h2>scale_boxes</h2>
 </div>
 

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -50,6 +50,7 @@ from supervision.detection.utils import (
     mask_to_polygons,
     mask_to_xyxy,
     move_boxes,
+    move_masks,
     polygon_to_mask,
     polygon_to_xyxy,
     scale_boxes,

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1014,8 +1014,8 @@ class Detections:
             class_agnostic (bool, optional): Whether to perform class-agnostic
                 non-maximum suppression. If True, the class_id of each detection
                 will be ignored. Defaults to False.
-            nms_mask (bool, optional): Whether to perform non-maximum suppression 
-                with mash. If True, the nms would be performance with the mask. 
+            nms_mask (bool, optional): Whether to perform non-maximum suppression
+                with mash. If True, the nms would be performance with the mask.
                 Defaults to False.
 
         Returns:

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -998,7 +998,10 @@ class Detections:
         return (self.xyxy[:, 3] - self.xyxy[:, 1]) * (self.xyxy[:, 2] - self.xyxy[:, 0])
 
     def with_nms(
-        self, threshold: float = 0.5, class_agnostic: bool = False, nms_mask: bool = False
+        self,
+        threshold: float = 0.5,
+        class_agnostic: bool = False,
+        nms_mask: bool = False,
     ) -> Detections:
         """
         Performs non-max suppression on detection set. If the detections result
@@ -1011,7 +1014,7 @@ class Detections:
             class_agnostic (bool, optional): Whether to perform class-agnostic
                 non-maximum suppression. If True, the class_id of each detection
                 will be ignored. Defaults to False.
-            nms_mask (bool, optional): Whether to perform non-maximum suppression with mash. 
+            nms_mask (bool, optional): Whether to perform non-maximum suppression with mash.
                 If True, the nms would be performance with the mask. Defaults to False.
 
         Returns:

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -797,16 +797,12 @@ class Detections:
         def stack_or_none(name: str):
             if all(d.__getattribute__(name) is None for d in detections_list):
                 return None
-            if name != "mask":
-                if any(d.__getattribute__(name) is None for d in detections_list):
-                    raise ValueError(f"All or none of the '{name}' fields must be None")
-                return np.hstack([d.__getattribute__(name) for d in detections_list])
-            else:
-                merged_mask = np.concatenate(
-                    [d.mask for d in detections_list if d.mask is not None], axis=0
-                )
-                return merged_mask
-
+            return (
+                np.hstack([getattr(d, name) for d in detections_list])
+                if name != "mask" and all(getattr(d, name) is not None for d in detections_list)
+                else np.vstack([d.mask for d in detections_list if d.mask is not None])
+            )
+        
         mask = stack_or_none("mask")
         confidence = stack_or_none("confidence")
         class_id = stack_or_none("class_id")

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -797,15 +797,15 @@ class Detections:
         def stack_or_none(name: str):
             if all(d.__getattribute__(name) is None for d in detections_list):
                 return None
-            if any(d.__getattribute__(name) is None for d in detections_list):
-                raise ValueError(f"All or none of the '{name}' fields must be None")
-            return (
-                np.vstack([d.__getattribute__(name) for d in detections_list])
-                if name == "mask"
-                else np.hstack([d.__getattribute__(name) for d in detections_list])
-            )
+            if name != "mask":
+                if any(d.__getattribute__(name) is None for d in detections_list):
+                    raise ValueError(f"All or none of the '{name}' fields must be None")
+                return np.hstack([d.__getattribute__(name) for d in detections_list])
+            else:
+                merged_mask = np.concatenate([d.mask for d in detections_list if d.mask is not None], axis=0)
+                return merged_mask
 
-        mask = stack_or_none("mask")
+        mask = stack_or_none("mask")   
         confidence = stack_or_none("confidence")
         class_id = stack_or_none("class_id")
         tracker_id = stack_or_none("tracker_id")

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -998,7 +998,7 @@ class Detections:
         return (self.xyxy[:, 3] - self.xyxy[:, 1]) * (self.xyxy[:, 2] - self.xyxy[:, 0])
 
     def with_nms(
-        self, threshold: float = 0.5, class_agnostic: bool = False
+        self, threshold: float = 0.5, class_agnostic: bool = False, nms_mask: bool = False
     ) -> Detections:
         """
         Performs non-max suppression on detection set. If the detections result
@@ -1011,6 +1011,8 @@ class Detections:
             class_agnostic (bool, optional): Whether to perform class-agnostic
                 non-maximum suppression. If True, the class_id of each detection
                 will be ignored. Defaults to False.
+            nms_mask (bool, optional): Whether to perform non-maximum suppression with mash. 
+                If True, the nms would be performance with the mask. Defaults to False.
 
         Returns:
             Detections: A new Detections object containing the subset of detections
@@ -1042,7 +1044,7 @@ class Detections:
                 )
             )
 
-        if self.mask is not None:
+        if self.mask is not None and nms_mask:
             indices = mask_non_max_suppression(
                 predictions=predictions, masks=self.mask, iou_threshold=threshold
             )

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -799,10 +799,11 @@ class Detections:
                 return None
             return (
                 np.hstack([getattr(d, name) for d in detections_list])
-                if name != "mask" and all(getattr(d, name) is not None for d in detections_list)
+                if name != "mask"
+                and all(getattr(d, name) is not None for d in detections_list)
                 else np.vstack([d.mask for d in detections_list if d.mask is not None])
             )
-        
+
         mask = stack_or_none("mask")
         confidence = stack_or_none("confidence")
         class_id = stack_or_none("class_id")

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -802,10 +802,12 @@ class Detections:
                     raise ValueError(f"All or none of the '{name}' fields must be None")
                 return np.hstack([d.__getattribute__(name) for d in detections_list])
             else:
-                merged_mask = np.concatenate([d.mask for d in detections_list if d.mask is not None], axis=0)
+                merged_mask = np.concatenate(
+                    [d.mask for d in detections_list if d.mask is not None], axis=0
+                )
                 return merged_mask
 
-        mask = stack_or_none("mask")   
+        mask = stack_or_none("mask")
         confidence = stack_or_none("confidence")
         class_id = stack_or_none("class_id")
         tracker_id = stack_or_none("tracker_id")

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1014,8 +1014,9 @@ class Detections:
             class_agnostic (bool, optional): Whether to perform class-agnostic
                 non-maximum suppression. If True, the class_id of each detection
                 will be ignored. Defaults to False.
-            nms_mask (bool, optional): Whether to perform non-maximum suppression with mash.
-                If True, the nms would be performance with the mask. Defaults to False.
+            nms_mask (bool, optional): Whether to perform non-maximum suppression 
+                with mash. If True, the nms would be performance with the mask. 
+                Defaults to False.
 
         Returns:
             Detections: A new Detections object containing the subset of detections

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -113,12 +113,11 @@ class InferenceSlicer:
                 executor.submit(self._run_callback, image, offset) for offset in offsets
             ]
             for future in as_completed(futures):
-                detections_list.append(future.result().with_nms(
-                    threshold=self.iou_threshold
-                ))
+                detections_list.append(
+                    future.result().with_nms(threshold=self.iou_threshold)
+                )
 
         return Detections.merge(detections_list=detections_list)
-
 
     def _apply_padding_to_slice(self, slice, target_size):
         """

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -8,13 +8,15 @@ from supervision.detection.utils import move_boxes, move_masks
 from supervision.utils.image import crop_image
 
 
-def move_detections(detections: Detections, offset: np.array, image_size: Tuple[int, int]) -> Detections:
+def move_detections(
+    detections: Detections, offset: np.array, image_size: Tuple[int, int]
+) -> Detections:
     """
     Args:
         detections (sv.Detections): Detections object to be moved.
         offset (np.array): An array of shape `(2,)` containing offset values in format
             is `[dx, dy]`.
-        image_size (Tuple[int, int]): The size of the full image to constrain 
+        image_size (Tuple[int, int]): The size of the full image to constrain
             the moved detections.
     Returns:
         (sv.Detections) repositioned Detections object.
@@ -24,6 +26,7 @@ def move_detections(detections: Detections, offset: np.array, image_size: Tuple[
     if detections.mask is not None:
         detections.mask = move_masks(detections.mask, offset, image_size[:2])
     return detections
+
 
 class InferenceSlicer:
     """
@@ -128,12 +131,12 @@ class InferenceSlicer:
             np.ndarray: The padded image slice.
         """
         pad_width = (
-            (0, target_size[0] - slice.shape[0]),  
-            (0, target_size[1] - slice.shape[1]),  
-            (0, 0)  
+            (0, target_size[0] - slice.shape[0]),
+            (0, target_size[1] - slice.shape[1]),
+            (0, 0),
         )
-        
-        padded_slice = np.pad(slice, pad_width, mode='constant', constant_values=128)
+
+        padded_slice = np.pad(slice, pad_width, mode="constant", constant_values=128)
         return padded_slice
 
     def _run_callback(self, image, offset) -> Detections:
@@ -154,7 +157,9 @@ class InferenceSlicer:
             image_slice = self._apply_padding_to_slice(image_slice, self.slice_wh)
 
         detections = self.callback(image_slice)
-        detections = move_detections(detections=detections, offset=offset[:2], image_size=image.shape)
+        detections = move_detections(
+            detections=detections, offset=offset[:2], image_size=image.shape
+        )
 
         return detections
 

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -116,7 +116,9 @@ class InferenceSlicer:
             ]
             for future in as_completed(futures):
                 detections_list.append(
-                    future.result().with_nms(threshold=self.iou_threshold, nms_mask=self.nms_mask)
+                    future.result().with_nms(
+                        threshold=self.iou_threshold, nms_mask=self.nms_mask
+                    )
                 )
 
         return Detections.merge(detections_list=detections_list)

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -61,12 +61,14 @@ class InferenceSlicer:
         overlap_ratio_wh: Tuple[float, float] = (0.2, 0.2),
         iou_threshold: Optional[float] = 0.5,
         thread_workers: int = 1,
+        nms_mask: Optional[bool] = False,
     ):
         self.slice_wh = slice_wh
         self.overlap_ratio_wh = overlap_ratio_wh
         self.iou_threshold = iou_threshold
         self.callback = callback
         self.thread_workers = thread_workers
+        self.nms_mask = nms_mask
 
     def __call__(self, image: np.ndarray) -> Detections:
         """
@@ -114,7 +116,7 @@ class InferenceSlicer:
             ]
             for future in as_completed(futures):
                 detections_list.append(
-                    future.result().with_nms(threshold=self.iou_threshold)
+                    future.result().with_nms(threshold=self.iou_threshold, nms_mask=self.nms_mask)
                 )
 
         return Detections.merge(detections_list=detections_list)

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -113,11 +113,12 @@ class InferenceSlicer:
                 executor.submit(self._run_callback, image, offset) for offset in offsets
             ]
             for future in as_completed(futures):
-                detections_list.append(future.result())
+                detections_list.append(future.result().with_nms(
+                    threshold=self.iou_threshold
+                ))
 
-        return Detections.merge(detections_list=detections_list).with_nms(
-            threshold=self.iou_threshold
-        )
+        return Detections.merge(detections_list=detections_list)
+
 
     def _apply_padding_to_slice(self, slice, target_size):
         """

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -542,7 +542,10 @@ def move_boxes(xyxy: np.ndarray, offset: np.ndarray) -> np.ndarray:
     """
     return xyxy + np.hstack([offset, offset])
 
-def move_masks(masks: np.ndarray, offset: np.ndarray, image_shape: Tuple[int, int]) -> np.ndarray:
+
+def move_masks(
+    masks: np.ndarray, offset: np.ndarray, image_shape: Tuple[int, int]
+) -> np.ndarray:
     """
     Move masks to align with the original image's coordinate system based on the offset.
 
@@ -550,7 +553,7 @@ def move_masks(masks: np.ndarray, offset: np.ndarray, image_shape: Tuple[int, in
         masks (np.ndarray): A 3D array of binary masks corresponding to the predictions.
             Shape: `(N, H, W)`, where N is the number of predictions, and H, W are the
             dimensions of each mask.
-        offset (np.array): An array of shape `(2,)` containing offset values in the 
+        offset (np.array): An array of shape `(2,)` containing offset values in the
             format `[dx, dy]`.
         image_shape (Tuple[int, int]): The height and width of the original image.
 
@@ -573,15 +576,13 @@ def move_masks(masks: np.ndarray, offset: np.ndarray, image_shape: Tuple[int, in
 
     dy, dx = offset
 
-    if (dy := offset[1]) < (new_y_max := min(dy + mask_height, image_shape[0])) and \
-       (dx := offset[0]) < (new_x_max := min(dx + mask_width, image_shape[1])):
-
-        padded_masks[:, 
-                     max(dy, 0):new_y_max, 
-                     max(dx, 0):new_x_max] = masks[
-            :, 
-            max(-dy, 0):max(-dy, 0) + new_y_max - max(dy, 0), 
-            max(-dx, 0):max(-dx, 0) + new_x_max - max(dx, 0)
+    if (dy := offset[1]) < (new_y_max := min(dy + mask_height, image_shape[0])) and (
+        dx := offset[0]
+    ) < (new_x_max := min(dx + mask_width, image_shape[1])):
+        padded_masks[:, max(dy, 0) : new_y_max, max(dx, 0) : new_x_max] = masks[
+            :,
+            max(-dy, 0) : max(-dy, 0) + new_y_max - max(dy, 0),
+            max(-dx, 0) : max(-dx, 0) + new_x_max - max(dx, 0),
         ]
 
     return padded_masks

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -542,6 +542,50 @@ def move_boxes(xyxy: np.ndarray, offset: np.ndarray) -> np.ndarray:
     """
     return xyxy + np.hstack([offset, offset])
 
+def move_masks(masks: np.ndarray, offset: np.ndarray, image_shape: Tuple[int, int]) -> np.ndarray:
+    """
+    Move masks to align with the original image's coordinate system based on the offset.
+
+    Parameters:
+        masks (np.ndarray): A 3D array of binary masks corresponding to the predictions.
+            Shape: `(N, H, W)`, where N is the number of predictions, and H, W are the
+            dimensions of each mask.
+        offset (np.array): An array of shape `(2,)` containing offset values in the 
+            format `[dx, dy]`.
+        image_shape (Tuple[int, int]): The height and width of the original image.
+
+    Returns:
+        np.ndarray: Repositioned masks.
+
+    Example:
+        ```python
+        import numpy as np
+        import supervision as sv
+
+        masks = np.random.randint(0, 2, (2, 100, 100))
+        offset = np.array([50, 30])
+        image_shape = (200, 200)
+        moved_mask = sv.move_masks(masks, offset, image_shape)
+        ```
+    """
+    num_masks, mask_height, mask_width = masks.shape
+    padded_masks = np.zeros((num_masks, *image_shape), dtype=bool)
+
+    dy, dx = offset
+
+    if (dy := offset[1]) < (new_y_max := min(dy + mask_height, image_shape[0])) and \
+       (dx := offset[0]) < (new_x_max := min(dx + mask_width, image_shape[1])):
+
+        padded_masks[:, 
+                     max(dy, 0):new_y_max, 
+                     max(dx, 0):new_x_max] = masks[
+            :, 
+            max(-dy, 0):max(-dy, 0) + new_y_max - max(dy, 0), 
+            max(-dx, 0):max(-dx, 0) + new_x_max - max(dx, 0)
+        ]
+
+    return padded_masks
+
 
 def scale_boxes(xyxy: np.ndarray, factor: float) -> np.ndarray:
     """

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -14,6 +14,7 @@ from supervision.detection.utils import (
     mask_non_max_suppression,
     merge_data,
     move_boxes,
+    move_masks,
     process_roboflow_result,
     scale_boxes,
 )
@@ -748,6 +749,66 @@ def test_move_boxes(
         result = move_boxes(xyxy=xyxy, offset=offset)
         assert np.array_equal(result, expected_result)
 
+
+@pytest.mark.parametrize(
+    "masks, offset, image_shape, expected_result, exception",
+    [
+        (
+            np.zeros((0, 10, 10), dtype=bool),
+            np.array([0, 0]),
+            (100, 100),
+            np.zeros((0, 100, 100), dtype=bool),
+            DoesNotRaise(),
+        ), # Empty masks array
+        (
+            np.array([[[False, True], [True, True]]]),
+            np.array([2, 2]),
+            (4, 4),
+            np.array([[[False, False, False, False], [False, False, False, False], [False, False, False, True], [False, False, True, True]]]),
+            DoesNotRaise(),
+        ), # Single mask, offset to the edge of the image
+        (
+            np.array([[[False, False], [True, True]]]),
+            np.array([1, 2]),
+            (4, 4),
+            np.array([[[False, False, False, False], [False, False, False, False], [False, False, False, False], [False, True, True, False]]]),
+            DoesNotRaise(),
+        ), # Single mask, positive offset
+        (
+            np.array([[[True, True, True], [True, True, True], [True, True, True]]]),
+            np.array([0, 0]),
+            (2, 2),
+            np.array([[[True, True], [True, True]]]),
+            DoesNotRaise(),
+        ), # Mask larger than the image shape
+        (
+            np.array([[[False, True], [True, False]]]),
+            np.array([5, 5]),
+            (4, 4),
+            np.array([[[False, False, False, False], [False, False, False, False], [False, False, False, False], [False, False, False, False]]]),
+            DoesNotRaise(),
+        ), # Offset moves mask completely outside the image
+        (
+            np.array([[[False, True], [True, False]], [[True, True], [False, False]]]),
+            np.array([1, 1]),
+            (4, 4),
+            np.array([[[False, False, False, False], [False, False, True, False], [False, True, False, False], [False, False, False, False]],
+                      [[False, False, False, False], [False, True, True, False], [False, False, False, False], [False, False, False, False]]]),
+            DoesNotRaise(),
+        ), # Multiple masks, mixed offsets
+    ],
+)   
+
+def test_move_masks(
+    masks: np.ndarray,
+    offset: np.ndarray,
+    image_shape: Tuple[int, int],
+    expected_result: np.ndarray,
+    exception: Exception,
+) -> None:
+    with exception:
+        result = move_masks(masks, offset, image_shape)
+        assert np.array_equal(result, expected_result)  
 
 @pytest.mark.parametrize(
     "xyxy, factor, expected_result, exception",

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -759,46 +759,86 @@ def test_move_boxes(
             (100, 100),
             np.zeros((0, 100, 100), dtype=bool),
             DoesNotRaise(),
-        ), # Empty masks array
+        ),  # Empty masks array
         (
             np.array([[[False, True], [True, True]]]),
             np.array([2, 2]),
             (4, 4),
-            np.array([[[False, False, False, False], [False, False, False, False], [False, False, False, True], [False, False, True, True]]]),
+            np.array(
+                [
+                    [
+                        [False, False, False, False],
+                        [False, False, False, False],
+                        [False, False, False, True],
+                        [False, False, True, True],
+                    ]
+                ]
+            ),
             DoesNotRaise(),
-        ), # Single mask, offset to the edge of the image
+        ),  # Single mask, offset to the edge of the image
         (
             np.array([[[False, False], [True, True]]]),
             np.array([1, 2]),
             (4, 4),
-            np.array([[[False, False, False, False], [False, False, False, False], [False, False, False, False], [False, True, True, False]]]),
+            np.array(
+                [
+                    [
+                        [False, False, False, False],
+                        [False, False, False, False],
+                        [False, False, False, False],
+                        [False, True, True, False],
+                    ]
+                ]
+            ),
             DoesNotRaise(),
-        ), # Single mask, positive offset
+        ),  # Single mask, positive offset
         (
             np.array([[[True, True, True], [True, True, True], [True, True, True]]]),
             np.array([0, 0]),
             (2, 2),
             np.array([[[True, True], [True, True]]]),
             DoesNotRaise(),
-        ), # Mask larger than the image shape
+        ),  # Mask larger than the image shape
         (
             np.array([[[False, True], [True, False]]]),
             np.array([5, 5]),
             (4, 4),
-            np.array([[[False, False, False, False], [False, False, False, False], [False, False, False, False], [False, False, False, False]]]),
+            np.array(
+                [
+                    [
+                        [False, False, False, False],
+                        [False, False, False, False],
+                        [False, False, False, False],
+                        [False, False, False, False],
+                    ]
+                ]
+            ),
             DoesNotRaise(),
-        ), # Offset moves mask completely outside the image
+        ),  # Offset moves mask completely outside the image
         (
             np.array([[[False, True], [True, False]], [[True, True], [False, False]]]),
             np.array([1, 1]),
             (4, 4),
-            np.array([[[False, False, False, False], [False, False, True, False], [False, True, False, False], [False, False, False, False]],
-                      [[False, False, False, False], [False, True, True, False], [False, False, False, False], [False, False, False, False]]]),
+            np.array(
+                [
+                    [
+                        [False, False, False, False],
+                        [False, False, True, False],
+                        [False, True, False, False],
+                        [False, False, False, False],
+                    ],
+                    [
+                        [False, False, False, False],
+                        [False, True, True, False],
+                        [False, False, False, False],
+                        [False, False, False, False],
+                    ],
+                ]
+            ),
             DoesNotRaise(),
-        ), # Multiple masks, mixed offsets
+        ),  # Multiple masks, mixed offsets
     ],
-)   
-
+)
 def test_move_masks(
     masks: np.ndarray,
     offset: np.ndarray,
@@ -808,7 +848,8 @@ def test_move_masks(
 ) -> None:
     with exception:
         result = move_masks(masks, offset, image_shape)
-        assert np.array_equal(result, expected_result)  
+        assert np.array_equal(result, expected_result)
+
 
 @pytest.mark.parametrize(
     "xyxy, factor, expected_result, exception",


### PR DESCRIPTION
## Description
This pull request introduces support for InferenceSlicer that focuses on segmentation. This is the second part of the discussion in the https://github.com/roboflow/supervision/issues/678 issue. 

First, I added a conditional statement to pad images that were smaller than the slice size, such as corners. Next, I created the `_apply_padding_to_slice` function to apply padding to a slice using the letterbox resizing method.

We are adjusting the masks to align them with the image coordinate system, which represents the entire image. Most of the masks are empty except for the specific area we want to focus on. This simplifies the process of merging all the masks, but it also requires more memory since the size of each mask will be the same as the original image. Besides, we are currently using a `concatenate` function to join all the masks in the `merge` function

The main difficulty lies in the high computational cost and time required by this method. The algorithm needs to fit every mask detection in the entire image, resulting in a significantly larger size of the data. 

In my opinion, this PR is not ready for production yet, as we need to handle the computational cost for the mask. However, I would like to hear your perspective @SkalskiP 

Currently, the method is consuming a lot of RAM.

```
- load image ✅ 
- slice the image into NxN tiles ✅ 
- surround smaller size slices (the ones close to the edges) with a letterbox so that all tiles are NxN
- loop over slices ✅ 
   - run inference ✅ 
- update box coordinate values to match the image coordinate system, not the slice coordinate system ✅ 
- pad masks to match the image coordinate system, not the slice coordinate system ✅ 
- merge detections ✅ 
```

In addition, this PR encompasses comprehensive unit tests for the new move_masks functionality and a demo that demonstrates the algorithm's application and effectiveness in real-world scenarios.

## Type of change
New feature (non-breaking change which adds functionality)

## How has this change been tested
I created a demo to showcase this functionality [here](https://colab.research.google.com/drive/1thQOeiRiKSkmRPOne98BSDe36s8ArfgY?usp=sharing)

