### PR TITLE
[DetectionDataset] - migrate field from List[str] to Dict[int, str]

### DIFF
--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -52,7 +52,7 @@ class DetectionDataset(BaseDataset):
     Dataclass containing information about object detection dataset.
 
     Attributes:
-        classes (Dict[int, str]): List containing dataset class names. Keys are indices,
+        classes (Dict[int, str]): Dict containing dataset class names. Keys are indices,
             values are class names.
         images (Dict[str, np.ndarray]): Dictionary mapping image name to image.
         annotations (Dict[str, Detections]): Dictionary mapping
@@ -548,7 +548,8 @@ class ClassificationDataset(BaseDataset):
     Dataclass containing information about a classification dataset.
 
     Attributes:
-        classes (List[str]): List containing dataset class names.
+        classes (Dict[int, str]): Dict containing dataset class names. Keys are indices,
+            values are class names.
         images (Dict[str, np.ndarray]): Dictionary mapping image name to image.
         annotations (Dict[str, Detections]): Dictionary mapping
             image name to annotations.
@@ -560,6 +561,12 @@ class ClassificationDataset(BaseDataset):
 
     @property
     def classes_list(self) -> List[str]:
+        """
+        Returns a sorted list of class names, derived from self.classes
+
+        Returns:
+            List[str]: A sorted list of class names.
+        """
         return [
             v
             for _, v in sorted(
@@ -673,8 +680,8 @@ class ClassificationDataset(BaseDataset):
             )
             ```
         """
-        classes = os.listdir(root_directory_path)
-        classes = {i: c for i,c in sorted(set(classes))}
+        classes_list = os.listdir(root_directory_path)
+        classes = {i: c for i,c in sorted(set(classes_list))}
 
         images = {}
         annotations = {}

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -687,7 +687,7 @@ class ClassificationDataset(BaseDataset):
             ```
         """
         classes_list = os.listdir(root_directory_path)
-        classes = {i: c for i, c in sorted(set(classes_list))}
+        classes = {i: c for i, c in enumerate(sorted(set(classes_list)))}
 
         images = {}
         annotations = {}

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -65,6 +65,12 @@ class DetectionDataset(BaseDataset):
 
     @property
     def classes_list(self) -> List[str]:
+        """
+        Returns a sorted list of class names, derived from self.classes
+
+        Returns:
+            List[str]: A sorted list of classes.
+        """
         return [
             v
             for _, v in sorted(
@@ -681,13 +687,12 @@ class ClassificationDataset(BaseDataset):
             ```
         """
         classes_list = os.listdir(root_directory_path)
-        classes = {i: c for i,c in sorted(set(classes_list))}
+        classes = {i: c for i, c in sorted(set(classes_list))}
 
         images = {}
         annotations = {}
 
         for class_id, class_name in classes.items():
-
             for image in os.listdir(os.path.join(root_directory_path, class_name)):
                 image_path = str(os.path.join(root_directory_path, class_name, image))
                 images[image_path] = cv2.imread(image_path)

--- a/supervision/dataset/core.py
+++ b/supervision/dataset/core.py
@@ -433,6 +433,7 @@ class DetectionDataset(BaseDataset):
             annotations_path=annotations_path,
             force_masks=force_masks,
         )
+
         return DetectionDataset(classes=classes, images=images, annotations=annotations)
 
     def as_coco(

--- a/supervision/dataset/formats/coco.py
+++ b/supervision/dataset/formats/coco.py
@@ -34,14 +34,14 @@ def build_coco_class_index_mapping(
     }
 
 
-def classes_to_coco_categories(classes: List[str]) -> List[dict]:
+def classes_to_coco_categories(classes: Dict[int, str]) -> List[dict]:
     return [
         {
             "id": class_id,
             "name": class_name,
             "supercategory": "common-objects",
         }
-        for class_id, class_name in enumerate(classes)
+        for class_id, class_name in classes.items()
     ]
 
 
@@ -136,11 +136,13 @@ def load_coco_annotations(
     images_directory_path: str,
     annotations_path: str,
     force_masks: bool = False,
-) -> Tuple[List[str], Dict[str, np.ndarray], Dict[str, Detections]]:
+) -> Tuple[Dict[int, str], Dict[str, np.ndarray], Dict[str, Detections]]:
     coco_data = read_json_file(file_path=annotations_path)
