### PR TITLE
add minimum_consecutive_frames to bytetrack

### DIFF
--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -98,7 +98,10 @@ class STrack(BaseTrack):
             self.mean, self.covariance, self.tlwh_to_xyah(new_tlwh)
         )
         self.state = TrackState.Tracked
-        if self.tracklet_len == self.minimum_consecutive_frames and not self.is_activated:
+        if (
+            self.tracklet_len == self.minimum_consecutive_frames
+            and not self.is_activated
+        ):
             self.is_activated = True
             self.external_track_id = self.next_external_id()
 

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -142,7 +142,7 @@ class STrack(BaseTrack):
     def next_external_id():
         STrack._external_count += 1
         return STrack._external_count
-    
+
     @staticmethod
     def reset_external_counter():
         STrack._external_count = 0

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -100,7 +100,7 @@ class STrack(BaseTrack):
         self.state = TrackState.Tracked
         if (
             self.tracklet_len == self.minimum_consecutive_frames
-            and not self.is_activated
+            and self.external_track_id == -1
         ):
             self.is_activated = True
             self.external_track_id = self.next_external_id()

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -65,8 +65,12 @@ class STrack(BaseTrack):
 
         self.tracklet_len = 0
         self.state = TrackState.Tracked
-        if frame_id == 1 and self.minimum_consecutive_frames == 1:
+        if frame_id == 1:
             self.is_activated = True
+
+        if self.minimum_consecutive_frames == 1:
+            self.external_track_id = self.next_external_id()
+        
         self.frame_id = frame_id
         self.start_frame = frame_id
 

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -98,7 +98,7 @@ class STrack(BaseTrack):
             self.mean, self.covariance, self.tlwh_to_xyah(new_tlwh)
         )
         self.state = TrackState.Tracked
-        if self.tracklet_len == self.minimum_consecutive_frames:
+        if self.tracklet_len == self.minimum_consecutive_frames and not self.is_activated:
             self.is_activated = True
             self.external_track_id = self.next_external_id()
 

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -102,9 +102,9 @@ class STrack(BaseTrack):
             self.mean, self.covariance, self.tlwh_to_xyah(new_tlwh)
         )
         self.state = TrackState.Tracked
-        if (self.tracklet_len == self.minimum_consecutive_frames):
+        if self.tracklet_len == self.minimum_consecutive_frames:
             self.is_activated = True
-            if (self.external_track_id == -1):
+            if self.external_track_id == -1:
                 self.external_track_id = self.next_external_id()
 
         self.score = new_track.score

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -137,7 +137,7 @@ class STrack(BaseTrack):
 
     def to_xyah(self):
         return self.tlwh_to_xyah(self.tlwh)
-    
+
     @staticmethod
     def next_external_id():
         STrack._external_count += 1
@@ -160,7 +160,9 @@ class STrack(BaseTrack):
         return ret
 
     def __repr__(self):
-        return "OT_{}_({}-{})".format(self.internal_track_id, self.start_frame, self.end_frame)
+        return "OT_{}_({}-{})".format(
+            self.internal_track_id, self.start_frame, self.end_frame
+        )
 
 
 def detections2boxes(detections: Detections) -> np.ndarray:
@@ -307,7 +309,9 @@ class ByteTrack:
             matches, _, _ = matching.linear_assignment(iou_costs, 0.5)
             detections.tracker_id = np.full(len(detections), -1, dtype=int)
             for i_detection, i_track in matches:
-                detections.tracker_id[i_detection] = int(tracks[i_track].external_track_id)
+                detections.tracker_id[i_detection] = int(
+                    tracks[i_track].external_track_id
+                )
 
             return detections[detections.tracker_id != -1]
 

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -102,12 +102,10 @@ class STrack(BaseTrack):
             self.mean, self.covariance, self.tlwh_to_xyah(new_tlwh)
         )
         self.state = TrackState.Tracked
-        if (
-            self.tracklet_len == self.minimum_consecutive_frames
-            and self.external_track_id == -1
-        ):
+        if (self.tracklet_len == self.minimum_consecutive_frames):
             self.is_activated = True
-            self.external_track_id = self.next_external_id()
+            if (self.external_track_id == -1):
+                self.external_track_id = self.next_external_id()
 
         self.score = new_track.score
 


### PR DESCRIPTION
# Description

This PR fixes https://github.com/roboflow/supervision/issues/1044. It replaces this PR https://github.com/roboflow/supervision/pull/1050 which caused only one track to be initialized per frame (see the comment)  I decided to re-implement this by instead of setting the tracker_id to -1, I used the existing is_activated property of STrack to mark whether the detection is valid or not. This does not affect the functionality of ByteTrack because every unconfirmed track will get added to the self.tracked_stracks list every time it is matched with a new detection.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested this by running writing pytests for ByteTrack and using them in a [colab notebook](https://colab.research.google.com/drive/1hM1trTUQfFO07znnI77wJPcziiNotCBK?usp=sharing). I will submit another PR with these tests added to supervision. They cover several cases, including all of the edge cases that I have run into.

## Any specific deployment considerations

This might require updating the documentation for ByteTrack, which I am willing to do if this is approved.

## Docs

-   [ ] Docs updated?
