### PR TITLE
fix Detections.get_data_item() bug (#1061)

### DIFF
--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -849,7 +849,9 @@ def get_data_item(
                 subset_data[key] = [value[i] for i in index]
             elif isinstance(index, np.ndarray):
                 if index.dtype == bool:
-                    subset_data[key] = [value[i] for i, index_value in enumerate(index) if index_value]
+                    subset_data[key] = [
+                        value[i] for i, index_value in enumerate(index) if index_value
+                    ]
                 else:
                     subset_data[key] = [value[i] for i in index]
             elif isinstance(index, int):

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -849,7 +849,7 @@ def get_data_item(
                 subset_data[key] = [value[i] for i in index]
             elif isinstance(index, np.ndarray):
                 if index.dtype == bool:
-                    subset_data[key] = [value[i] for i in range(len(index)) if index[i]]
+                    subset_data[key] = [value[i] for i, index_value in enumerate(index) if index_value]
                 else:
                     subset_data[key] = [value[i] for i in index]
             elif isinstance(index, int):

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -845,8 +845,13 @@ def get_data_item(
         elif isinstance(value, list):
             if isinstance(index, slice):
                 subset_data[key] = value[index]
-            elif isinstance(index, (list, np.ndarray)):
+            elif isinstance(index, list):
                 subset_data[key] = [value[i] for i in index]
+            elif isinstance(index, np.ndarray):
+                if index.dtype == bool:
+                    subset_data[key] = [value[i] for i in range(len(index)) if index[i]]
+                else:
+                    subset_data[key] = [value[i] for i in index]
             elif isinstance(index, int):
                 subset_data[key] = [value[index]]
             else:


### PR DESCRIPTION
# Description

When I tried to use boolean array indexing to get specific detections from a Detections object, the data field sometimes returned the wrong values (everything is the second value) and sometimes it just didn't work. (See issue #1061)

This is an issue I ran into while trying to simplify ByteTrack.update_with_detections(). Boolean indexing is a feature that is commonly used in general and it would be good to ensure Detections works the same way np.arrays and lists work.

## Type of change


-   [x] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested this with the same test cases from my bug report. [Colab notebook](https://colab.research.google.com/drive/1nRKhgTnlubPNOtEGZV4QMYffDjI1VxnQ?usp=sharing)

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
