### PR TITLE
Add ImageAssets for download

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -4,7 +4,7 @@ comments: true
 
 # Assets
 
-Supervision offers an assets download utility that allows you to download video files
+Supervision offers an assets download utility that allows you to download image and video files
 that you can use in your demos.
 
 ## Install extra
@@ -29,3 +29,9 @@ as an extra within the Supervision package.
 </div>
 
 :::supervision.assets.list.VideoAssets
+
+<div class="md-typeset">
+  <h2>ImageAssets</h2>
+</div>
+
+:::supervision.assets.list.ImageAssets

--- a/supervision/assets/__init__.py
+++ b/supervision/assets/__init__.py
@@ -1,2 +1,2 @@
 from supervision.assets.downloader import download_assets
-from supervision.assets.list import VideoAssets
+from supervision.assets.list import VideoAssets, ImageAssets

--- a/supervision/assets/list.py
+++ b/supervision/assets/list.py
@@ -2,14 +2,19 @@ from enum import Enum
 from typing import Dict, Tuple
 
 BASE_VIDEO_URL = "https://media.roboflow.com/supervision/video-examples/"
+BASE_IMAGE_URL = "https://media.roboflow.com/inference/"
 
+class Assets(Enum):
+    def __init__(self, filename: str, hash: str):
+        self.filename = filename
+        self.hash = hash
 
-class VideoAssets(Enum):
+class VideoAssets(Assets):
     """
-    Each member of this enum represents a video asset. The value associated with each
-    member is the filename of the video.
+    Each member of this class represents a video asset. The value associated with each
+    member has a filename and hash of the video. File names and links can be seen below. 
 
-    | Enum Member            | Video Filename             | Video URL                                                                             |
+    | Asset                  | Video Filename             | Video URL                                                                             |
     |------------------------|----------------------------|---------------------------------------------------------------------------------------|
     | `VEHICLES`             | `vehicles.mp4`             | [Link](https://media.roboflow.com/supervision/video-examples/vehicles.mp4)            |
     | `MILK_BOTTLING_PLANT`  | `milk-bottling-plant.mp4`  | [Link](https://media.roboflow.com/supervision/video-examples/milk-bottling-plant.mp4) |
@@ -20,46 +25,35 @@ class VideoAssets(Enum):
     | `PEOPLE_WALKING`       | `people-walking.mp4`       | [Link](https://media.roboflow.com/supervision/video-examples/people-walking.mp4)      |
     """  # noqa: E501 // docs
 
-    VEHICLES = "vehicles.mp4"
-    MILK_BOTTLING_PLANT = "milk-bottling-plant.mp4"
-    VEHICLES_2 = "vehicles-2.mp4"
-    GROCERY_STORE = "grocery-store.mp4"
-    SUBWAY = "subway.mp4"
-    MARKET_SQUARE = "market-square.mp4"
-    PEOPLE_WALKING = "people-walking.mp4"
+    VEHICLES = ("vehicles.mp4", "8155ff4e4de08cfa25f39de96483f918")
+    MILK_BOTTLING_PLANT = ("milk-bottling-plant.mp4", "9e8fb6e883f842a38b3d34267290bdc7")
+    VEHICLES_2 = ("vehicles-2.mp4", "830af6fba21ffbf14867a7fea595937b")
+    GROCERY_STORE = ("grocery-store.mp4", "453475750691fb23c56a0cffef089194")
+    SUBWAY = ("subway.mp4", "453475750691fb23c56a0cffef089194")
+    MARKET_SQUARE = ("market-square.mp4", "859179bf4a21f80a8baabfdb2ed716dc")
+    PEOPLE_WALKING = ("people-walking.mp4", "0574c053c8686c3f1dc0aa3743e45cb9")
 
