### PR TITLE
Add codec arg to process_video

### DIFF
--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -177,6 +177,7 @@ def process_video(
     source_path: str,
     target_path: str,
     callback: Callable[[np.ndarray, int], np.ndarray],
+    codec: str = "mp4v",
 ) -> None:
     """
     Process a video file by applying a callback function on each frame
@@ -189,6 +190,8 @@ def process_video(
             a numpy ndarray representation of a video frame and an
             int index of the frame and returns a processed numpy ndarray
             representation of the frame.
+        codec (str): FOURCC code for video format. Default is `mp4v`.
+            Other common codecs are `H264`, `XVID`, `MJPG`, etc.
 
     Examples:
         ```python
@@ -205,7 +208,11 @@ def process_video(
         ```
     """
     source_video_info = VideoInfo.from_video_path(video_path=source_path)
-    with VideoSink(target_path=target_path, video_info=source_video_info) as sink:
+    with VideoSink(
+        target_path=target_path,
+        video_info=source_video_info,
+        codec=codec,
+    ) as sink:
         for index, frame in enumerate(
             get_video_frames_generator(source_path=source_path)
         ):


### PR DESCRIPTION
# Description

`VideoSink` provides an argument for a `FourCC` codec, allowing encoding the video in different formats. `process_video`, however, does not and defaults to `mp4v`.

This PR adds the same arg, hardcode-defaulting to `mp4v`.
Note: An alternative implementation would make `process_video` `codec` have the type `Optional[str]` and link it with `VideoSink`, but this is more concise and self-documenting.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

https://colab.research.google.com/drive/16ggPDIUnk808HE0nUG-H7QCDjTncjldC?usp=sharing

## Any specific deployment considerations

:warning: Turns out `H264`, which I meant to enable, is not trivial to set up.

`cv2.VideoWriter_fourcc` fails silently, without throwing an error, doesn't even produce the file as an output. (tested in a [different Colab](https://colab.research.google.com/drive/1rso8hy0dZkz-K-_z0LjG62lVR5LeQlWl?usp=sharing))

Similar issues plague others - `XVID`, `YVYU`, etc. 

Leaving this as draft until we figure out what the codec behaviour is.

## Docs

-   [ ] Docs updated? What were the changes:
