### PR TITLE
new cookbook z-index fix for author avatar

### DIFF
--- a/docs/cookbooks.md
+++ b/docs/cookbooks.md
@@ -3,5 +3,6 @@ template: cookbooks.html
 comments: true
 status: new
 hide:
+  - navigation
   - toc
 ---

--- a/docs/javascripts/cookbooks-card.js
+++ b/docs/javascripts/cookbooks-card.js
@@ -55,11 +55,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
     let authorAvatarsHTML = authorDataArray.map((authorData, index) => {
         const marginLeft = index === 0 ? '0' : '-10px';
+        const zIndex = 4 - index;
         return `
             <div
                 class="author-container"
                 data-login="${authorData.login}-${elementIndex}"
-                style="margin-left: ${marginLeft};"
+                style="margin-left: ${marginLeft}; z-index: ${zIndex};"
             >
                 <a
                     href="https://github.com/${authorData.login}"


### PR DESCRIPTION
# Description

- Hide navigation in the cookbook website (we made a decision to hide it)
- Make author avatars work the same way as in OpenAI Cookbooks
- Better fix for author avatars on top of navbar (navbar is `z-index: 5`)