### PR TITLE
Fix keypoint issues when zero or multiple objects are detected

### DIFF
--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -32,7 +32,10 @@ def _validate_confidence(confidence: Any, n: int, m: int) -> None:
 @dataclass
 class Keypoints:
     keypoints: np.ndarray
+    """Keypoints, array of shape (num_detections, keypoint_count, 2) or (num_detections, keypoint_count, 3)"""
+
     confidence: Optional[np.ndarray] = None
+    """Confidence, array of shape (num_detections, keypoint_count)"""
 
     def __len__(self) -> int:
         """
@@ -76,15 +79,16 @@ class Keypoints:
             keypoints = sv.Keypoints.from_ultralytics(result)
             ```
         """
-        xy = [item.keypoints.xy.data.cpu().numpy() for item in ultralytics_results]
+
+        xy = [item.keypoints.xy.cpu().numpy()[0] for item in ultralytics_results]
         confidence = [
-            item.keypoints.conf.data.cpu().numpy() for item in ultralytics_results
+            item.keypoints.conf.cpu().numpy()[0] for item in ultralytics_results
         ]
 
         if len(xy) == 0:
             return cls.empty()
 
-        return cls(keypoints=np.array(xy)[0], confidence=np.array(confidence)[0])
+        return cls(keypoints=np.array(xy), confidence=np.array(confidence))
 
     @classmethod
     def from_mediapipe(cls, mediapipe_results) -> Keypoints:
@@ -118,9 +122,9 @@ class Keypoints:
 
             image = mp.Image.create_from_file("image.jpg")
 
-            detection_result = detector.detect(image)
+            result = detector.detect(image)
 
-            pose_landmarks = sv.Keypoints.from_mediapipe(detection_result)
+            pose_landmarks = sv.Keypoints.from_mediapipe(result)
             ```
         """
 

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -32,7 +32,8 @@ def _validate_confidence(confidence: Any, n: int, m: int) -> None:
 @dataclass
 class Keypoints:
     keypoints: np.ndarray
-    """Keypoints, array of shape (num_detections, keypoint_count, 2) or (num_detections, keypoint_count, 3)"""
+    """Keypoints, array of shape (num_detections, keypoint_count, 2) or
+    (num_detections, keypoint_count, 3)"""
 
     confidence: Optional[np.ndarray] = None
     """Confidence, array of shape (num_detections, keypoint_count)"""

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -81,6 +81,9 @@ class Keypoints:
             item.keypoints.conf.data.cpu().numpy() for item in ultralytics_results
         ]
 
+        if len(xy) == 0:
+            return cls.empty()
+
         return cls(keypoints=np.array(xy)[0], confidence=np.array(confidence)[0])
 
     @classmethod
@@ -127,6 +130,9 @@ class Keypoints:
         for pose_landmarks in mediapipe_results.pose_landmarks:
             xyz.append([[item.x, item.y, item.z] for item in pose_landmarks])
             confidence.append([item.visibility for item in pose_landmarks])
+
+        if len(xyz) == 0:
+            return cls.empty()
 
         return cls(keypoints=np.array(xyz), confidence=np.array(confidence))
 

--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -65,15 +65,15 @@ class Keypoints:
 
         Example:
             ```python
-            >>> import cv2
-            >>> from ultralytics import YOLO
-            >>> import supervision as sv
+            import cv2
+            from ultralytics import YOLO
+            import supervision as sv
 
-            >>> image = cv2.imread(SOURCE_IMAGE_PATH)
-            >>> model = YOLO('yolov8n-pose.pt')
+            image = cv2.imread(SOURCE_IMAGE_PATH)
+            model = YOLO('yolov8n-pose.pt')
 
-            >>> result = model(image)[0]
-            >>> classifications = sv.Classifications.from_ultralytics(result)
+            result = model(image)[0]
+            keypoints = sv.Keypoints.from_ultralytics(result)
             ```
         """
         xy = [item.keypoints.xy.data.cpu().numpy() for item in ultralytics_results]
@@ -102,25 +102,25 @@ class Keypoints:
 
         Example:
             ```python
-            >>> import mediapipe as mp
-            >>> from mediapipe.tasks import python
-            >>> from mediapipe.tasks.python import vision
-            >>> import supervision as sv
+            import mediapipe as mp
+            from mediapipe.tasks import python
+            from mediapipe.tasks.python import vision
+            import supervision as sv
 
