### PR TITLE
Redesign update with detections to match detections with tracker

### DIFF
--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -297,7 +297,7 @@ class ByteTrack:
                     print(f"Shape of detections xyxy: {detections.xyxy.shape}")
                     current_detection = detections[[idet]]
                     current_detection.tracker_id[0] = int(tracks[itrack].track_id)
-                    Detections.merge([final_detections, current_detection])
+                    final_detections = Detections.merge([final_detections, current_detection])
                 i += 1
 
         else:

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 import numpy as np
 
 from supervision.detection.core import Detections
+from supervision.detection.utils import box_iou_batch
 from supervision.tracker.byte_tracker import matching
 from supervision.tracker.byte_tracker.basetrack import BaseTrack, TrackState
 from supervision.tracker.byte_tracker.kalman_filter import KalmanFilter
@@ -269,24 +270,20 @@ class ByteTrack:
             )
             ```
         """
+        # Tensors is in the same order as detections
+        tensors = detections2boxes(detections=detections)
 
-        tracks = self.update_with_tensors(
-            tensors=detections2boxes(detections=detections)
-        )
-        detections = Detections.empty()
+        tracks = self.update_with_tensors(tensors=tensors)
+
         if len(tracks) > 0:
-            detections.xyxy = np.array(
-                [track.tlbr for track in tracks], dtype=np.float32
-            )
-            detections.class_id = np.array(
-                [int(t.class_ids) for t in tracks], dtype=int
-            )
-            detections.tracker_id = np.array(
-                [int(t.track_id) for t in tracks], dtype=int
-            )
-            detections.confidence = np.array(
-                [t.score for t in tracks], dtype=np.float32
-            )
+            ious = box_iou_batch(tensors, tracks)
+
+            iou_costs = 1 - ious
+
+            matches, _, _ = matching.linear_assignment(iou_costs, 0.25)
+
+            for idet, itrack in matches:
+                detections.tracker_id[idet] = int(tracks[itrack].track_id)
         else:
             detections.tracker_id = np.array([], dtype=int)
 

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -293,7 +293,8 @@ class ByteTrack:
                 print(f"det xyxy: {detections.xyxy[idet]}")
                 print(f"track xyxy: {tracks[itrack].tlbr}")
                 print(" ")
-                current_detection = detections[idet]
+                print(f"Shape of detections xyxy: {detections.xyxy.shape}")
+                current_detection = detections[[idet,0]]
                 current_detection.tracker_id[0] = int(tracks[itrack].track_id)
                 Detections.merge([final_detections, current_detection])
 

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -275,8 +275,6 @@ class ByteTrack:
 
         tracks = self.update_with_tensors(tensors=tensors)
 
-        final_detections = Detections.empty()
-
         if len(tracks) > 0:
             det_tlbrs = np.asarray([det[:4] for det in tensors])
             print(f"  det_tlbrs: {det_tlbrs}")
@@ -288,15 +286,19 @@ class ByteTrack:
             iou_costs = 1 - ious
 
             matches, _, _ = matching.linear_assignment(iou_costs, 0.5)
-
+            i = 0
             for idet, itrack in matches:
-                print(f"det xyxy: {detections.xyxy[idet]}")
-                print(f"track xyxy: {tracks[itrack].tlbr}")
-                print(" ")
-                print(f"Shape of detections xyxy: {detections.xyxy.shape}")
-                current_detection = detections[[idet,0]]
-                current_detection.tracker_id[0] = int(tracks[itrack].track_id)
-                Detections.merge([final_detections, current_detection])
+                if i == 0:
+                    final_detections = detections[[idet]]
+                else:
+                    print(f"det xyxy: {detections.xyxy[idet]}")
+                    print(f"track xyxy: {tracks[itrack].tlbr}")
+                    print(" ")
+                    print(f"Shape of detections xyxy: {detections.xyxy.shape}")
+                    current_detection = detections[[idet]]
+                    current_detection.tracker_id[0] = int(tracks[itrack].track_id)
+                    Detections.merge([final_detections, current_detection])
+                i += 1
 
         else:
             final_detections.tracker_id = np.array([], dtype=int)

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -8,7 +8,6 @@ from supervision.tracker.byte_tracker import matching
 from supervision.tracker.byte_tracker.basetrack import BaseTrack, TrackState
 from supervision.tracker.byte_tracker.kalman_filter import KalmanFilter
 from supervision.utils.internal import deprecated_parameter
-from supervision.detection.utils import box_iou_batch
 
 
 class STrack(BaseTrack):
@@ -277,7 +276,10 @@ class ByteTrack:
         tracks = self.update_with_tensors(tensors=tensors)
 
         if len(tracks) > 0:
-            ious = box_iou_batch(tensors, tracks)
+            det_tlbrs = np.asarray([det[:4] for det in tensors])
+            track_tlbrs = np.asarray([track.tlbr for track in tracks])
+
+            ious = box_iou_batch(det_tlbrs, track_tlbrs)
 
             iou_costs = 1 - ious
 
@@ -287,7 +289,7 @@ class ByteTrack:
                 detections.tracker_id[idet] = int(tracks[itrack].track_id)
         else:
             detections.tracker_id = np.array([], dtype=int)
-        
+
         return detections
 
     def reset(self):

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -279,9 +279,7 @@ class ByteTrack:
 
         if len(tracks) > 0:
             det_tlbrs = np.asarray([det[:4] for det in tensors])
-            print(f"  det_tlbrs: {det_tlbrs}")
             track_tlbrs = np.asarray([track.tlbr for track in tracks])
-            print(f"track_tlbrs: {track_tlbrs}")
 
             ious = box_iou_batch(det_tlbrs, track_tlbrs)
 
@@ -294,13 +292,11 @@ class ByteTrack:
                     final_detections = detections[[idet]]
                     final_detections.tracker_id[0] = int(tracks[itrack].track_id)
                 else:
-                    print(f"det xyxy: {detections.xyxy[idet]}")
-                    print(f"track xyxy: {tracks[itrack].tlbr}")
-                    print(" ")
-                    print(f"Shape of detections xyxy: {detections.xyxy.shape}")
                     current_detection = detections[[idet]]
                     current_detection.tracker_id[0] = int(tracks[itrack].track_id)
-                    final_detections = Detections.merge([final_detections, current_detection])
+                    final_detections = Detections.merge(
+                        [final_detections, current_detection]
+                    )
                 i += 1
 
         else:

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -275,6 +275,8 @@ class ByteTrack:
 
         tracks = self.update_with_tensors(tensors=tensors)
 
+        final_detections = Detections.empty()
+
         if len(tracks) > 0:
             det_tlbrs = np.asarray([det[:4] for det in tensors])
             print(f"  det_tlbrs: {det_tlbrs}")
@@ -290,6 +292,7 @@ class ByteTrack:
             for idet, itrack in matches:
                 if i == 0:
                     final_detections = detections[[idet]]
+                    final_detections.tracker_id[0] = int(tracks[itrack].track_id)
                 else:
                     print(f"det xyxy: {detections.xyxy[idet]}")
                     print(f"track xyxy: {tracks[itrack].tlbr}")


### PR DESCRIPTION
# Description

This change addresses this issue: (https://github.com/roboflow/supervision/issues/754)
`update_with_detections` now returns the original detections that were tracked by ByteTrack with their original bboxes, masks, class_ids, data fields and with updated track_ids. Detections that were not tracked this frame are not included in the returned detections.

## Type of change


-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality) - Segmentation tracking

## How has this change been tested, please provide a testcase or example of how you tested the change?

I have tested this change by running object tracking for both object detection and segmentation in this [colab notebook](https://colab.research.google.com/drive/1azgc_A-divM3Z5l0TyHW2SRHnw6EUlbO?usp=sharing)

![segmentation_tracking](https://github.com/roboflow/supervision/assets/99894460/64a4ba95-6c43-4a2c-8f32-b74604023868)

## Any specific deployment considerations

Tracking docs should be updated to reflect that ByteTrack can now do segmentation tracking.

## Docs

-   [ ] Docs updated? What were the changes:
