### PR TITLE
Bugfix mask_iou_batch memory limit 5MB -> 5GB

### DIFF
--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -93,7 +93,7 @@ def _mask_iou_batch_split(
 def mask_iou_batch(
     masks_true: np.ndarray,
     masks_detection: np.ndarray,
-    memory_limit: int = 1024 * 1024 * 1024 * 5,
+    memory_limit: int = 1024 * 5,
 ) -> np.ndarray:
     """
     Compute Intersection over Union (IoU) of two sets of masks -
@@ -102,7 +102,7 @@ def mask_iou_batch(
     Args:
         masks_true (np.ndarray): 3D `np.ndarray` representing ground-truth masks.
         masks_detection (np.ndarray): 3D `np.ndarray` representing detection masks.
-        memory_limit (int, optional): memory limit in bytes, default is 5GB.
+        memory_limit (int, optional): memory limit in MB, default is 1024 * 5 MB (5GB).
 
     Returns:
         np.ndarray: Pairwise IoU of masks from `masks_true` and `masks_detection`.
@@ -112,6 +112,8 @@ def mask_iou_batch(
         * masks_true.shape[1]
         * masks_true.shape[2]
         * masks_detection.shape[0]
+        / 1024
+        / 1024
     )
     if memory <= memory_limit:
         return _mask_iou_batch_split(masks_true, masks_detection)
@@ -119,6 +121,8 @@ def mask_iou_batch(
     ious = []
     step = max(
         memory_limit
+        * 1024
+        * 1024
         // (
             masks_detection.shape[0]
             * masks_detection.shape[1]

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -93,7 +93,7 @@ def _mask_iou_batch_split(
 def mask_iou_batch(
     masks_true: np.ndarray,
     masks_detection: np.ndarray,
-    memory_limit: int = 1024 * 1024 * 5,
+    memory_limit: int = 1024 * 1024 * 1024 * 5,
 ) -> np.ndarray:
     """
     Compute Intersection over Union (IoU) of two sets of masks -
@@ -113,7 +113,7 @@ def mask_iou_batch(
         * masks_true.shape[2]
         * masks_detection.shape[0]
     )
-    if memory <= memory_limit:  # 5GB memory
+    if memory <= memory_limit:
         return _mask_iou_batch_split(masks_true, masks_detection)
 
     ious = []


### PR DESCRIPTION
# Description

Bugfix mask_iou_batch memory limit 5MB -> 5GB
Change memory_limit unit from Byte to MB


## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally
