### PR TITLE
Polygonzone add multiple anchors support

### DIFF
--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -23,7 +23,8 @@ class PolygonZone:
         frame_resolution_wh (Tuple[int, int]): The frame resolution (width, height)
         triggering_anchors (Iterable[sv.Position]): A list of positions specifying
             which anchors of the detections bounding box to consider when deciding on
-            whether the detection fits within the PolygonZone (default: (sv.Position.BOTTOM_CENTER,)).
+            whether the detection fits within the PolygonZone
+            (default: (sv.Position.BOTTOM_CENTER,)).
         current_count (int): The current count of detected objects within the zone
         mask (np.ndarray): The 2D bool mask for the polygon zone
     """
@@ -46,7 +47,9 @@ class PolygonZone:
         self.current_count = 0
 
         width, height = frame_resolution_wh
-        self.mask = polygon_to_mask(polygon=polygon, resolution_wh=(width + 1, height + 1))
+        self.mask = polygon_to_mask(
+            polygon=polygon, resolution_wh=(width + 1, height + 1)
+        )
 
     def trigger(self, detections: Detections) -> np.ndarray:
         """
@@ -61,7 +64,9 @@ class PolygonZone:
                 if each detection is within the polygon zone
         """
 
-        clipped_xyxy = clip_boxes(xyxy=detections.xyxy, resolution_wh=self.frame_resolution_wh)
+        clipped_xyxy = clip_boxes(
+            xyxy=detections.xyxy, resolution_wh=self.frame_resolution_wh
+        )
         clipped_detections = replace(detections, xyxy=clipped_xyxy)
         all_clipped_anchors = np.array(
             [
@@ -70,7 +75,11 @@ class PolygonZone:
             ]
         )
 
-        is_in_zone = self.mask[all_clipped_anchors[:, :, 1], all_clipped_anchors[:, :, 0]].transpose().astype(bool)
+        is_in_zone = (
+            self.mask[all_clipped_anchors[:, :, 1], all_clipped_anchors[:, :, 0]]
+            .transpose()
+            .astype(bool)
+        )
         is_in_zone = np.all(is_in_zone, axis=1)
 
         self.current_count = int(np.sum(is_in_zone))

--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -69,7 +69,7 @@ class PolygonZone:
         )
 
         is_in_zone = self.mask[all_clipped_anchors[:, :, 1], all_clipped_anchors[:, :, 0]].transpose().astype(bool)
-        is_in_zone = np.sum(is_in_zone, axis=1) == is_in_zone.shape[1]
+        is_in_zone = np.all(is_in_zone, axis=1)
 
         self.current_count = int(np.sum(is_in_zone))
         return is_in_zone.astype(bool)

--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -30,9 +30,9 @@ class PolygonZone:
     """
 
     @deprecated_parameter(
-        old_param="triggering_position",
-        new_param="triggering_anchors",
-        map_func=lambda x: [x],
+        old_parameter="triggering_position",
+        new_parameter="triggering_anchors",
+        map_function=lambda x: [x],
     )
     def __init__(
         self,

--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -21,8 +21,9 @@ class PolygonZone:
         polygon (np.ndarray): A polygon represented by a numpy array of shape
             `(N, 2)`, containing the `x`, `y` coordinates of the points.
         frame_resolution_wh (Tuple[int, int]): The frame resolution (width, height)
-        triggering_position (Position): The position within the bounding
-            box that triggers the zone (default: Position.BOTTOM_CENTER)
+        triggering_anchors (Iterable[sv.Position]): A list of positions specifying
+            which anchors of the detections bounding box to consider when deciding on
+            whether the detection fits within the PolygonZone (default: (sv.Position.BOTTOM_CENTER,)).
         current_count (int): The current count of detected objects within the zone
         mask (np.ndarray): The 2D bool mask for the polygon zone
     """
@@ -41,6 +42,7 @@ class PolygonZone:
         self.polygon = polygon.astype(int)
         self.frame_resolution_wh = frame_resolution_wh
         self.triggering_anchors = triggering_anchors
+
         self.current_count = 0
 
         width, height = frame_resolution_wh

--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -10,6 +10,7 @@ from supervision.draw.color import Color
 from supervision.draw.utils import draw_polygon, draw_text
 from supervision.geometry.core import Position
 from supervision.geometry.utils import get_polygon_center
+from supervision.utils.internal import deprecated_parameter
 
 
 class PolygonZone:
@@ -26,6 +27,11 @@ class PolygonZone:
         mask (np.ndarray): The 2D bool mask for the polygon zone
     """
 
+    @deprecated_parameter(
+        old_param="triggering_position",
+        new_param="triggering_anchors",
+        map_func=lambda x: [x],
+    )
     def __init__(
         self,
         polygon: np.ndarray,

--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -33,6 +33,10 @@ class PolygonZone:
         old_parameter="triggering_position",
         new_parameter="triggering_anchors",
         map_function=lambda x: [x],
+        warning_message="Warning: '{old_parameter}' in '{function_name}' "
+        "is deprecated and will be remove in "
+        "'{removal_sv_version}: use '{new_parameter}' instead.",
+        removal_sv_version="supervision-0.23.0",
     )
     def __init__(
         self,

--- a/supervision/utils/internal.py
+++ b/supervision/utils/internal.py
@@ -1,5 +1,34 @@
 import functools
 import warnings
+from typing import Callable
+
+
+def deprecated_parameter(old_param: str, new_param: str, map_func: Callable = lambda x: x):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if old_param in kwargs:
+                # In case of a method, display also the class name.
+                if args and hasattr(args[0], "__class__"):
+                    class_name = args[0].__class__.__name__
+                    function_name = f"{class_name}.{func.__name__}"
+                else:
+                    function_name = func.__name__
+
+                # Display deprecation warning
+                warnings.warn(
+                    f"Warning: '{old_param}' in '{function_name}' is deprecated: use '{new_param}' instead.",
+                    category=DeprecationWarning,
+                    stacklevel=2,
+                )
+                # Map old_param to new_param
+                kwargs[new_param] = map_func(kwargs.pop(old_param))
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def deprecated(reason: str):

--- a/supervision/utils/internal.py
+++ b/supervision/utils/internal.py
@@ -4,12 +4,43 @@ from typing import Callable
 
 
 def deprecated_parameter(
-    old_param: str, new_param: str, map_func: Callable = lambda x: x
+    old_parameter: str, 
+    new_parameter: str, 
+    map_function: Callable = lambda x: x, 
+    warn_message: str = "Warning: '{old_parameter}' in '{function_name}' is deprecated: " \
+                        "use '{new_parameter}' instead.",
+    **message_kwargs
 ):
+    """
+    A decorator to mark a function's parameter as deprecated and issue a warning when used.
+
+    Parameters:
+    - old_parameter (str): The name of the deprecated parameter.
+    - new_parameter (str): The name of the parameter that should be used instead.
+    - map_function (Callable, optional): A function used to map the value of the old parameter to the new parameter.
+      Defaults to the identity function.
+    - warn_message (str, optional): The warning message to be displayed when the deprecated parameter is used.
+      Defaults to a generic warning message with placeholders for the old parameter, new parameter, and function name.
+    - **message_kwargs: Additional keyword arguments that can be used to customize the warning message.
+
+    Returns:
+    Callable: A decorator function that can be applied to mark a function's parameter as deprecated.
+
+    Usage Example:
+    ```python
+    @deprecated_parameter(old_parameter="old_param", new_parameter="new_param")
+    def example_function(new_param):
+        print(f"Function called with new_param: {new_param}")
+
+    # When calling the function with the deprecated parameter:
+    example_function(old_param="deprecated_value")
+    ```
+    This will trigger a deprecation warning and execute the function with the mapped value of the deprecated parameter.
+    """
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            if old_param in kwargs:
+            if old_parameter in kwargs:
                 # In case of a method, display also the class name.
                 if args and hasattr(args[0], "__class__"):
                     class_name = args[0].__class__.__name__
@@ -19,13 +50,15 @@ def deprecated_parameter(
 
                 # Display deprecation warning
                 warnings.warn(
-                    f"Warning: '{old_param}' in '{function_name}' is deprecated: "
-                    f"use '{new_param}' instead.",
+                    message=warn_message.format(function_name=function_name, 
+                                                old_parameter=old_parameter, 
+                                                new_parameter=new_parameter, 
+                                                **message_kwargs),
                     category=DeprecationWarning,
                     stacklevel=2,
                 )
                 # Map old_param to new_param
-                kwargs[new_param] = map_func(kwargs.pop(old_param))
+                kwargs[new_parameter] = map_function(kwargs.pop(old_parameter))
 
             return func(*args, **kwargs)
 

--- a/supervision/utils/internal.py
+++ b/supervision/utils/internal.py
@@ -4,27 +4,31 @@ from typing import Callable
 
 
 def deprecated_parameter(
-    old_parameter: str, 
-    new_parameter: str, 
-    map_function: Callable = lambda x: x, 
-    warn_message: str = "Warning: '{old_parameter}' in '{function_name}' is deprecated: " \
-                        "use '{new_parameter}' instead.",
-    **message_kwargs
+    old_parameter: str,
+    new_parameter: str,
+    map_function: Callable = lambda x: x,
+    warn_message: str = "Warning: '{old_parameter}' in '{function_name}' "
+    "is deprecated: use '{new_parameter}' instead.",
+    **message_kwargs,
 ):
     """
-    A decorator to mark a function's parameter as deprecated and issue a warning when used.
+    A decorator to mark a function's parameter as deprecated
+    and issue a warning when used.
 
     Parameters:
     - old_parameter (str): The name of the deprecated parameter.
     - new_parameter (str): The name of the parameter that should be used instead.
-    - map_function (Callable, optional): A function used to map the value of the old parameter to the new parameter.
-      Defaults to the identity function.
-    - warn_message (str, optional): The warning message to be displayed when the deprecated parameter is used.
-      Defaults to a generic warning message with placeholders for the old parameter, new parameter, and function name.
-    - **message_kwargs: Additional keyword arguments that can be used to customize the warning message.
+    - map_function (Callable, optional): A function used to map the value of the old
+      parameter to the new parameter. Defaults to the identity function.
+    - warn_message (str, optional): The warning message to be displayed when the
+      deprecated parameter is used. Defaults to a generic warning message with
+      placeholders for the old parameter, new parameter, and function name.
+    - **message_kwargs: Additional keyword arguments that can be used to customize
+      the warning message.
 
     Returns:
-    Callable: A decorator function that can be applied to mark a function's parameter as deprecated.
+    Callable: A decorator function that can be applied to mark a function's
+    parameter as deprecated.
 
     Usage Example:
     ```python
@@ -35,8 +39,10 @@ def deprecated_parameter(
     # When calling the function with the deprecated parameter:
     example_function(old_param="deprecated_value")
     ```
-    This will trigger a deprecation warning and execute the function with the mapped value of the deprecated parameter.
+    This will trigger a deprecation warning and execute the function with the mapped
+    value of the deprecated parameter.
     """
+
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
@@ -50,10 +56,12 @@ def deprecated_parameter(
 
                 # Display deprecation warning
                 warnings.warn(
-                    message=warn_message.format(function_name=function_name, 
-                                                old_parameter=old_parameter, 
-                                                new_parameter=new_parameter, 
-                                                **message_kwargs),
+                    message=warn_message.format(
+                        function_name=function_name,
+                        old_parameter=old_parameter,
+                        new_parameter=new_parameter,
+                        **message_kwargs,
+                    ),
                     category=DeprecationWarning,
                     stacklevel=2,
                 )

--- a/supervision/utils/internal.py
+++ b/supervision/utils/internal.py
@@ -7,7 +7,7 @@ def deprecated_parameter(
     old_parameter: str,
     new_parameter: str,
     map_function: Callable = lambda x: x,
-    warn_message: str = "Warning: '{old_parameter}' in '{function_name}' "
+    warning_message: str = "Warning: '{old_parameter}' in '{function_name}' "
     "is deprecated: use '{new_parameter}' instead.",
     **message_kwargs,
 ):
@@ -56,7 +56,7 @@ def deprecated_parameter(
 
                 # Display deprecation warning
                 warnings.warn(
-                    message=warn_message.format(
+                    message=warning_message.format(
                         function_name=function_name,
                         old_parameter=old_parameter,
                         new_parameter=new_parameter,

--- a/supervision/utils/internal.py
+++ b/supervision/utils/internal.py
@@ -3,7 +3,9 @@ import warnings
 from typing import Callable
 
 
-def deprecated_parameter(old_param: str, new_param: str, map_func: Callable = lambda x: x):
+def deprecated_parameter(
+    old_param: str, new_param: str, map_func: Callable = lambda x: x
+):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
@@ -17,7 +19,8 @@ def deprecated_parameter(old_param: str, new_param: str, map_func: Callable = la
 
                 # Display deprecation warning
                 warnings.warn(
-                    f"Warning: '{old_param}' in '{function_name}' is deprecated: use '{new_param}' instead.",
+                    f"Warning: '{old_param}' in '{function_name}' is deprecated: "
+                    f"use '{new_param}' instead.",
                     category=DeprecationWarning,
                     stacklevel=2,
                 )

--- a/test/detection/test_polygonzone.py
+++ b/test/detection/test_polygonzone.py
@@ -1,4 +1,5 @@
 from contextlib import ExitStack as DoesNotRaise
+from test.test_utils import mock_detections
 
 import numpy as np
 import pytest
@@ -20,7 +21,7 @@ DETECTION_BOXES = np.array(
     dtype=np.float32,
 )
 
-DETECTIONS = sv.Detections(
+DETECTIONS = mock_detections(
     xyxy=DETECTION_BOXES, class_id=np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])
 )
 
@@ -89,4 +90,3 @@ def test_polygon_zone_trigger(
     with exception:
         in_zone = polygon_zone.trigger(detections)
         assert np.all(in_zone == expected_results)
-        

--- a/test/detection/test_polygonzone.py
+++ b/test/detection/test_polygonzone.py
@@ -1,0 +1,88 @@
+from contextlib import ExitStack as DoesNotRaise
+
+import numpy as np
+import pytest
+
+import supervision as sv
+
+DETECTION_BOXES = np.array(
+    [
+        [35.0, 35.0, 65.0, 65.0],
+        [60.0, 60.0, 90.0, 90.0],
+        [85.0, 85.0, 115.0, 115.0],
+        [110.0, 110.0, 140.0, 140.0],
+        [135.0, 135.0, 165.0, 165.0],
+        [160.0, 160.0, 190.0, 190.0],
+        [185.0, 185.0, 215.0, 215.0],
+        [210.0, 210.0, 240.0, 240.0],
+        [235.0, 235.0, 265.0, 265.0],
+    ],
+    dtype=np.float32,
+)
+
+DETECTIONS = sv.Detections(xyxy=DETECTION_BOXES, class_id=np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]))
+
+POLYGON = np.array([[100, 100], [200, 100], [200, 200], [100, 200]])
+FRAME_RESOLUTION = (300, 300)
+
+
+@pytest.mark.parametrize(
+    "detections, polygon_zone, expected_results, exception",
+    [
+        (
+            DETECTIONS,
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+                triggering_anchors=(
+                    sv.Position.TOP_LEFT,
+                    sv.Position.TOP_RIGHT,
+                    sv.Position.BOTTOM_LEFT,
+                    sv.Position.BOTTOM_RIGHT,
+                ),
+            ),
+            np.array([False, False, False, True, True, True, False, False, False], dtype=bool),
+            DoesNotRaise(),
+        ),  # Test all four corners
+        (
+            DETECTIONS,
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+            ),
+            np.array([False, False, True, True, True, True, False, False, False], dtype=bool),
+            DoesNotRaise(),
+        ),  # Test default behaviour when no anchors are provided
+        (
+            DETECTIONS,
+            sv.PolygonZone(POLYGON, FRAME_RESOLUTION, triggering_position=sv.Position.BOTTOM_CENTER),
+            np.array([False, False, True, True, True, True, False, False, False], dtype=bool),
+            DoesNotRaise(),
+        ),  # Test default behaviour with deprecated api.
+        (
+            sv.Detections.empty(),
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+            ),
+            np.array([], dtype=bool),
+            DoesNotRaise(),
+        ),  # Test empty detections
+    ],
+)
+def test_polygon_zone_trigger(
+    detections: sv.Detections,
+    polygon_zone: sv.PolygonZone,
+    expected_results: np.ndarray,
+    exception: Exception,
+) -> None:
+    with exception:
+        in_zone = polygon_zone.trigger(detections)
+        assert np.all(in_zone == expected_results)
+
+
+def test_polygon_zone_deprecated() -> None:
+    with pytest.deprecated_call():
+        sv.PolygonZone(POLYGON, FRAME_RESOLUTION, triggering_position=sv.Position.CENTER)
+    with DoesNotRaise():
+        sv.PolygonZone(POLYGON, FRAME_RESOLUTION, triggering_anchors=(sv.Position.CENTER,))

--- a/test/detection/test_polygonzone.py
+++ b/test/detection/test_polygonzone.py
@@ -89,14 +89,4 @@ def test_polygon_zone_trigger(
     with exception:
         in_zone = polygon_zone.trigger(detections)
         assert np.all(in_zone == expected_results)
-
-
-def test_polygon_zone_deprecated() -> None:
-    with pytest.deprecated_call():
-        sv.PolygonZone(
-            POLYGON, FRAME_RESOLUTION, triggering_position=sv.Position.CENTER
-        )
-    with DoesNotRaise():
-        sv.PolygonZone(
-            POLYGON, FRAME_RESOLUTION, triggering_anchors=(sv.Position.CENTER,)
-        )
+        

--- a/test/detection/test_polygonzone.py
+++ b/test/detection/test_polygonzone.py
@@ -20,7 +20,9 @@ DETECTION_BOXES = np.array(
     dtype=np.float32,
 )
 
-DETECTIONS = sv.Detections(xyxy=DETECTION_BOXES, class_id=np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]))
+DETECTIONS = sv.Detections(
+    xyxy=DETECTION_BOXES, class_id=np.array([0, 0, 0, 0, 0, 0, 0, 0, 0])
+)
 
 POLYGON = np.array([[100, 100], [200, 100], [200, 200], [100, 200]])
 FRAME_RESOLUTION = (300, 300)
@@ -41,7 +43,9 @@ FRAME_RESOLUTION = (300, 300)
                     sv.Position.BOTTOM_RIGHT,
                 ),
             ),
-            np.array([False, False, False, True, True, True, False, False, False], dtype=bool),
+            np.array(
+                [False, False, False, True, True, True, False, False, False], dtype=bool
+            ),
             DoesNotRaise(),
         ),  # Test all four corners
         (
@@ -50,13 +54,19 @@ FRAME_RESOLUTION = (300, 300)
                 POLYGON,
                 FRAME_RESOLUTION,
             ),
-            np.array([False, False, True, True, True, True, False, False, False], dtype=bool),
+            np.array(
+                [False, False, True, True, True, True, False, False, False], dtype=bool
+            ),
             DoesNotRaise(),
         ),  # Test default behaviour when no anchors are provided
         (
             DETECTIONS,
-            sv.PolygonZone(POLYGON, FRAME_RESOLUTION, triggering_position=sv.Position.BOTTOM_CENTER),
-            np.array([False, False, True, True, True, True, False, False, False], dtype=bool),
+            sv.PolygonZone(
+                POLYGON, FRAME_RESOLUTION, triggering_position=sv.Position.BOTTOM_CENTER
+            ),
+            np.array(
+                [False, False, True, True, True, True, False, False, False], dtype=bool
+            ),
             DoesNotRaise(),
         ),  # Test default behaviour with deprecated api.
         (
@@ -83,6 +93,10 @@ def test_polygon_zone_trigger(
 
 def test_polygon_zone_deprecated() -> None:
     with pytest.deprecated_call():
-        sv.PolygonZone(POLYGON, FRAME_RESOLUTION, triggering_position=sv.Position.CENTER)
+        sv.PolygonZone(
+            POLYGON, FRAME_RESOLUTION, triggering_position=sv.Position.CENTER
+        )
     with DoesNotRaise():
-        sv.PolygonZone(POLYGON, FRAME_RESOLUTION, triggering_anchors=(sv.Position.CENTER,))
+        sv.PolygonZone(
+            POLYGON, FRAME_RESOLUTION, triggering_anchors=(sv.Position.CENTER,)
+        )


### PR DESCRIPTION
# Description

This PR addresses [Issue #844](https://github.com/roboflow/supervision/issues/844).

- Rename `triggering_position` to `triggering_anchors` to be consistent with the `LineZone` naming convention.
- Update type of argument from `Position` to `Iterable[Position]`.
- Maintain the default behavior. The zone should, by default, be triggered by `Position.BOTTOM_CENTER`.
- Adds unit tests for `PolygonZone`.
- Updates documentation.


## Type of change

-   [ x ] New feature (non-breaking change which adds functionality)
-   [ x ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
For a minimalist setup, I'm doing the following:

1- Create mock detections simulating an object moving in a straight line.
2- Instantiate a `PolygonZone` object with polygon partially intersecting the line.
3- Compute the `PolygonZone.trigger(mock_detections)` and annotate the detections triggering the `PolygonZone` object as green, and red otherwise.

The setup used here was also used as base for the unit tests.

Google colab: [https://colab.research.google.com/drive/1fcsVrprMuf7hm_bxitSqmeL5L7KBVGHh?usp=sharing](https://colab.research.google.com/drive/1fcsVrprMuf7hm_bxitSqmeL5L7KBVGHh?usp=sharing)

## Deployment Concerns

### API Backward Compatibility

#### Option 1: Maintaining Deprecation Logic Within the Function

To ensure backward compatibility after renaming a parameter in this PR, one approach is to maintain deprecation logic within the function itself. The implementation could look something like this:

```python
class PolygonZone:
    def __init__(self, polygon, frame_resolution_wh, triggering_anchors, **kwargs):
        if 'triggering_position' in kwargs:
            warning.warn('deprecated argument...')
            ''' logic to handle deprecated parameter'''
```

While effective for specific cases, this approach has some drawbacks:

1. **Documentation Readability**: Inserting `**kwargs` might make the documentation less clear.
2. **Code Visibility**: Deprecated code may become challenging to locate, especially with scale.
3. **Lack of Precedence**: I couldn't find any examples of this pattern in the codebase.

#### Option 2: Adding a `@deprecated_parameter` Annotator (Adopted Solution)

The chosen solution involves creating a `@deprecated_parameter` annotator using pseudocode like this:

```python
def deprecated_parameter(old_param: str, new_param: str, map_func: Callable = lambda x: x):
    def decorator(func):
        @functools.wraps(func)
        def wrapper(*args, **kwargs):
            if old_param in kwargs:
                print('warning message...')
                kwargs[new_param] = map_func(kwargs.pop(old_param))
            return func(*args, **kwargs)
        return wrapper
    return decorator
```

While this solution may not be suitable for highly complex parameter changes, it aligns with existing practices, such as the use of the `@deprecated` annotator, making it easier to track deprecated code references.

Please share your thoughts on this proposed solution.

### Deprecated Examples

Some examples, like `examples/traffic_analysis`, explicitly set `triggering_position` for the `PolygonZone` class. This PR renders it deprecated.

Should we address these changes within this PR, or would it be more appropriate to handle them in a separate one? I am open to incorporating the necessary modifications here if that is the preferred approach.

Let me know your preferences regarding these considerations. 
## Docs

-   [ x ] Docs updated? What were the changes:

[Changed the documentation for class `PolygonZone`](https://github.com/roboflow/supervision/pull/910/files#diff-738bb6b6510e46b8633ab062a4c980fa338f7f3ccf7c9792b91a1bd589e8bf01L23-R27).