-            >>> base_options = python.BaseOptions(
-            ... model_asset_path='pose_landmarker.task'
-            >>> )
-            >>> options = vision.PoseLandmarkerOptions(
-            ...     base_options=base_options,
-            ...     output_segmentation_masks=True
-            ... )
-            >>> detector = vision.PoseLandmarker.create_from_options(options)
+            base_options = python.BaseOptions(
+            model_asset_path='pose_landmarker.task'
+            )
+            options = vision.PoseLandmarkerOptions(
+                base_options=base_options,
+                output_segmentation_masks=True
+            )
+            detector = vision.PoseLandmarker.create_from_options(options)
 
-            >>> image = mp.Image.create_from_file("image.jpg")
+            image = mp.Image.create_from_file("image.jpg")
 
-            >>> detection_result = detector.detect(image)
+            detection_result = detector.detect(image)
 
-            >>> pose_landmarks = sv.Keypoints.from_mediapipe(detection_result)
+            pose_landmarks = sv.Keypoints.from_mediapipe(detection_result)
             ```
         """
 
@@ -146,9 +146,9 @@ class Keypoints:
 
         Example:
             ```python
-            >>> from supervision import Keypoints
+            from supervision import Keypoints
 
-            >>> empty_keypoints = Keypoints.empty()
+            empty_keypoints = Keypoints.empty()
             ```
         """
         return cls(


### PR DESCRIPTION
# Description

Tidied up `sv.Keypoints` a bit.

* Validation would formerly fail when no objects were detected, both after parsing `MediaPipe` and `ultralytics` results.
* Docstrings now match the style of `Detections` on `develop`.
* `ultralytics` data loader would previously return only one set of keypoints - even when multiple were detected.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Images used:
* [no-pose](https://github.com/roboflow/supervision/assets/6500785/52036c79-aeb2-40e6-be84-eebbae8ac128)
* [one-person](https://github.com/roboflow/supervision/assets/6500785/2f1ef31f-cf35-4bfe-b36c-e79fabb3501b)
* [two-people](https://github.com/roboflow/supervision/assets/6500785/2a8ebf17-98ae-46b9-aa78-6dbad92fc900)


<details>
  <summary>Test code</summary>
    from pathlib import Path
    import importlib
    
    import cv2
    from prettyprinter import cpprint as cpp  # type: ignore
    from ultralytics import YOLO  # type: ignore
    
    import mediapipe as mp
    from mediapipe.tasks import python
    from mediapipe.tasks.python import vision
    import supervision as sv # type: ignore

    FILE_NO_POSE = "no-pose.png"
    FILE_1_PERSON = "one-person.png"
    FILE_2_PEOPLE = "two-people.png"

    
    img_no_pose = cv2.imread(FILE_NO_POSE)
    img_pose = cv2.imread(FILE_1_PERSON)
    img_2_poses = cv2.imread(FILE_2_PEOPLE)
    
    # YOLO
    model = YOLO('yolov8n-pose.pt')
    
    result = model(img_no_pose)
    result = result[0]
    keypoints = sv.Keypoints.from_ultralytics(result)
    assert keypoints.keypoints.shape == (0, 0, 2)
    
    result = model(img_pose)
    result = result[0]
    keypoints = sv.Keypoints.from_ultralytics(result)
    assert keypoints.keypoints.shape == (1, 17, 2)
    
    result = model(img_2_poses)
    result = result[0]
    keypoints = sv.Keypoints.from_ultralytics(result)
    assert keypoints.keypoints.shape == (2, 17, 2)
    
    # MediaPipe
    base_options = python.BaseOptions(model_asset_path='pose_landmarker.task')
    options = vision.PoseLandmarkerOptions(
        base_options=base_options,
        output_segmentation_masks=True
    )
    detector = vision.PoseLandmarker.create_from_options(options)
    # options.num_poses = 1
    
    image = mp.Image.create_from_file(FILE_NO_POSE)
    result = detector.detect(image)
    keypoints = sv.Keypoints.from_mediapipe(result)
    assert keypoints.keypoints.shape == (0, 0, 2)
    
    image = mp.Image.create_from_file(FILE_1_PERSON)
    result = detector.detect(image)
    keypoints = sv.Keypoints.from_mediapipe(result)
    assert keypoints.keypoints.shape == (1, 33, 3)
    
    # 2 people
    options.num_poses = 2
    detector = vision.PoseLandmarker.create_from_options(options)
    image = mp.Image.create_from_file(FILE_2_PEOPLE)
    result = detector.detect(image)
    keypoints = sv.Keypoints.from_mediapipe(result)
    assert keypoints.keypoints.shape == (2, 33, 3)

</details>

## Any specific deployment considerations

Documentation matches the style in `develop` branch, rather than the `add-sv-keypoints`. I was not able to install `mkdocs` prerequisites and have not tested the impacts.

## Docs

-   [x] Docs updated? What were the changes:

Style matches the one in `Detections`.