-    classes = coco_categories_to_classes(coco_categories=coco_data["categories"])
+    classes_list = coco_categories_to_classes(coco_categories=coco_data["categories"])
+    classes = {i: c for i, c in enumerate(classes_list)}
+
     class_index_mapping = build_coco_class_index_mapping(
-        coco_categories=coco_data["categories"], target_classes=classes
+        coco_categories=coco_data["categories"], target_classes=classes_list
     )
     coco_images = coco_data["images"]
     coco_annotations_groups = group_coco_annotations_by_image_id(
@@ -180,7 +182,7 @@ def save_coco_annotations(
     annotation_path: str,
     images: Dict[str, np.ndarray],
     annotations: Dict[str, Detections],
-    classes: List[str],
+    classes: Dict[int, str],
     min_image_area_percentage: float = 0.0,
     max_image_area_percentage: float = 1.0,
     approximation_percentage: float = 0.75,

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -63,8 +63,8 @@ def detections_to_pascal_voc(
     Args:
         detections (Detections): A Detections object containing bounding boxes,
             class ids, and other relevant information.
-        classes (List[str]): A list of class names corresponding to the
-            class ids in the Detections object.
+        classes (Dict[int, str]): List containing dataset class names. Keys are indices,
+            values are class names.
         filename (str): The name of the image file associated with the detections.
         image_shape (Tuple[int, int, int]): The shape of the image
             file associated with the detections.

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -184,7 +184,6 @@ def load_pascal_voc_annotations(
         annotation, classes_list = detections_from_xml_obj(
             root, classes_list, resolution_wh, force_masks
         )
-        print(classes_list)
 
         images[image_path] = image
         annotations[image_path] = annotation

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -50,7 +50,7 @@ def object_to_pascal_voc(
 
 def detections_to_pascal_voc(
     detections: Detections,
-    classes: List[str],
+    classes: Dict[int, str],
     filename: str,
     image_shape: Tuple[int, int, int],
     min_image_area_percentage: float = 0.0,
@@ -138,7 +138,7 @@ def load_pascal_voc_annotations(
     images_directory_path: str,
     annotations_directory_path: str,
     force_masks: bool = False,
-) -> Tuple[List[str], Dict[str, np.ndarray], Dict[str, Detections]]:
+) -> Tuple[Dict[int, str], Dict[str, np.ndarray], Dict[str, Detections]]:
     """
     Loads PASCAL VOC XML annotations and returns the image name,
         a Detections instance, and a list of class names.
@@ -187,6 +187,8 @@ def load_pascal_voc_annotations(
 
         images[image_path] = image
         annotations[image_path] = annotation
+
+    classes = {i: c for i, c in enumerate(classes)}
 
     return classes, images, annotations
 

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -162,7 +162,7 @@ def load_pascal_voc_annotations(
         directory=images_directory_path, extensions=["jpg", "jpeg", "png"]
     )
 
-    classes = []
+    classes_list = []
     images = {}
     annotations = {}
 
@@ -181,14 +181,14 @@ def load_pascal_voc_annotations(
         root = tree.getroot()
 
         resolution_wh = (image.shape[1], image.shape[0])
-        annotation, classes = detections_from_xml_obj(
-            root, classes, resolution_wh, force_masks
+        annotation, classes_list = detections_from_xml_obj(
+            root, classes_list, resolution_wh, force_masks
         )
 
         images[image_path] = image
         annotations[image_path] = annotation
 
-    classes = {i: c for i, c in enumerate(classes)}
+    classes = {i: c for i, c in enumerate(classes_list)}
 
     return classes, images, annotations
 

--- a/supervision/dataset/formats/pascal_voc.py
+++ b/supervision/dataset/formats/pascal_voc.py
@@ -184,6 +184,7 @@ def load_pascal_voc_annotations(
         annotation, classes_list = detections_from_xml_obj(
             root, classes_list, resolution_wh, force_masks
         )
+        print(classes_list)
 
         images[image_path] = image
         annotations[image_path] = annotation

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -56,11 +56,9 @@ def _with_mask(lines: List[str]) -> bool:
     return any([len(line.split()) > 5 for line in lines])
 
 
-def _extract_class_names(file_path: str) -> List[str]:
+def _extract_class_names(file_path: str) -> Dict[int, str]:
     data = read_yaml_file(file_path=file_path)
     names = data["names"]
-    if isinstance(names, dict):
-        names = [names[key] for key in sorted(names.keys())]
     return names
 
 
@@ -110,7 +108,7 @@ def load_yolo_annotations(
     annotations_directory_path: str,
     data_yaml_path: str,
     force_masks: bool = False,
-) -> Tuple[List[str], Dict[str, np.ndarray], Dict[str, Detections]]:
+) -> Tuple[Dict[int, str], Dict[str, np.ndarray], Dict[str, Detections]]:
     """
     Loads YOLO annotations and returns class names, images,
         and their corresponding detections.
@@ -245,7 +243,7 @@ def save_yolo_annotations(
         save_text_file(lines=lines, file_path=yolo_annotations_path)
 
 
-def save_data_yaml(data_yaml_path: str, classes: List[str]) -> None:
+def save_data_yaml(data_yaml_path: str, classes: Dict[int, str]) -> None:
     data = {"nc": len(classes), "names": classes}
     Path(data_yaml_path).parent.mkdir(parents=True, exist_ok=True)
     save_yaml_file(data=data, file_path=data_yaml_path)

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -58,8 +58,10 @@ def _with_mask(lines: List[str]) -> bool:
 
 def _extract_class_names(file_path: str) -> Dict[int, str]:
     data = read_yaml_file(file_path=file_path)
-    if isinstance(data, dict):
-        names = {i: c for i, c in enumerate(sorted(data["names"]))}
+
+    names = data["names"]
+    if isinstance(names, dict):
+        names = {i: c for i, c in enumerate(sorted(names))}
     return names
 
 

--- a/supervision/dataset/formats/yolo.py
+++ b/supervision/dataset/formats/yolo.py
@@ -58,7 +58,8 @@ def _with_mask(lines: List[str]) -> bool:
 
 def _extract_class_names(file_path: str) -> Dict[int, str]:
     data = read_yaml_file(file_path=file_path)
-    names = data["names"]
+    if isinstance(data, dict):
+        names = {i: c for i, c in enumerate(sorted(data["names"]))}
     return names
 
 

--- a/supervision/dataset/utils.py
+++ b/supervision/dataset/utils.py
@@ -60,13 +60,14 @@ def build_class_index_mapping(
 ) -> Dict[int, int]:
     index_mapping = {}
 
+    inverse_target_classes = {v: k for k, v in target_classes.items()}
     for i, class_name in source_classes.items():
-        if class_name not in target_classes:
+        if class_name not in inverse_target_classes:
             raise ValueError(
                 f"Class {class_name} not found in target classes. "
                 "source_classes must be a subset of target_classes."
             )
-        corresponding_index = target_classes.index(class_name)
+        corresponding_index = inverse_target_classes[class_name]
         index_mapping[i] = corresponding_index
 
     return index_mapping

--- a/supervision/dataset/utils.py
+++ b/supervision/dataset/utils.py
@@ -56,11 +56,11 @@ def merge_class_lists(class_lists: List[List[str]]) -> List[str]:
 
 
 def build_class_index_mapping(
-    source_classes: List[str], target_classes: List[str]
+    source_classes: Dict[int, str], target_classes: Dict[int, str]
 ) -> Dict[int, int]:
     index_mapping = {}
 
-    for i, class_name in enumerate(source_classes):
+    for i, class_name in source_classes.items():
         if class_name not in target_classes:
             raise ValueError(
                 f"Class {class_name} not found in target classes. "

--- a/test/dataset/test_core.py
+++ b/test/dataset/test_core.py
@@ -13,36 +13,44 @@ from supervision import DetectionDataset
     [
         (
             [],
-            DetectionDataset(classes=[], images={}, annotations={}),
+            DetectionDataset(classes={}, images={}, annotations={}),
             DoesNotRaise(),
         ),  # empty dataset list
         (
-            [DetectionDataset(classes=[], images={}, annotations={})],
-            DetectionDataset(classes=[], images={}, annotations={}),
+            [DetectionDataset(classes={}, images={}, annotations={})],
+            DetectionDataset(classes={}, images={}, annotations={}),
             DoesNotRaise(),
         ),  # single empty dataset
         (
             [
-                DetectionDataset(classes=["dog", "person"], images={}, annotations={}),
-                DetectionDataset(classes=["dog", "person"], images={}, annotations={}),
+                DetectionDataset(
+                    classes={0: "dog", 1: "person"}, images={}, annotations={}
+                ),
+                DetectionDataset(
+                    classes={0: "dog", 1: "person"}, images={}, annotations={}
+                ),
             ],
-            DetectionDataset(classes=["dog", "person"], images={}, annotations={}),
+            DetectionDataset(
+                classes={0: "dog", 1: "person"}, images={}, annotations={}
+            ),
             DoesNotRaise(),
         ),  # two datasets; no images and annotations, the same classes
         (
             [
-                DetectionDataset(classes=["dog", "person"], images={}, annotations={}),
-                DetectionDataset(classes=["cat"], images={}, annotations={}),
+                DetectionDataset(
+                    classes={0: "dog", 1: "person"}, images={}, annotations={}
+                ),
+                DetectionDataset(classes={0: "cat"}, images={}, annotations={}),
             ],
             DetectionDataset(
-                classes=["cat", "dog", "person"], images={}, annotations={}
+                classes={0: "cat", 1: "dog", 2: "person"}, images={}, annotations={}
             ),
             DoesNotRaise(),
         ),  # two datasets; no images and annotations, different classes
         (
             [
                 DetectionDataset(
-                    classes=["dog", "person"],
+                    classes={0: "dog", 1: "person"},
                     images={
                         "image-1.png": np.zeros((100, 100, 3), dtype=np.uint8),
                         "image-2.png": np.zeros((100, 100, 3), dtype=np.uint8),
@@ -56,10 +64,10 @@ from supervision import DetectionDataset
                         ),
                     },
                 ),
-                DetectionDataset(classes=[], images={}, annotations={}),
+                DetectionDataset(classes={}, images={}, annotations={}),
             ],
             DetectionDataset(
-                classes=["dog", "person"],
+                classes={0: "dog", 1: "person"},
                 images={
                     "image-1.png": np.zeros((100, 100, 3), dtype=np.uint8),
                     "image-2.png": np.zeros((100, 100, 3), dtype=np.uint8),
@@ -74,7 +82,7 @@ from supervision import DetectionDataset
         (
             [
                 DetectionDataset(
-                    classes=["dog", "person"],
+                    classes={0: "dog", 1: "person"},
                     images={
                         "image-1.png": np.zeros((100, 100, 3), dtype=np.uint8),
                         "image-2.png": np.zeros((100, 100, 3), dtype=np.uint8),
@@ -88,10 +96,10 @@ from supervision import DetectionDataset
                         ),
                     },
                 ),
-                DetectionDataset(classes=["cat"], images={}, annotations={}),
+                DetectionDataset(classes={0: "cat"}, images={}, annotations={}),
             ],
             DetectionDataset(
-                classes=["cat", "dog", "person"],
+                classes={0: "cat", 1: "dog", 2: "person"},
                 images={
                     "image-1.png": np.zeros((100, 100, 3), dtype=np.uint8),
                     "image-2.png": np.zeros((100, 100, 3), dtype=np.uint8),
@@ -106,7 +114,7 @@ from supervision import DetectionDataset
         (
             [
                 DetectionDataset(
-                    classes=["dog", "person"],
+                    classes={0: "dog", 1: "person"},
                     images={
                         "image-1.png": np.zeros((100, 100, 3), dtype=np.uint8),
                         "image-2.png": np.zeros((100, 100, 3), dtype=np.uint8),
@@ -121,7 +129,7 @@ from supervision import DetectionDataset
                     },
                 ),
                 DetectionDataset(
-                    classes=["cat"],
+                    classes={0: "cat"},
                     images={
                         "image-3.png": np.zeros((100, 100, 3), dtype=np.uint8),
                     },
@@ -133,7 +141,7 @@ from supervision import DetectionDataset
                 ),
             ],
             DetectionDataset(
-                classes=["cat", "dog", "person"],
+                classes={0: "cat", 1: "dog", 2: "person"},
                 images={
                     "image-1.png": np.zeros((100, 100, 3), dtype=np.uint8),
                     "image-2.png": np.zeros((100, 100, 3), dtype=np.uint8),
@@ -150,7 +158,7 @@ from supervision import DetectionDataset
         (
             [
                 DetectionDataset(
-                    classes=["dog", "person"],
+                    classes={0: "dog", 1: "person"},
                     images={
                         "image-1.png": np.zeros((100, 100, 3), dtype=np.uint8),
                         "image-2.png": np.zeros((100, 100, 3), dtype=np.uint8),
@@ -165,7 +173,7 @@ from supervision import DetectionDataset
                     },
                 ),
                 DetectionDataset(
-                    classes=["dog", "person"],
+                    classes={0: "dog", 1: "person"},
                     images={
                         "image-2.png": np.zeros((100, 100, 3), dtype=np.uint8),
                         "image-3.png": np.zeros((100, 100, 3), dtype=np.uint8),

--- a/test/dataset/test_utils.py
+++ b/test/dataset/test_utils.py
@@ -124,43 +124,43 @@ def test_merge_class_maps(
 @pytest.mark.parametrize(
     "source_classes, target_classes, expected_result, exception",
     [
-        ([], [], {}, DoesNotRaise()),  # empty class lists
-        ([], ["dog", "person"], {}, DoesNotRaise()),  # empty source class list
+        ({}, {}, {}, DoesNotRaise()),  # empty class lists
+        ({}, {0: "dog", 1: "person"}, {}, DoesNotRaise()),  # empty source class list
         (
-            ["dog", "person"],
-            [],
+            {0: "dog", 1: "person"},
+            {},
             None,
             pytest.raises(ValueError),
         ),  # empty target class list
         (
-            ["dog", "person"],
-            ["dog", "person"],
+            {0: "dog", 1: "person"},
+            {0: "dog", 1: "person"},
             {0: 0, 1: 1},
             DoesNotRaise(),
         ),  # same class lists
         (
-            ["dog", "person"],
-            ["person", "dog"],
+            {0: "dog", 1: "person"},
+            {0: "person", 1: "dog"},
             {0: 1, 1: 0},
             DoesNotRaise(),
         ),  # same class lists but not alphabetically sorted
         (
-            ["dog", "person"],
-            ["cat", "dog", "person"],
+            {0: "dog", 1: "person"},
+            {0: "cat", 1: "dog", 2: "person"},
             {0: 1, 1: 2},
             DoesNotRaise(),
         ),  # source class list is a subset of target class list
         (
-            ["dog", "person"],
-            ["cat", "dog"],
+            {0: "dog", 1: "person"},
+            {0: "cat", 1: "dog"},
             None,
             pytest.raises(ValueError),
         ),  # source class list is not a subset of target class list
     ],
 )
 def test_build_class_index_mapping(
-    source_classes: List[str],
-    target_classes: List[str],
+    source_classes: Dict[int, str],
+    target_classes: Dict[int, str],
     expected_result: Optional[Dict[int, int]],
     exception: Exception,
 ) -> None:


### PR DESCRIPTION
# Description

Fixes https://github.com/roboflow/supervision/issues/291

Pascal VOC class loading seems already broken, not sure how to proceed as the classes that already are loaded are empty every time.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ x ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Yes, 

- Updated tests
- Also see for yourself [notebook](https://colab.research.google.com/drive/1pYPjIdXH7JHmwiuvsFtagBF0mWO5JlHO)

Note for the future: A few smoke tests saving & loading the datasets in all formats would streamline this massively

## Any specific deployment considerations

N/A

## Docs

-   [ x ] Docs updated? What were the changes:

Type info for the change mostly
