### PR TITLE
Fixed obb key check in ultralytics_results

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -208,22 +208,25 @@ class Detections:
             ```
         """  # noqa: E501 // docs
 
-        if ultralytics_results.obb is not None:
-            class_id = ultralytics_results.obb.cls.cpu().numpy().astype(int)
-            class_names = np.array([ultralytics_results.names[i] for i in class_id])
-            oriented_box_coordinates = ultralytics_results.obb.xyxyxyxy.cpu().numpy()
-            return cls(
-                xyxy=ultralytics_results.obb.xyxy.cpu().numpy(),
-                confidence=ultralytics_results.obb.conf.cpu().numpy(),
-                class_id=class_id,
-                tracker_id=ultralytics_results.obb.id.int().cpu().numpy()
-                if ultralytics_results.obb.id is not None
-                else None,
-                data={
-                    ORIENTED_BOX_COORDINATES: oriented_box_coordinates,
-                    CLASS_NAME_DATA_FIELD: class_names,
-                },
-            )
+        if "obb" in ultralytics_results:
+            if ultralytics_results.obb is not None:
+                class_id = ultralytics_results.obb.cls.cpu().numpy().astype(int)
+                class_names = np.array([ultralytics_results.names[i] for i in class_id])
+                oriented_box_coordinates = (
+                    ultralytics_results.obb.xyxyxyxy.cpu().numpy()
+                )
+                return cls(
+                    xyxy=ultralytics_results.obb.xyxy.cpu().numpy(),
+                    confidence=ultralytics_results.obb.conf.cpu().numpy(),
+                    class_id=class_id,
+                    tracker_id=ultralytics_results.obb.id.int().cpu().numpy()
+                    if ultralytics_results.obb.id is not None
+                    else None,
+                    data={
+                        ORIENTED_BOX_COORDINATES: oriented_box_coordinates,
+                        CLASS_NAME_DATA_FIELD: class_names,
+                    },
+                )
 
         class_id = ultralytics_results.boxes.cls.cpu().numpy().astype(int)
         class_names = np.array([ultralytics_results.names[i] for i in class_id])

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -208,25 +208,22 @@ class Detections:
             ```
         """  # noqa: E501 // docs
 
-        if "obb" in ultralytics_results:
-            if ultralytics_results.obb is not None:
-                class_id = ultralytics_results.obb.cls.cpu().numpy().astype(int)
-                class_names = np.array([ultralytics_results.names[i] for i in class_id])
-                oriented_box_coordinates = (
-                    ultralytics_results.obb.xyxyxyxy.cpu().numpy()
-                )
-                return cls(
-                    xyxy=ultralytics_results.obb.xyxy.cpu().numpy(),
-                    confidence=ultralytics_results.obb.conf.cpu().numpy(),
-                    class_id=class_id,
-                    tracker_id=ultralytics_results.obb.id.int().cpu().numpy()
-                    if ultralytics_results.obb.id is not None
-                    else None,
-                    data={
-                        ORIENTED_BOX_COORDINATES: oriented_box_coordinates,
-                        CLASS_NAME_DATA_FIELD: class_names,
-                    },
-                )
+        if "obb" in ultralytics_results and ultralytics_results.obb is not None:
+            class_id = ultralytics_results.obb.cls.cpu().numpy().astype(int)
+            class_names = np.array([ultralytics_results.names[i] for i in class_id])
+            oriented_box_coordinates = ultralytics_results.obb.xyxyxyxy.cpu().numpy()
+            return cls(
+                xyxy=ultralytics_results.obb.xyxy.cpu().numpy(),
+                confidence=ultralytics_results.obb.conf.cpu().numpy(),
+                class_id=class_id,
+                tracker_id=ultralytics_results.obb.id.int().cpu().numpy()
+                if ultralytics_results.obb.id is not None
+                else None,
+                data={
+                    ORIENTED_BOX_COORDINATES: oriented_box_coordinates,
+                    CLASS_NAME_DATA_FIELD: class_names,
+                },
+            )
 
         class_id = ultralytics_results.boxes.cls.cpu().numpy().astype(int)
         class_names = np.array([ultralytics_results.names[i] for i in class_id])


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).
Fix issue #8107

Allows you to convert detections from Ultralytics which do not contain the key "obb".
An if statement is added before accessing the "obb" key in the dictionary in order to verify its presence.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

The fix was tested with the code snippet provided in the [official documentation](https://supervision.roboflow.com/detection/core/#supervision.detection.core.Detections.from_ultralytics)

## Any specific deployment considerations

No

## Docs

-   [ ] Docs updated? What were the changes:
