### PR TITLE
ci: 👷 publish pypi on branch removed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+[0-9]+.[0-9]'
-    branches:
-      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -14,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
     steps:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
I will re-write this branch part in a better way (I was already testing and there is a couple of problems I am talking with GH people as well)  For now I want to remove fail action part 