### PR TITLE
[Detections] - from_inference should include 'class_name' key in Detections.data even if result is empty #837

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -487,7 +487,9 @@ class Detections:
         )
 
         if np.asarray(xyxy).shape[0] == 0:
-            return cls.empty()
+            empty_detection = cls.empty()
+            empty_detection.data = {CLASS_NAME_DATA_FIELD: np.empty(0)}
+            return empty_detection
 
         return cls(
             xyxy=xyxy,


### PR DESCRIPTION
resolve #837 

This Pull Request proposes a modification to the from_inference function to ensure it includes the class_name key within Detections.data even when the Roboflow inference result is empty.

For testing purposes, please refer to the provided [Colab link](https://colab.research.google.com/drive/1zfE98kjjyLQDGysUAZhQalQUj3k5aS2L?usp=sharing).

Please feel free to provide any feedback or comments you may have regarding this Pull Request.