### PR TITLE
fixed a bug in get_data_item for np.array index

### DIFF
--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -845,8 +845,10 @@ def get_data_item(
         elif isinstance(value, list):
             if isinstance(index, slice):
                 subset_data[key] = value[index]
-            elif isinstance(index, (list, np.ndarray)):
+            elif isinstance(index, list):
                 subset_data[key] = [value[i] for i in index]
+            elif isinstance(index, np.ndarray):
+                subset_data[key] = [value[i] for i in index if i]
             elif isinstance(index, int):
                 subset_data[key] = [value[index]]
             else:


### PR DESCRIPTION
# Description

fixed a bug in get_data_item for np.array index, there was a bug when trying to mask detections using np.array and the list values in data field were not getting updated properly.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change.

It was tested as part of my personal project. example:

```python
# detections was created before:
detections.data["test_data"] = [None for _ in range(len(detections))]
detections = detections[detections.confidence > 0.5]
# this would lead to error in validation function without the current changes, since the size of data["test_data"] will not change.
```
## Any specific deployment considerations

N/A

## Docs

-  N/A
