### PR TITLE
Add `corner_radius` to `sv.LabelAnnotator` to handle roundness of label edges.

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -907,6 +907,7 @@ class LabelAnnotator:
 
     def __init__(
         self,
+        corner_radius: int = 15,
         color: Union[Color, ColorPalette] = ColorPalette.DEFAULT,
         text_color: Color = Color.WHITE,
         text_scale: float = 0.5,
@@ -917,6 +918,8 @@ class LabelAnnotator:
     ):
         """
         Args:
+            corner_radius (int): The radius to apply round edges. If the selected
+                value is higher than the lower dimension, width or height, is clipped.
             color (Union[Color, ColorPalette]): The color or color palette to use for
                 annotating the text background.
             text_color (Color): The color to use for the text.
@@ -928,6 +931,7 @@ class LabelAnnotator:
             color_lookup (str): Strategy for mapping colors to annotations.
                 Options are `INDEX`, `CLASS`, `TRACK`.
         """
+        self.corner_radius: int = corner_radius
         self.color: Union[Color, ColorPalette] = color
         self.text_color: Color = text_color
         self.text_scale: float = text_scale

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1103,6 +1103,49 @@ class LabelAnnotator:
             )
         return scene
 
+    @staticmethod
+    def draw_rounded_rectangle(
+        img: ImageType, pt1: Tuple[int, int], pt2: Tuple[int, int],
+        color: Tuple[int, int, int], thickness: int, corner_radius: int
+    ) -> ImageType:
+        x1, y1 = pt1
+        x2, y2 = pt2
+        
+        width = x2 - x1
+        height = y2 - y1
+        
+        max_corner_radius = min(width, height) // 2
+        
+        corner_radius = min(corner_radius, max_corner_radius)
+        
+        rectangle_coords = [
+            ((x1 + corner_radius, y1), (x2 - corner_radius, y2)),
+            ((x1, y1 + corner_radius),(x2, y2 - corner_radius))
+        ]
+        circle_centers = [
+            (x1 + corner_radius, y1 + corner_radius),
+            (x2 - corner_radius, y1 + corner_radius),
+            (x1 + corner_radius, y2 - corner_radius),
+            (x2 - corner_radius, y2 - corner_radius),
+        ]
+
+        for coords in rectangle_coords:
+            cv2.rectangle(
+                img=img,
+                pt1=coords[0],
+                pt2=coords[1],
+                color=color,
+                thickness=thickness 
+            )
+        for center in circle_centers:
+            cv2.circle(
+                img=img,
+                center=center,
+                radius=corner_radius,
+                color=color,
+                thickness=thickness
+            )
+
 
 class BlurAnnotator(BaseAnnotator):
     """

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1090,7 +1090,7 @@ class LabelAnnotator:
                 pt2=(text_background_xyxy[2], text_background_xyxy[3]),
                 color=color.as_bgr(),
                 thickness=cv2.FILLED,
-                corner_radius=self.corner_radius
+                corner_radius=self.corner_radius,
             )
             cv2.putText(
                 img=scene,
@@ -1106,22 +1106,26 @@ class LabelAnnotator:
 
     @staticmethod
     def draw_rounded_rectangle(
-        img: ImageType, pt1: Tuple[int, int], pt2: Tuple[int, int],
-        color: Tuple[int, int, int], thickness: int, corner_radius: int
+        img: ImageType,
+        pt1: Tuple[int, int],
+        pt2: Tuple[int, int],
+        color: Tuple[int, int, int],
+        thickness: int,
+        corner_radius: int,
     ) -> ImageType:
         x1, y1 = pt1
         x2, y2 = pt2
-        
+
         width = x2 - x1
         height = y2 - y1
-        
+
         max_corner_radius = min(width, height) // 2
-        
+
         corner_radius = min(corner_radius, max_corner_radius)
-        
+
         rectangle_coords = [
             ((x1 + corner_radius, y1), (x2 - corner_radius, y2)),
-            ((x1, y1 + corner_radius),(x2, y2 - corner_radius))
+            ((x1, y1 + corner_radius), (x2, y2 - corner_radius)),
         ]
         circle_centers = [
             (x1 + corner_radius, y1 + corner_radius),
@@ -1132,11 +1136,7 @@ class LabelAnnotator:
 
         for coords in rectangle_coords:
             cv2.rectangle(
-                img=img,
-                pt1=coords[0],
-                pt2=coords[1],
-                color=color,
-                thickness=thickness 
+                img=img, pt1=coords[0], pt2=coords[1], color=color, thickness=thickness
             )
         for center in circle_centers:
             cv2.circle(
@@ -1144,7 +1144,7 @@ class LabelAnnotator:
                 center=center,
                 radius=corner_radius,
                 color=color,
-                thickness=thickness
+                thickness=thickness,
             )
 
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1132,7 +1132,7 @@ class LabelAnnotator:
                 pt1=coordinates[0],
                 pt2=coordinates[1],
                 color=color,
-                thickness=-1
+                thickness=-1,
             )
         for center in circle_centers:
             cv2.circle(

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1084,12 +1084,13 @@ class LabelAnnotator:
             text_x = text_background_xyxy[0] + self.text_padding
             text_y = text_background_xyxy[1] + self.text_padding + text_h
 
-            cv2.rectangle(
+            self.draw_rounded_rectangle(
                 img=scene,
                 pt1=(text_background_xyxy[0], text_background_xyxy[1]),
                 pt2=(text_background_xyxy[2], text_background_xyxy[3]),
                 color=color.as_bgr(),
                 thickness=cv2.FILLED,
+                corner_radius=self.corner_radius
             )
             cv2.putText(
                 img=scene,


### PR DESCRIPTION
# Description

Implements #1027 

`sv.LabelAnnotator` has a new attributre `corner_radius`.

A new custom method `draw_rounded_rectangle` has been added using almost same arguments with `cv2.rectangle` but using the new `corner_radius` attribute.

Examples using `corner_radius = 8 | 20`, are attached below:

![label-annotator-example-all_8](https://github.com/roboflow/supervision/assets/65918758/b50f62da-c0b7-4d77-9180-17d3f79facb7)

![label-annotator-example-all_20](https://github.com/roboflow/supervision/assets/65918758/ad23eb3b-5f00-4b3d-bc80-e02ba6c1115b)


List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Google Colab ready for testing:
https://colab.research.google.com/drive/1sHdjb1bg8aGekj7uaSNQ80VqhgTzASOs?usp=sharing

## Any specific deployment considerations

When initializing `sv.LabelAnnotator()` the `corner_radius` can be specified using int values. 

## Docs

-   [ ] Docs updated? **NO. Update needed**
