### PR TITLE
'from_depthai' conversion function added

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -742,14 +742,18 @@ class Detections:
             # For device and nn setup, refer:
                 [RGB & TinyYOLO](https://docs.luxonis.com/projects/api/en/latest/samples/SpatialDetection/spatial_tiny_yolo/)
         """
-        depthai_detections_predictions = np.array([[
-            depthai_results.xmin,
-            depthai_results.ymin,
-            depthai_results.xmax,
-            depthai_results.ymax,
-            depthai_results.confidence,
-            depthai_results.label
-        ]])
+        depthai_detections_predictions = np.array(
+            [
+                [
+                    depthai_results.xmin,
+                    depthai_results.ymin,
+                    depthai_results.xmax,
+                    depthai_results.ymax,
+                    depthai_results.confidence,
+                    depthai_results.label,
+                ]
+            ]
+        )
 
         return cls(
             xyxy=depthai_detections_predictions[:, :4],

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -711,6 +711,53 @@ class Detections:
         )
 
     @classmethod
+    def from_depthai(cls, depthai_results) -> Detections:
+        """
+        Creates a Detections instance from a
+        [DepthAI](https://https://github.com/luxonis/depthai) inference result.
+
+        Args:
+            depthai_results (depthai/resources/nn):
+                The output Detections instance from DepthAI
+
+        Returns:
+            Detections: A new Detections object.
+
+        Example:
+            ```python
+            import depthai as dai
+            import supervision as sv
+
+            tracker = sv.ByteTrack()
+
+            with dai.Device(pipeline) as device:
+                qDet = device.getOutputQueue(name="nn", maxSize=4, blocking=False)
+                while True:
+                    inDet = qDet.get()
+                    detections = inDet.detections
+                    for detection in detections:
+                        results = sv.Detections.from_depthai(detection)
+                        tracks = tracker.update_with_detections(results)
+            ```
+            # For device and nn setup, refer:
+                [RGB & TinyYOLO](https://docs.luxonis.com/projects/api/en/latest/samples/SpatialDetection/spatial_tiny_yolo/)
+        """
+        depthai_detections_predictions = np.array([[
+            depthai_results.xmin,
+            depthai_results.ymin,
+            depthai_results.xmax,
+            depthai_results.ymax,
+            depthai_results.confidence,
+            depthai_results.label
+        ]])
+
+        return cls(
+            xyxy=depthai_detections_predictions[:, :4],
+            confidence=depthai_detections_predictions[:, 4],
+            class_id=depthai_detections_predictions[:, 5].astype(int),
+        )
+
+    @classmethod
     def empty(cls) -> Detections:
         """
         Create an empty Detections object with no bounding boxes,


### PR DESCRIPTION
# Description

Added 'from_depthai()' function to convert depthai detection class to supervision detection class. Returns a new detections object. This can now be used in any of the supervision functions for detections or tracking.

## Dependencies
depthai

## Type of change

Please delete options that are not relevant.
-   [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Initially I added this function to `venv/lib/python3.11/site-packages/supervision/detection/core.py` and used the example code to convert `depthai` detections result to `supervision` format. I then used the result to apply supervision's ByteTracker. I created a PPE detection application that used Oak-1 device for real-time detection and deployment.

## Any specific deployment considerations

No

## Docs

- No docs update
