### PR TITLE
Update examples to remove `frame_resloution_wh` in [PolygonZone]

### DIFF
--- a/examples/count_people_in_zone/inference_example.py
+++ b/examples/count_people_in_zone/inference_example.py
@@ -46,7 +46,7 @@ def initiate_annotators(
     box_annotators = []
 
     for index, polygon in enumerate(polygons):
-        zone = sv.PolygonZone(polygon=polygon, frame_resolution_wh=resolution_wh)
+        zone = sv.PolygonZone(polygon=polygon)
         zone_annotator = sv.PolygonZoneAnnotator(
             zone=zone,
             color=COLORS.by_idx(index),

--- a/examples/count_people_in_zone/requirements.txt
+++ b/examples/count_people_in_zone/requirements.txt
@@ -1,5 +1,5 @@
 gdown
 inference
-supervision==0.19.0
+supervision>=0.20.0
 tqdm
 ultralytics

--- a/examples/count_people_in_zone/ultralytics_example.py
+++ b/examples/count_people_in_zone/ultralytics_example.py
@@ -44,7 +44,7 @@ def initiate_annotators(
     box_annotators = []
 
     for index, polygon in enumerate(polygons):
-        zone = sv.PolygonZone(polygon=polygon, frame_resolution_wh=resolution_wh)
+        zone = sv.PolygonZone(polygon=polygon)
         zone_annotator = sv.PolygonZoneAnnotator(
             zone=zone,
             color=COLORS.by_idx(index),

--- a/examples/speed_estimation/inference_example.py
+++ b/examples/speed_estimation/inference_example.py
@@ -116,9 +116,7 @@ if __name__ == "__main__":
 
     frame_generator = sv.get_video_frames_generator(source_path=args.source_video_path)
 
-    polygon_zone = sv.PolygonZone(
-        polygon=SOURCE, frame_resolution_wh=video_info.resolution_wh
-    )
+    polygon_zone = sv.PolygonZone(polygon=SOURCE)
     view_transformer = ViewTransformer(source=SOURCE, target=TARGET)
 
     coordinates = defaultdict(lambda: deque(maxlen=video_info.fps))

--- a/examples/speed_estimation/requirements.txt
+++ b/examples/speed_estimation/requirements.txt
@@ -1,4 +1,4 @@
-supervision==0.19.0
+supervision>=0.20.0
 tqdm==4.66.1
 requests
 ultralytics==8.0.237

--- a/examples/speed_estimation/ultralytics_example.py
+++ b/examples/speed_estimation/ultralytics_example.py
@@ -94,9 +94,7 @@ if __name__ == "__main__":
 
     frame_generator = sv.get_video_frames_generator(source_path=args.source_video_path)
 
-    polygon_zone = sv.PolygonZone(
-        polygon=SOURCE, frame_resolution_wh=video_info.resolution_wh
-    )
+    polygon_zone = sv.PolygonZone(polygon=SOURCE)
     view_transformer = ViewTransformer(source=SOURCE, target=TARGET)
 
     coordinates = defaultdict(lambda: deque(maxlen=video_info.fps))

--- a/examples/speed_estimation/yolo_nas_example.py
+++ b/examples/speed_estimation/yolo_nas_example.py
@@ -95,9 +95,7 @@ if __name__ == "__main__":
 
     frame_generator = sv.get_video_frames_generator(source_path=args.source_video_path)
 
-    polygon_zone = sv.PolygonZone(
-        polygon=SOURCE, frame_resolution_wh=video_info.resolution_wh
-    )
+    polygon_zone = sv.PolygonZone(polygon=SOURCE)
     view_transformer = ViewTransformer(source=SOURCE, target=TARGET)
 
     coordinates = defaultdict(lambda: deque(maxlen=video_info.fps))

--- a/examples/time_in_zone/inference_file_example.py
+++ b/examples/time_in_zone/inference_file_example.py
@@ -29,14 +29,10 @@ def main(
     video_info = sv.VideoInfo.from_video_path(video_path=source_video_path)
     frames_generator = sv.get_video_frames_generator(source_video_path)
 
-    frame = next(frames_generator)
-    resolution_wh = frame.shape[1], frame.shape[0]
-
     polygons = load_zones_config(file_path=zone_configuration_path)
     zones = [
         sv.PolygonZone(
             polygon=polygon,
-            frame_resolution_wh=resolution_wh,
             triggering_anchors=(sv.Position.CENTER,),
         )
         for polygon in polygons

--- a/examples/time_in_zone/inference_naive_stream_example.py
+++ b/examples/time_in_zone/inference_naive_stream_example.py
@@ -29,14 +29,10 @@ def main(
     frames_generator = get_stream_frames_generator(rtsp_url=rtsp_url)
     fps_monitor = sv.FPSMonitor()
 
-    frame = next(frames_generator)
-    resolution_wh = frame.shape[1], frame.shape[0]
-
     polygons = load_zones_config(file_path=zone_configuration_path)
     zones = [
         sv.PolygonZone(
             polygon=polygon,
-            frame_resolution_wh=resolution_wh,
             triggering_anchors=(sv.Position.CENTER,),
         )
         for polygon in polygons

--- a/examples/time_in_zone/inference_stream_example.py
+++ b/examples/time_in_zone/inference_stream_example.py
@@ -28,11 +28,9 @@ class CustomSink:
 
     def on_prediction(self, result: dict, frame: VideoFrame) -> None:
         if self.zones is None:
-            resolution_wh = frame.image.shape[1], frame.image.shape[0]
             self.zones = [
                 sv.PolygonZone(
                     polygon=polygon,
-                    frame_resolution_wh=resolution_wh,
                     triggering_anchors=(sv.Position.CENTER,),
                 )
                 for polygon in self.polygons

--- a/examples/time_in_zone/inference_stream_example.py
+++ b/examples/time_in_zone/inference_stream_example.py
@@ -24,18 +24,15 @@ class CustomSink:
         self.fps_monitor = sv.FPSMonitor()
         self.polygons = load_zones_config(file_path=zone_configuration_path)
         self.timers = [ClockBasedTimer() for _ in self.polygons]
-        self.zones = None
+        self.zones = [
+            sv.PolygonZone(
+                polygon=polygon,
+                triggering_anchors=(sv.Position.CENTER,),
+            )
+            for polygon in self.polygons
+        ]
 
     def on_prediction(self, result: dict, frame: VideoFrame) -> None:
-        if self.zones is None:
-            self.zones = [
-                sv.PolygonZone(
-                    polygon=polygon,
-                    triggering_anchors=(sv.Position.CENTER,),
-                )
-                for polygon in self.polygons
-            ]
-
         self.fps_monitor.tick()
         fps = self.fps_monitor.fps
 

--- a/examples/time_in_zone/requirements.txt
+++ b/examples/time_in_zone/requirements.txt
@@ -1,5 +1,5 @@
 opencv-python
-supervision
+supervision>=0.20.0
 ultralytics
 inference
 pytube

--- a/examples/time_in_zone/ultralytics_file_example.py
+++ b/examples/time_in_zone/ultralytics_file_example.py
@@ -30,14 +30,10 @@ def main(
     video_info = sv.VideoInfo.from_video_path(video_path=source_video_path)
     frames_generator = sv.get_video_frames_generator(source_video_path)
 
-    frame = next(frames_generator)
-    resolution_wh = frame.shape[1], frame.shape[0]
-
     polygons = load_zones_config(file_path=zone_configuration_path)
     zones = [
         sv.PolygonZone(
             polygon=polygon,
-            frame_resolution_wh=resolution_wh,
             triggering_anchors=(sv.Position.CENTER,),
         )
         for polygon in polygons

--- a/examples/time_in_zone/ultralytics_naive_stream_example.py
+++ b/examples/time_in_zone/ultralytics_naive_stream_example.py
@@ -30,14 +30,10 @@ def main(
     frames_generator = get_stream_frames_generator(rtsp_url=rtsp_url)
     fps_monitor = sv.FPSMonitor()
 
-    frame = next(frames_generator)
-    resolution_wh = frame.shape[1], frame.shape[0]
-
     polygons = load_zones_config(file_path=zone_configuration_path)
     zones = [
         sv.PolygonZone(
             polygon=polygon,
-            frame_resolution_wh=resolution_wh,
             triggering_anchors=(sv.Position.CENTER,),
         )
         for polygon in polygons

--- a/examples/time_in_zone/ultralytics_stream_example.py
+++ b/examples/time_in_zone/ultralytics_stream_example.py
@@ -29,11 +29,9 @@ class CustomSink:
 
     def on_prediction(self, detections: sv.Detections, frame: VideoFrame) -> None:
         if self.zones is None:
-            resolution_wh = frame.image.shape[1], frame.image.shape[0]
             self.zones = [
                 sv.PolygonZone(
                     polygon=polygon,
-                    frame_resolution_wh=resolution_wh,
                     triggering_anchors=(sv.Position.CENTER,),
                 )
                 for polygon in self.polygons

--- a/examples/time_in_zone/ultralytics_stream_example.py
+++ b/examples/time_in_zone/ultralytics_stream_example.py
@@ -25,18 +25,15 @@ class CustomSink:
         self.fps_monitor = sv.FPSMonitor()
         self.polygons = load_zones_config(file_path=zone_configuration_path)
         self.timers = [ClockBasedTimer() for _ in self.polygons]
-        self.zones = None
+        self.zones = [
+            sv.PolygonZone(
+                polygon=polygon,
+                triggering_anchors=(sv.Position.CENTER,),
+            )
+            for polygon in self.polygons
+        ]
 
     def on_prediction(self, detections: sv.Detections, frame: VideoFrame) -> None:
-        if self.zones is None:
-            self.zones = [
-                sv.PolygonZone(
-                    polygon=polygon,
-                    triggering_anchors=(sv.Position.CENTER,),
-                )
-                for polygon in self.polygons
-            ]
-
         self.fps_monitor.tick()
         fps = self.fps_monitor.fps
 

--- a/examples/traffic_analysis/inference_example.py
+++ b/examples/traffic_analysis/inference_example.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-from typing import Dict, Iterable, List, Set, Tuple
+from typing import Dict, Iterable, List, Set
 
 import cv2
 import numpy as np
@@ -90,12 +90,8 @@ class VideoProcessor:
         self.tracker = sv.ByteTrack()
 
         self.video_info = sv.VideoInfo.from_video_path(source_video_path)
-        self.zones_in = initiate_polygon_zones(
-            ZONE_IN_POLYGONS, [sv.Position.CENTER]
-        )
-        self.zones_out = initiate_polygon_zones(
-            ZONE_OUT_POLYGONS, [sv.Position.CENTER]
-        )
+        self.zones_in = initiate_polygon_zones(ZONE_IN_POLYGONS, [sv.Position.CENTER])
+        self.zones_out = initiate_polygon_zones(ZONE_OUT_POLYGONS, [sv.Position.CENTER])
 
         self.bounding_box_annotator = sv.BoundingBoxAnnotator(color=COLORS)
         self.label_annotator = sv.LabelAnnotator(

--- a/examples/traffic_analysis/inference_example.py
+++ b/examples/traffic_analysis/inference_example.py
@@ -60,13 +60,11 @@ class DetectionsManager:
 
 def initiate_polygon_zones(
     polygons: List[np.ndarray],
-    frame_resolution_wh: Tuple[int, int],
     triggering_anchors: Iterable[sv.Position] = [sv.Position.CENTER],
 ) -> List[sv.PolygonZone]:
     return [
         sv.PolygonZone(
             polygon=polygon,
-            frame_resolution_wh=frame_resolution_wh,
             triggering_anchors=triggering_anchors,
         )
         for polygon in polygons
@@ -93,10 +91,10 @@ class VideoProcessor:
 
         self.video_info = sv.VideoInfo.from_video_path(source_video_path)
         self.zones_in = initiate_polygon_zones(
-            ZONE_IN_POLYGONS, self.video_info.resolution_wh, [sv.Position.CENTER]
+            ZONE_IN_POLYGONS, [sv.Position.CENTER]
         )
         self.zones_out = initiate_polygon_zones(
-            ZONE_OUT_POLYGONS, self.video_info.resolution_wh, [sv.Position.CENTER]
+            ZONE_OUT_POLYGONS, [sv.Position.CENTER]
         )
 
         self.bounding_box_annotator = sv.BoundingBoxAnnotator(color=COLORS)

--- a/examples/traffic_analysis/requirements.txt
+++ b/examples/traffic_analysis/requirements.txt
@@ -1,5 +1,5 @@
 gdown
 inference
-supervision>=0.19.0
+supervision>=0.20.0
 tqdm
 ultralytics

--- a/examples/traffic_analysis/ultralytics_example.py
+++ b/examples/traffic_analysis/ultralytics_example.py
@@ -58,13 +58,11 @@ class DetectionsManager:
 
 def initiate_polygon_zones(
     polygons: List[np.ndarray],
-    frame_resolution_wh: Tuple[int, int],
     triggering_anchors: Iterable[sv.Position] = [sv.Position.CENTER],
 ) -> List[sv.PolygonZone]:
     return [
         sv.PolygonZone(
             polygon=polygon,
-            frame_resolution_wh=frame_resolution_wh,
             triggering_anchors=triggering_anchors,
         )
         for polygon in polygons
@@ -90,10 +88,10 @@ class VideoProcessor:
 
         self.video_info = sv.VideoInfo.from_video_path(source_video_path)
         self.zones_in = initiate_polygon_zones(
-            ZONE_IN_POLYGONS, self.video_info.resolution_wh, [sv.Position.CENTER]
+            ZONE_IN_POLYGONS, [sv.Position.CENTER]
         )
         self.zones_out = initiate_polygon_zones(
-            ZONE_OUT_POLYGONS, self.video_info.resolution_wh, [sv.Position.CENTER]
+            ZONE_OUT_POLYGONS, [sv.Position.CENTER]
         )
 
         self.bounding_box_annotator = sv.BoundingBoxAnnotator(color=COLORS)

--- a/examples/traffic_analysis/ultralytics_example.py
+++ b/examples/traffic_analysis/ultralytics_example.py
@@ -1,5 +1,5 @@
 import argparse
-from typing import Dict, Iterable, List, Set, Tuple
+from typing import Dict, Iterable, List, Set
 
 import cv2
 import numpy as np
@@ -87,12 +87,8 @@ class VideoProcessor:
         self.tracker = sv.ByteTrack()
 
         self.video_info = sv.VideoInfo.from_video_path(source_video_path)
-        self.zones_in = initiate_polygon_zones(
-            ZONE_IN_POLYGONS, [sv.Position.CENTER]
-        )
-        self.zones_out = initiate_polygon_zones(
-            ZONE_OUT_POLYGONS, [sv.Position.CENTER]
-        )
+        self.zones_in = initiate_polygon_zones(ZONE_IN_POLYGONS, [sv.Position.CENTER])
+        self.zones_out = initiate_polygon_zones(ZONE_OUT_POLYGONS, [sv.Position.CENTER])
 
         self.bounding_box_annotator = sv.BoundingBoxAnnotator(color=COLORS)
         self.label_annotator = sv.LabelAnnotator(


### PR DESCRIPTION
# Description
Removed the `frame_resolution_wh` parameter in `PolygonZone` from examples. #1109



## Type of change

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested out a couple of examples, and everything looks good.
