### PR TITLE
Non-max-merging for Inference Slicer

### DIFF
--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -35,7 +35,7 @@ from supervision.dataset.core import (
     DetectionDataset,
 )
 from supervision.detection.annotate import BoxAnnotator
-from supervision.detection.core import Detections
+from supervision.detection.core import Detections, OverlapFiltering
 from supervision.detection.line_zone import LineZone, LineZoneAnnotator
 from supervision.detection.tools.csv_sink import CSVSink
 from supervision.detection.tools.inference_slicer import InferenceSlicer

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -1,9 +1,10 @@
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Callable, Optional, Tuple
+from typing import Callable, Tuple
 
 import numpy as np
 
-from supervision.detection.core import Detections
+from supervision.detection.core import Detections, OverlapFiltering
 from supervision.detection.utils import move_boxes
 from supervision.utils.image import crop_image
 
@@ -39,6 +40,8 @@ class InferenceSlicer:
         callback (Callable): A function that performs inference on a given image
             slice and returns detections.
         thread_workers (int): Number of threads for parallel execution.
+        overlap_filtering (OverlapFiltering): Strategy for
+            filtering or merging overlapping detections in slices.
 
     Note:
         The class ensures that slices do not exceed the boundaries of the original
@@ -52,14 +55,16 @@ class InferenceSlicer:
         callback: Callable[[np.ndarray], Detections],
         slice_wh: Tuple[int, int] = (320, 320),
         overlap_ratio_wh: Tuple[float, float] = (0.2, 0.2),
-        iou_threshold: Optional[float] = 0.5,
+        iou_threshold: float = 0.5,
         thread_workers: int = 1,
+        overlap_filtering: OverlapFiltering = OverlapFiltering.NON_MAX_SUPPRESSION,
     ):
         self.slice_wh = slice_wh
         self.overlap_ratio_wh = overlap_ratio_wh
         self.iou_threshold = iou_threshold
         self.callback = callback
         self.thread_workers = thread_workers
+        self.overlap_filtering = overlap_filtering
 
     def __call__(self, image: np.ndarray) -> Detections:
         """
@@ -108,9 +113,18 @@ class InferenceSlicer:
             for future in as_completed(futures):
                 detections_list.append(future.result())
 
-        return Detections.merge(detections_list=detections_list).with_nms(
-            threshold=self.iou_threshold
-        )
+        merged = Detections.merge(detections_list=detections_list)
+        if self.overlap_filtering == OverlapFiltering.NONE:
+            return merged
+        elif self.overlap_filtering == OverlapFiltering.NON_MAX_SUPPRESSION:
+            return merged.with_nms(threshold=self.iou_threshold)
+        elif self.overlap_filtering == OverlapFiltering.NON_MAX_MERGE:
+            return merged.with_nmm(threshold=self.iou_threshold)
+        else:
+            warnings.warn(
+                f"Invalid overlap filtering strategy: {self.overlap_filtering}"
+            )
+            return merged
 
     def _run_callback(self, image, offset) -> Detections:
         """

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -36,12 +36,6 @@ class InferenceSlicer:
             slices in the format `(width_ratio, height_ratio)`.
         iou_threshold (Optional[float]): Intersection over Union (IoU) threshold
             used for non-max suppression.
-        merge_detections (Optional[bool]): Whether to merge the detection from all
-            slices or simply concatenate them. If `True`, Non-Maximum Merging (NMM),
-            otherwise Non-Maximum Suppression (NMS), is applied to the detections.
-        perform_standard_pred (Optional[bool]): Whether to perform inference on the
-            whole image in addition to the slices to increase the accuracy of
-            large object detection.
         callback (Callable): A function that performs inference on a given image
             slice and returns detections.
         thread_workers (int): Number of threads for parallel execution.
@@ -59,15 +53,11 @@ class InferenceSlicer:
         slice_wh: Tuple[int, int] = (320, 320),
         overlap_ratio_wh: Tuple[float, float] = (0.2, 0.2),
         iou_threshold: Optional[float] = 0.5,
-        merge_detections: Optional[bool] = False,
-        perform_standard_pred: Optional[bool] = False,
         thread_workers: int = 1,
     ):
         self.slice_wh = slice_wh
         self.overlap_ratio_wh = overlap_ratio_wh
         self.iou_threshold = iou_threshold
-        self.merge_detections = merge_detections
-        self.perform_standard_pred = perform_standard_pred
         self.callback = callback
         self.thread_workers = thread_workers
 
@@ -118,17 +108,9 @@ class InferenceSlicer:
             for future in as_completed(futures):
                 detections_list.append(future.result())
 
-        if self.perform_standard_pred:
-            detections_list.append(self.callback(image))
-
-        if self.merge_detections:
-            return Detections.merge(detections_list=detections_list).with_nmm(
-                threshold=self.iou_threshold
-            )
-        else:
-            return Detections.merge(detections_list=detections_list).with_nms(
-                threshold=self.iou_threshold
-            )
+        return Detections.merge(detections_list=detections_list).with_nms(
+            threshold=self.iou_threshold
+        )
 
     def _run_callback(self, image, offset) -> Detections:
         """

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -274,6 +274,194 @@ def box_non_max_suppression(
     return keep[sort_index.argsort()]
 
 
+def greedy_nmm(predictions: np.ndarray, threshold: float = 0.5) -> Dict[int, List[int]]:
+    """
+    Apply greedy version of non-maximum merging to avoid detecting too many
+    overlapping bounding boxes for a given object.
+
+    Args:
+        predictions (np.ndarray): An array of shape `(n, 5)` containing
+            the bounding boxes coordinates in format `[x1, y1, x2, y2]`
+            and the confidence scores.
+        threshold (float, optional): The intersection-over-union threshold
+            to use for non-maximum suppression. Defaults to 0.5.
+
+    Returns:
+        Dict[int, List[int]]: Mapping from prediction indices
+        to keep to a list of prediction indices to be merged.
+    """
+    keep_to_merge_list = {}
+
+    x1 = predictions[:, 0]
+    y1 = predictions[:, 1]
+    x2 = predictions[:, 2]
+    y2 = predictions[:, 3]
+
+    scores = predictions[:, 4]
+
+    areas = (x2 - x1) * (y2 - y1)
+
+    order = scores.argsort()
+
+    keep = []
+
+    while len(order) > 0:
+        idx = order[-1]
+
+        keep.append(idx.tolist())
+
+        order = order[:-1]
+
+        if len(order) == 0:
+            keep_to_merge_list[idx.tolist()] = []
+            break
+
+        xx1 = np.take(x1, axis=0, indices=order)
+        xx2 = np.take(x2, axis=0, indices=order)
+        yy1 = np.take(y1, axis=0, indices=order)
+        yy2 = np.take(y2, axis=0, indices=order)
+
+        xx1 = np.maximum(xx1, x1[idx])
+        yy1 = np.maximum(yy1, y1[idx])
+        xx2 = np.minimum(xx2, x2[idx])
+        yy2 = np.minimum(yy2, y2[idx])
+
+        w = np.maximum(0.0, xx2 - xx1)
+        h = np.maximum(0.0, yy2 - yy1)
+
+        inter = w * h
+
+        rem_areas = np.take(areas, axis=0, indices=order)
+
+        union = (rem_areas - inter) + areas[idx]
+        match_metric_value = inter / union
+
+        mask = match_metric_value < threshold
+        mask = mask.astype(np.uint8)
+        matched_box_indices = np.flip(order[np.where(mask == 0)[0]])
+        unmatched_indices = order[np.where(mask == 1)[0]]
+
+        order = unmatched_indices[scores[unmatched_indices].argsort()]
+
+        keep_to_merge_list[idx.tolist()] = []
+
+        for matched_box_ind in matched_box_indices.tolist():
+            keep_to_merge_list[idx.tolist()].append(matched_box_ind)
+
+    return keep_to_merge_list
+
+
+def batched_greedy_nmm(
+    predictions: np.ndarray, threshold: float = 0.5
+) -> Dict[int, List[int]]:
+    """
+    Apply greedy version of non-maximum merging per category to avoid detecting
+    too many overlapping bounding boxes for a given object.
+
+    Args:
+        predictions (np.ndarray): An array of shape `(n, 6)` containing
+            the bounding boxes coordinates in format `[x1, y1, x2, y2]`,
+            the confidence scores and class_ids.
+        threshold (float, optional): The intersection-over-union threshold
+            to use for non-maximum suppression. Defaults to 0.5.
+
+    Returns:
+        Dict[int, List[int]]: Mapping from prediction indices
+        to keep to a list of prediction indices to be merged.
+    """
+    category_ids = predictions[:, 5]
+    keep_to_merge_list = {}
+    for category_id in np.unique(category_ids):
+        curr_indices = np.where(category_ids == category_id)[0]
+        curr_keep_to_merge_list = greedy_nmm(predictions[curr_indices], threshold)
+        curr_indices_list = curr_indices.tolist()
+        for curr_keep, curr_merge_list in curr_keep_to_merge_list.items():
+            keep = curr_indices_list[curr_keep]
+            merge_list = [curr_indices_list[i] for i in curr_merge_list]
+            keep_to_merge_list[keep] = merge_list
+    return keep_to_merge_list
+
+
+def get_merged_bbox(bbox1: np.ndarray, bbox2: np.ndarray) -> np.ndarray:
+    """
+    Merges two bounding boxes into one.
+
+    Args:
+        bbox1 (np.ndarray): A numpy array of shape `(, 4)` where the
+            row corresponds to a bounding box in
+            the format `(x_min, y_min, x_max, y_max)`.
+        bbox2 (np.ndarray): A numpy array of shape `(, 4)` where the
+            row corresponds to a bounding box in
+            the format `(x_min, y_min, x_max, y_max)`.
+
+    Returns:
+        np.ndarray: A numpy array of shape `(, 4)` where the new
+            bounding box is the merged bounding box of `bbox1` and `bbox2`.
+    """
+    left_top = np.minimum(bbox1[:2], bbox2[:2])
+    right_bottom = np.maximum(bbox1[2:], bbox2[2:])
+    return np.concatenate([left_top, right_bottom])
+
+
+def get_merged_class_id(id1: int, id2: int) -> int:
+    """
+    Merges two class ids into one.
+
+    Args:
+        id1 (int): The first class id.
+        id2 (int): The second class id.
+
+    Returns:
+        int: The merged class id.
+    """
+    return max(id1, id2)
+
+
+def get_merged_confidence(confidence1: float, confidence2: float) -> float:
+    """
+    Merges two confidences into one.
+
+    Args:
+        confidence1 (float): The first confidence.
+        confidence2 (float): The second confidence.
+
+    Returns:
+        float: The merged confidence.
+    """
+    return max(confidence1, confidence2)
+
+
+def get_merged_mask(mask1: np.ndarray, mask2: np.ndarray) -> np.ndarray:
+    """
+    Merges two masks into one.
+
+    Args:
+        mask1 (np.ndarray): A numpy array of shape `(H, W)` where `H` and `W`
+            are the height and width of the mask, respectively.
+        mask2 (np.ndarray): A numpy array of shape `(H, W)` where `H` and `W`
+            are the height and width of the mask, respectively.
+
+    Returns:
+        np.ndarray: A numpy array of shape `(H, W)` where the new mask is the
+            merged mask of `mask1` and `mask2`.
+    """
+    return np.logical_or(mask1, mask2)
+
+
+def get_merged_tracker_id(tracker_id1: int, tracker_id2: int) -> int:
+    """
+    Merges two tracker ids into one.
+
+    Args:
+        tracker_id1 (int): The first tracker id.
+        tracker_id2 (int): The second tracker id.
+
+    Returns:
+        int: The merged tracker id.
+    """
+    return max(tracker_id1, tracker_id2)
+
+
 def clip_boxes(xyxy: np.ndarray, resolution_wh: Tuple[int, int]) -> np.ndarray:
     """
     Clips bounding boxes coordinates to fit within the frame resolution.

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -326,8 +326,8 @@ def greedy_nmm(predictions: np.ndarray, threshold: float = 0.5) -> Dict[int, Lis
         xx2 = np.minimum(xx2, x2[idx])
         yy2 = np.minimum(yy2, y2[idx])
 
-        w = np.maximum(0.0, xx2 - xx1)
-        h = np.maximum(0.0, yy2 - yy1)
+        w = np.maximum(0, xx2 - xx1)
+        h = np.maximum(0, yy2 - yy1)
 
         inter = w * h
 
@@ -398,37 +398,39 @@ def get_merged_bbox(bbox1: np.ndarray, bbox2: np.ndarray) -> np.ndarray:
         np.ndarray: A numpy array of shape `(, 4)` where the new
             bounding box is the merged bounding box of `bbox1` and `bbox2`.
     """
-    left_top = np.minimum(bbox1[:2], bbox2[:2])
-    right_bottom = np.maximum(bbox1[2:], bbox2[2:])
-    return np.concatenate([left_top, right_bottom])
+    left_top = np.minimum(bbox1[0][:2], bbox2[0][:2])
+    right_bottom = np.maximum(bbox1[0][2:], bbox2[0][2:])
+    return np.array([np.concatenate([left_top, right_bottom])])
 
 
-def get_merged_class_id(id1: int, id2: int) -> int:
+def get_merged_class_id(id1: np.ndarray, id2: np.ndarray) -> np.ndarray:
     """
     Merges two class ids into one.
 
     Args:
-        id1 (int): The first class id.
-        id2 (int): The second class id.
+        id1 (np.ndarray): The first class id.
+        id2 (np.ndarray): The second class id.
 
     Returns:
-        int: The merged class id.
+        np.ndarray: The merged class id.
     """
-    return max(id1, id2)
+    return np.array([max(id1.item(), id2.item())])
 
 
-def get_merged_confidence(confidence1: float, confidence2: float) -> float:
+def get_merged_confidence(
+    confidence1: np.ndarray, confidence2: np.ndarray
+) -> np.ndarray:
     """
     Merges two confidences into one.
 
     Args:
-        confidence1 (float): The first confidence.
-        confidence2 (float): The second confidence.
+        confidence1 (np.ndarray): The first confidence.
+        confidence2 (np.ndarray): The second confidence.
 
     Returns:
-        float: The merged confidence.
+        np.ndarray: The merged confidence.
     """
-    return max(confidence1, confidence2)
+    return np.array([max(confidence1.item(), confidence2.item())])
 
 
 def get_merged_mask(mask1: np.ndarray, mask2: np.ndarray) -> np.ndarray:

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -274,7 +274,9 @@ def box_non_max_suppression(
     return keep[sort_index.argsort()]
 
 
-def greedy_nmm(predictions: np.ndarray, threshold: float = 0.5) -> Dict[int, List[int]]:
+def non_max_merge(
+    predictions: np.ndarray, threshold: float = 0.5
+) -> Dict[int, List[int]]:
     """
     Apply greedy version of non-maximum merging to avoid detecting too many
     overlapping bounding boxes for a given object.
@@ -351,7 +353,7 @@ def greedy_nmm(predictions: np.ndarray, threshold: float = 0.5) -> Dict[int, Lis
     return keep_to_merge_list
 
 
-def batched_greedy_nmm(
+def batch_non_max_merge(
     predictions: np.ndarray, threshold: float = 0.5
 ) -> Dict[int, List[int]]:
     """
@@ -373,7 +375,7 @@ def batched_greedy_nmm(
     keep_to_merge_list = {}
     for category_id in np.unique(category_ids):
         curr_indices = np.where(category_ids == category_id)[0]
-        curr_keep_to_merge_list = greedy_nmm(predictions[curr_indices], threshold)
+        curr_keep_to_merge_list = non_max_merge(predictions[curr_indices], threshold)
         curr_indices_list = curr_indices.tolist()
         for curr_keep, curr_merge_list in curr_keep_to_merge_list.items():
             keep = curr_indices_list[curr_keep]
@@ -401,67 +403,6 @@ def get_merged_bbox(bbox1: np.ndarray, bbox2: np.ndarray) -> np.ndarray:
     left_top = np.minimum(bbox1[0][:2], bbox2[0][:2])
     right_bottom = np.maximum(bbox1[0][2:], bbox2[0][2:])
     return np.array([np.concatenate([left_top, right_bottom])])
-
-
-def get_merged_class_id(id1: np.ndarray, id2: np.ndarray) -> np.ndarray:
-    """
-    Merges two class ids into one.
-
-    Args:
-        id1 (np.ndarray): The first class id.
-        id2 (np.ndarray): The second class id.
-
-    Returns:
-        np.ndarray: The merged class id.
-    """
-    return np.array([max(id1.item(), id2.item())])
-
-
-def get_merged_confidence(
-    confidence1: np.ndarray, confidence2: np.ndarray
-) -> np.ndarray:
-    """
-    Merges two confidences into one.
-
-    Args:
-        confidence1 (np.ndarray): The first confidence.
-        confidence2 (np.ndarray): The second confidence.
-
-    Returns:
-        np.ndarray: The merged confidence.
-    """
-    return np.array([max(confidence1.item(), confidence2.item())])
-
-
-def get_merged_mask(mask1: np.ndarray, mask2: np.ndarray) -> np.ndarray:
-    """
-    Merges two masks into one.
-
-    Args:
-        mask1 (np.ndarray): A numpy array of shape `(H, W)` where `H` and `W`
-            are the height and width of the mask, respectively.
-        mask2 (np.ndarray): A numpy array of shape `(H, W)` where `H` and `W`
-            are the height and width of the mask, respectively.
-
-    Returns:
-        np.ndarray: A numpy array of shape `(H, W)` where the new mask is the
-            merged mask of `mask1` and `mask2`.
-    """
-    return np.logical_or(mask1, mask2)
-
-
-def get_merged_tracker_id(tracker_id1: int, tracker_id2: int) -> int:
-    """
-    Merges two tracker ids into one.
-
-    Args:
-        tracker_id1 (int): The first tracker id.
-        tracker_id2 (int): The second tracker id.
-
-    Returns:
-        int: The merged tracker id.
-    """
-    return max(tracker_id1, tracker_id2)
 
 
 def clip_boxes(xyxy: np.ndarray, resolution_wh: Tuple[int, int]) -> np.ndarray:


### PR DESCRIPTION
# Description

This PR builds on top of @mario-dg PR #500, replacing it, fixing issues, adding non-max-merging to `Detections` and connecting to InferenceSlicer.

There main stylistic complexity here is dealing with individual objects inside `Detections`.

Here, the following changes are implemented:
* `Detections` now have `with_nmm`, which merges the detections based on their overlap.
* `detections/core.py` exposes an `OverlapFiltering` enum, which allows other methods to distinguish between the types. This enum is exposed globally in `__init__.py`.
* `InferenceSlicer` is the only class using it right now. `NMS` is performed by default, and users may specify `overlap_filtering` to pick which filtering type to use.
* New method `Detections._set_at_index` mimicks the former `__setitem__`, to be used internally. Only used in one location, so happy to refactor there.
* Removed `Optional` from InferenceSlicer's `iou_threshold` arg.

:warning: So far, only tested with object detections - not segmentation.
:warning: Naming could be made more clear, e.g. in methods like `utils.py::batch_non_max_merge`. Ping me and I'll look into that.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tests:
* Works with 0 detections
* Works with ~5 detections
* Works with inference slicer, visual results the same as drawn in SAHI example in #500 
* Benchmarking in progress

Colab: https://colab.research.google.com/drive/1iiJ5oCl8dwwcefRgNXRdaFH6G9dVpf4P?usp=sharing

## Any specific deployment considerations

One thing I couldn't figure out was the **_right_** way to access values of individual detected objects.
When a scalar was needed, I went with `self.xyxy[i]`. When an array was expected, I left the `self[i].xyxy` calls. Feels a bit backwards, but most concise - is there a better way?

## Docs

-   [ ] Docs updated? What were the changes:
