### PR TITLE
added trigger_overlap to polygon_zone

### DIFF
--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -117,7 +117,7 @@ class PolygonZone:
             bbox_mask[y1:y2, x1:x2] = True
             masks.append(bbox_mask)
             overlap_ratio = np.count_nonzero(np.logical_and(bbox_mask, self.mask)) / detections.area[i]
-            overlap_results[i] = overlap_ratio > overlap_threshold
+            overlap_results[i] = overlap_ratio >= overlap_threshold
         
         return overlap_results
 

--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -89,14 +89,16 @@ class PolygonZone:
         self.current_count = int(np.sum(is_in_zone))
         return is_in_zone.astype(bool)
 
-    def trigger_overlap(self, detections: Detections, overlap_threshold: float) -> npt.NDArray[np.bool_]:
+    def trigger_overlap(
+        self, detections: Detections, overlap_threshold: float
+    ) -> npt.NDArray[np.bool_]:
         """
         Determines if the detections are within the polygon zone.
 
         Parameters:
             detections (Detections): The detections
                 to be checked against the polygon zone
-            
+
             overlap_threshold (float): threshold of overlap
 
         Returns:
@@ -108,7 +110,9 @@ class PolygonZone:
             xyxy=detections.xyxy, resolution_wh=self.frame_resolution_wh
         )
         clipped_detections = replace(detections, xyxy=clipped_xyxy)
-        overlap_results: npt.NDArray[np.bool_] = np.zeros(len(clipped_detections), dtype=bool)
+        overlap_results: npt.NDArray[np.bool_] = np.zeros(
+            len(clipped_detections), dtype=bool
+        )
 
         masks = []
         for i, (x1, y1, x2, y2) in enumerate(detections.xyxy.astype(np.int32)):
@@ -116,9 +120,12 @@ class PolygonZone:
 
             bbox_mask[y1:y2, x1:x2] = True
             masks.append(bbox_mask)
-            overlap_ratio = np.count_nonzero(np.logical_and(bbox_mask, self.mask)) / detections.area[i]
+            overlap_ratio = (
+                np.count_nonzero(np.logical_and(bbox_mask, self.mask))
+                / detections.area[i]
+            )
             overlap_results[i] = overlap_ratio >= overlap_threshold
-        
+
         return overlap_results
 
 

--- a/test/detection/test_polygonzone.py
+++ b/test/detection/test_polygonzone.py
@@ -33,61 +33,61 @@ FRAME_RESOLUTION = (300, 300)
     "detections, polygon_zone, expected_results, exception",
     [
         (
-                DETECTIONS,
-                sv.PolygonZone(
-                    POLYGON,
-                    FRAME_RESOLUTION,
-                    triggering_anchors=(
-                            sv.Position.TOP_LEFT,
-                            sv.Position.TOP_RIGHT,
-                            sv.Position.BOTTOM_LEFT,
-                            sv.Position.BOTTOM_RIGHT,
-                    ),
+            DETECTIONS,
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+                triggering_anchors=(
+                    sv.Position.TOP_LEFT,
+                    sv.Position.TOP_RIGHT,
+                    sv.Position.BOTTOM_LEFT,
+                    sv.Position.BOTTOM_RIGHT,
                 ),
-                np.array(
-                    [False, False, False, True, True, True, False, False, False], dtype=bool
-                ),
-                DoesNotRaise(),
+            ),
+            np.array(
+                [False, False, False, True, True, True, False, False, False], dtype=bool
+            ),
+            DoesNotRaise(),
         ),  # Test all four corners
         (
-                DETECTIONS,
-                sv.PolygonZone(
-                    POLYGON,
-                    FRAME_RESOLUTION,
-                ),
-                np.array(
-                    [False, False, True, True, True, True, False, False, False], dtype=bool
-                ),
-                DoesNotRaise(),
+            DETECTIONS,
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+            ),
+            np.array(
+                [False, False, True, True, True, True, False, False, False], dtype=bool
+            ),
+            DoesNotRaise(),
         ),  # Test default behaviour when no anchors are provided
         (
-                DETECTIONS,
-                sv.PolygonZone(
-                    POLYGON,
-                    FRAME_RESOLUTION,
-                    triggering_anchors=[sv.Position.BOTTOM_CENTER],
-                ),
-                np.array(
-                    [False, False, True, True, True, True, False, False, False], dtype=bool
-                ),
-                DoesNotRaise(),
+            DETECTIONS,
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+                triggering_anchors=[sv.Position.BOTTOM_CENTER],
+            ),
+            np.array(
+                [False, False, True, True, True, True, False, False, False], dtype=bool
+            ),
+            DoesNotRaise(),
         ),  # Test default behaviour with deprecated api.
         (
-                sv.Detections.empty(),
-                sv.PolygonZone(
-                    POLYGON,
-                    FRAME_RESOLUTION,
-                ),
-                np.array([], dtype=bool),
-                DoesNotRaise(),
+            sv.Detections.empty(),
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+            ),
+            np.array([], dtype=bool),
+            DoesNotRaise(),
         ),  # Test empty detections
     ],
 )
 def test_polygon_zone_trigger(
-        detections: sv.Detections,
-        polygon_zone: sv.PolygonZone,
-        expected_results: np.ndarray,
-        exception: Exception,
+    detections: sv.Detections,
+    polygon_zone: sv.PolygonZone,
+    expected_results: np.ndarray,
+    exception: Exception,
 ) -> None:
     with exception:
         in_zone = polygon_zone.trigger(detections)
@@ -99,77 +99,77 @@ def test_polygon_zone_trigger(
     [
         # Test cases for trigger_overlap function
         (
-                DETECTIONS,
-                sv.PolygonZone(
-                    POLYGON,
-                    FRAME_RESOLUTION,
-                    triggering_anchors=(
-                            sv.Position.TOP_LEFT,
-                            sv.Position.TOP_RIGHT,
-                            sv.Position.BOTTOM_LEFT,
-                            sv.Position.BOTTOM_RIGHT,
-                    ),
+            DETECTIONS,
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+                triggering_anchors=(
+                    sv.Position.TOP_LEFT,
+                    sv.Position.TOP_RIGHT,
+                    sv.Position.BOTTOM_LEFT,
+                    sv.Position.BOTTOM_RIGHT,
                 ),
-                0.25,  # Overlap threshold
-                np.array(
-                    [False, False, True, True, True, True, True, False, False], dtype=bool
-                ),
-                DoesNotRaise(),
+            ),
+            0.25,  # Overlap threshold
+            np.array(
+                [False, False, True, True, True, True, True, False, False], dtype=bool
+            ),
+            DoesNotRaise(),
         ),  # Case with specific overlap threshold
         (
-                DETECTIONS,
-                sv.PolygonZone(
-                    POLYGON,
-                    FRAME_RESOLUTION,
-                ),
-                0.5,  # Overlap threshold
-                np.array(
-                    [False, False, False, True, True, True, False, False, False], dtype=bool
-                ),
-                DoesNotRaise(),
+            DETECTIONS,
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+            ),
+            0.5,  # Overlap threshold
+            np.array(
+                [False, False, False, True, True, True, False, False, False], dtype=bool
+            ),
+            DoesNotRaise(),
         ),  # Another overlap threshold
         (
-                DETECTIONS,
-                sv.PolygonZone(
-                    POLYGON,
-                    FRAME_RESOLUTION,
-                ),
-                0.1,  # Lower overlap threshold to catch more detections
-                np.array(
-                    [False, False, True, True, True, True, True, False, False], dtype=bool
-                ),
-                DoesNotRaise(),
+            DETECTIONS,
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+            ),
+            0.1,  # Lower overlap threshold to catch more detections
+            np.array(
+                [False, False, True, True, True, True, True, False, False], dtype=bool
+            ),
+            DoesNotRaise(),
         ),  # Lower threshold test
         (
-                DETECTIONS,
-                sv.PolygonZone(
-                    POLYGON,
-                    FRAME_RESOLUTION,
-                ),
-                0,  # Lower overlap threshold to catch more detections
-                np.array(
-                    [True, True, True, True, True, True, True, True, True], dtype=bool
-                ),
-                DoesNotRaise(),
+            DETECTIONS,
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+            ),
+            0,  # Lower overlap threshold to catch more detections
+            np.array(
+                [True, True, True, True, True, True, True, True, True], dtype=bool
+            ),
+            DoesNotRaise(),
         ),  # Lower threshold test
         (
-                sv.Detections.empty(),
-                sv.PolygonZone(
-                    POLYGON,
-                    FRAME_RESOLUTION,
-                ),
-                0,
-                np.array([], dtype=bool),
-                DoesNotRaise(),
+            sv.Detections.empty(),
+            sv.PolygonZone(
+                POLYGON,
+                FRAME_RESOLUTION,
+            ),
+            0,
+            np.array([], dtype=bool),
+            DoesNotRaise(),
         ),  # Test empty detections
     ],
 )
 def test_polygon_zone_overlap(
-        detections: sv.Detections,
-        polygon_zone: sv.PolygonZone,
-        overlap_threshold: float,
-        expected_results: np.ndarray,
-        exception: Exception,
+    detections: sv.Detections,
+    polygon_zone: sv.PolygonZone,
+    overlap_threshold: float,
+    expected_results: np.ndarray,
+    exception: Exception,
 ) -> None:
     with exception:
         overlaps = polygon_zone.trigger_overlap(detections, overlap_threshold)


### PR DESCRIPTION
# Description

In my personal project I needed to only consider detections that have a certain overlap with some regions (I used polygone_zone to specify my regions) that's why I added trigger_overlap to achieve that goal. Although the operation is a bit time-consuming but sometimes needed.

## Type of change

Please delete options that are not relevant.

-   [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I added some test cases in test_polygonzone, and it was tested in my personal project as well.

## Any specific deployment considerations

The operation is a bit costly in terms of time but sometimes needed.

## Docs

N/A
