### PR TITLE
Add beach drone footage asset

### DIFF
--- a/supervision/assets/list.py
+++ b/supervision/assets/list.py
@@ -18,6 +18,7 @@ class VideoAssets(Enum):
     | `SUBWAY`               | `subway.mp4`               | [Link](https://media.roboflow.com/supervision/video-examples/subway.mp4)              |
     | `MARKET_SQUARE`        | `market-square.mp4`        | [Link](https://media.roboflow.com/supervision/video-examples/market-square.mp4)       |
     | `PEOPLE_WALKING`       | `people-walking.mp4`       | [Link](https://media.roboflow.com/supervision/video-examples/people-walking.mp4)      |
+    | `BEACH`                | `beach-1.mp4`              | [Link](https://media.roboflow.com/supervision/video-examples/beach-1.mp4)             |
     """  # noqa: E501 // docs
 
     VEHICLES = "vehicles.mp4"
@@ -27,6 +28,7 @@ class VideoAssets(Enum):
     SUBWAY = "subway.mp4"
     MARKET_SQUARE = "market-square.mp4"
     PEOPLE_WALKING = "people-walking.mp4"
+    BEACH = "beach-1.mp4"
 
     @classmethod
     def list(cls):
@@ -61,5 +63,9 @@ VIDEO_ASSETS: Dict[str, Tuple[str, str]] = {
     VideoAssets.PEOPLE_WALKING.value: (
         f"{BASE_VIDEO_URL}{VideoAssets.PEOPLE_WALKING.value}",
         "0574c053c8686c3f1dc0aa3743e45cb9",
+    ),
+    VideoAssets.BEACH.value: (
+        f"{BASE_VIDEO_URL}{VideoAssets.BEACH.value}",
+        "4175d42fec4d450ed081523fd39e0cf8",
     ),
 }


### PR DESCRIPTION
# Description

Adding the beach drone footage to assets as discussed with @SkalskiP

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

```
from supervision.assets import download_assets, VideoAssets

# Initial download
download_assets(VideoAssets.BEACH)

# Repeated download does not happen - hash is correct
download_assets(VideoAssets.BEACH)
```
