### PR TITLE
Fix ever increasing memory consumption in ByteTrack

### DIFF
--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -487,7 +487,7 @@ class ByteTrack:
         self.lost_tracks = sub_tracks(self.lost_tracks, self.tracked_tracks)
         self.lost_tracks.extend(lost_stracks)
         self.lost_tracks = sub_tracks(self.lost_tracks, self.removed_tracks)
-        self.removed_tracks.extend(removed_stracks)
+        self.removed_tracks = removed_stracks
         self.tracked_tracks, self.lost_tracks = remove_duplicate_tracks(
             self.tracked_tracks, self.lost_tracks
         )


### PR DESCRIPTION
# Description

Fix issue https://github.com/roboflow/supervision/issues/1164

ByteTrack stores all removed tracklets in a single list. This list grows indefinitely increasing tracking computational cost. 
This PR fixes the issue by restricting the list to tracklets removed in the last pass of the tracker.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Currently, there are no tests for tracking. I've used publicly available tracking videos to test for regression. 