-    @classmethod
-    def list(cls):
-        return list(map(lambda c: c.value, cls))
+class ImageAssets(Assets):
+    """
+    Each member of this enum represents a image asset. The value associated with each
+    member is the filename of the image.
+
+    | Asset                  | Image Filename             | Video URL                                                                             |
+    |------------------------|----------------------------|---------------------------------------------------------------------------------------|
+    | `PEOPLE_WALKING`       | `people-walking.jpg`       | [Link](https://media.roboflow.com/inference/people-walking.jpg)                      |
+
+    """  # noqa: E501 // docs
+
+    PEOPLE_WALKING = ("people-walking.jpg", "e6bda00b47f2908eeae7df86ef995dcd")
 
 
-VIDEO_ASSETS: Dict[str, Tuple[str, str]] = {
-    VideoAssets.VEHICLES.value: (
-        f"{BASE_VIDEO_URL}{VideoAssets.VEHICLES.value}",
-        "8155ff4e4de08cfa25f39de96483f918",
-    ),
-    VideoAssets.VEHICLES_2.value: (
-        f"{BASE_VIDEO_URL}{VideoAssets.VEHICLES_2.value}",
-        "830af6fba21ffbf14867a7fea595937b",
-    ),
-    VideoAssets.MILK_BOTTLING_PLANT.value: (
-        f"{BASE_VIDEO_URL}{VideoAssets.MILK_BOTTLING_PLANT.value}",
-        "9e8fb6e883f842a38b3d34267290bdc7",
-    ),
-    VideoAssets.GROCERY_STORE.value: (
-        f"{BASE_VIDEO_URL}{VideoAssets.GROCERY_STORE.value}",
-        "11402e7b861c1980527d3d74cbe3b366",
-    ),
-    VideoAssets.SUBWAY.value: (
-        f"{BASE_VIDEO_URL}{VideoAssets.SUBWAY.value}",
-        "453475750691fb23c56a0cffef089194",
-    ),
-    VideoAssets.MARKET_SQUARE.value: (
-        f"{BASE_VIDEO_URL}{VideoAssets.MARKET_SQUARE.value}",
-        "859179bf4a21f80a8baabfdb2ed716dc",
-    ),
-    VideoAssets.PEOPLE_WALKING.value: (
-        f"{BASE_VIDEO_URL}{VideoAssets.PEOPLE_WALKING.value}",
-        "0574c053c8686c3f1dc0aa3743e45cb9",
-    ),
+ASSETS: Dict[str, Tuple[str, str]] = {
+    **{
+        asset.value[0]: (f"{BASE_VIDEO_URL}{asset.value[0]}", asset.value[1])
+        for asset in VideoAssets
+    },
+    **{
+        asset.value[0]: (f"{BASE_IMAGE_URL}{asset.value[0]}", asset.value[1])
+        for asset in ImageAssets
+    },
 }


### PR DESCRIPTION
# Description

This PR is related to Issue https://github.com/roboflow/supervision/issues/926.

The idea is to add `ImageAssets` for download along side the already great `VideoAssets`.

## Type of change

This change is a non-breaking change. 

-   [X] New feature (non-breaking change which adds functionality)
-   [X] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

To test the change you can install the assets submodule by running

```shell
pip install -e ".[assets]"
```

From there, test the new functionality with

```python
from supervision.assets import download_assets, VideoAssets, ImageAssets

# Old method of downloading video assets still relevant.
download_assets(VideoAssets.VEHICLES)
"vehicles.mp4"

# New method of downloading image assts.
download_assets(ImageAssets.PEOPLE_WALKING)
"people-walking.jpg"
```

## Any specific deployment considerations

I did my best to change the documentation, but please call out anything I missed and I will update. 

To simplify the code, I also included a "Assets" class, and each enum has a 'filename' and a 'hash' tied to it reduce verbosity of building out the "VIDEO_ASSETS" dictionary. Let me know if this isn't a good direction, and I can refactor. The customer facing behavior is still the same. 


## Docs

-   [X] Docs updated? What were the changes:

Changes to the the `docs/assets` and changes to docstrings in the function were changed. 
