### PR TITLE
Fix keypoint crash with no detections

### DIFF
--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -135,7 +135,7 @@ class KeyPoints:
             keypoints = sv.KeyPoints.from_ultralytics(result)
             ```
         """
-        if len(ultralytics_results.keypoints.xy) == 0:
+        if ultralytics_results.keypoints.xy.numel() == 0:
             return cls.empty()
 
         xy = ultralytics_results.keypoints.xy.cpu().numpy()


### PR DESCRIPTION
# Description

Keypoints crash when none are detected.

## Type of change


-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Uncomment other parts for regression tests on videos.

```python
import numpy as np
import cv2
import requests
from pathlib import Path

from ultralytics import YOLO

import supervision as sv
from supervision.keypoint.skeletons import Skeleton
from supervision.assets import download_assets, VideoAssets


def download_img(url: str, out_path: Path) -> None:
    if out_path.exists():
        print(f"File already exists: {out_path}")
        return
    r = requests.get(url)
    with open(out_path, "wb") as f:
        f.write(r.content)


model = YOLO('yolov8n-pose')
download_assets(VideoAssets.PEOPLE_WALKING)

img_url = "https://placedog.net/400x400?id=13"
img_path = Path("dog.jpg")
download_img(img_url, img_path)
img = cv2.imread(str(img_path))

# cap = cv2.VideoCapture(0)
cap = cv2.VideoCapture(VideoAssets.PEOPLE_WALKING.value)

while True:
    ret, frame = cap.read()
    if not ret:
        continue

    # Run on image without people. Repeatedly. For no reason.
    frame = img
    result = model(frame, verbose=False)[0]

    # result = model(frame, verbose=False)[0]
    keypoints = sv.KeyPoints.from_ultralytics(result)

    ann_point_large = sv.VertexAnnotator(color=sv.Color.ROBOFLOW, radius=5)
    ann_point_small = sv.VertexAnnotator(color=sv.Color.WHITE, radius=3)

    # Option 1: Use a predefined skeleton
    # ann_skeleton = sv.EdgeAnnotator(
    #     color=sv.Color.ROBOFLOW,
    #     thickness=5,
    #     edges=Skeleton.COCO.value
    # )

    # Option 2: No skeleton
    # ann_skeleton = sv.EdgeAnnotator(
    #     color=sv.Color.ROBOFLOW,
    #     thickness=5,
    #     edges=[]
    # )

    # Option 3: Figure out automatically
    ann_skeleton = sv.EdgeAnnotator(
        color=sv.Color.ROBOFLOW,
        thickness=5
    )

    # Option 4: Take a guess (connect sequential points)
    # TODO: remove COCO from Skeleton before running
    # ann_skeleton = sv.EdgeAnnotator(
    #     color=sv.Color.ROBOFLOW,
    #     thickness=5
    # )

    # Draw (order matters!)
    ann_skeleton.annotate(frame, keypoints)
    ann_point_large.annotate(frame, keypoints)
    ann_point_small.annotate(frame, keypoints)

    cv2.imshow('frame', frame)

    if cv2.waitKey(1) & 0xFF == ord('q'):
        break

cap.release()
cv2.destroyAllWindows()
```

## Docs

-   [ ] Docs updated? What were the changes:
