### PR TITLE
ci: 👷 update ruff config and group lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,13 +111,6 @@ exclude = '''
 
 [tool.ruff]
 target-version = "py38"
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-lint.select = ["E", "F"]
-lint.ignore = []
-
-# Allow autofix for all enabled rules (when `--fix`) is provided.
-lint.fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
-lint.unfixable = []
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -147,12 +140,19 @@ exclude = [
     "docs",
 ]
 
-# Same as Black.
 line-length = 88
 indent-width = 4
 
+[tool.ruff.lint]
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F"]
+ignore = []
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+unfixable = []
 # Allow unused variables when underscore-prefixed.
-lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+pylint.max-args = 20
 
 [tool.ruff.lint.flake8-quotes]
 inline-quotes = "double"
@@ -164,15 +164,10 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402","F401"]
-"supervision/assets/list.py" = ["E501"]
 
 [tool.ruff.lint.mccabe]
 # Flag errors (`C901`) whenever the complexity level exceeds 5.
 max-complexity = 20
-
-
-[tool.ruff.pylint]
-max-args = 20
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.


### PR DESCRIPTION
### Description

FIxing warning

```console
- hook id: ruff-format
- files were modified by this hook

warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'pylint' -> 'lint.pylint'
1 file reformatted, 88 files left unchanged
```

Organize ruff config bit more to make cleaner 