### PR TITLE
More flexibility in Detections.merge 

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -831,9 +831,10 @@ class Detections:
 
         This method takes a list of Detections objects and combines their
         respective fields (`xyxy`, `mask`, `confidence`, `class_id`, and `tracker_id`)
-        into a single Detections object. If all elements in a field are not
-        `None`, the corresponding field will be stacked.
-        Otherwise, the field will be set to `None`.
+        into a single Detections object.
+
+        For example, if merging Detections with 3 and 4 detected objects, this method
+        will return a Detections with 7 objects (7 entries in `xyxy`, `mask`, etc).
 
         Args:
             detections_list (List[Detections]): A list of Detections objects to merge.
@@ -891,13 +892,12 @@ class Detections:
         def stack_or_none(name: str):
             if all(d.__getattribute__(name) is None for d in detections_list):
                 return None
-            if any(d.__getattribute__(name) is None for d in detections_list):
-                raise ValueError(f"All or none of the '{name}' fields must be None")
-            return (
-                np.vstack([d.__getattribute__(name) for d in detections_list])
-                if name == "mask"
-                else np.hstack([d.__getattribute__(name) for d in detections_list])
-            )
+            stack_list = [
+                d.__getattribute__(name)
+                for d in detections_list
+                if d.__getattribute__(name) is not None
+            ]
+            return np.vstack(stack_list) if name == "mask" else np.hstack(stack_list)
 
         mask = stack_or_none("mask")
         confidence = stack_or_none("confidence")

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -55,8 +55,7 @@ def box_iou_batch(boxes_true: np.ndarray, boxes_detection: np.ndarray) -> np.nda
     top_left = np.maximum(boxes_true[:, None, :2], boxes_detection[:, :2])
     bottom_right = np.minimum(boxes_true[:, None, 2:], boxes_detection[:, 2:])
 
-    area_inter = np.prod(
-        np.clip(bottom_right - top_left, a_min=0, a_max=None), 2)
+    area_inter = np.prod(np.clip(bottom_right - top_left, a_min=0, a_max=None), 2)
     return area_inter / (area_true[:, None] + area_detection - area_inter)
 
 
@@ -81,8 +80,7 @@ def _mask_iou_batch_split(
 
     masks_true_area = masks_true.sum(axis=(1, 2))
     masks_detection_area = masks_detection.sum(axis=(1, 2))
-    union_area = masks_true_area[:, None] + \
-        masks_detection_area - intersection_area
+    union_area = masks_true_area[:, None] + masks_detection_area - intersection_area
 
     return np.divide(
         intersection_area,
@@ -133,8 +131,7 @@ def mask_iou_batch(
         1,
     )
     for i in range(0, masks_true.shape[0], step):
-        ious.append(_mask_iou_batch_split(
-            masks_true[i: i + step], masks_detection))
+        ious.append(_mask_iou_batch_split(masks_true[i : i + step], masks_detection))
 
     return np.vstack(ious)
 
@@ -164,8 +161,7 @@ def resize_masks(masks: np.ndarray, max_dimension: int = 640) -> np.ndarray:
 
     resized_masks = masks[:, yv, xv]
 
-    resized_masks = resized_masks.reshape(
-        masks.shape[0], new_height, new_width)
+    resized_masks = resized_masks.reshape(masks.shape[0], new_height, new_width)
     return resized_masks
 
 
@@ -218,9 +214,8 @@ def mask_non_max_suppression(
     keep = np.ones(rows, dtype=bool)
     for i in range(rows):
         if keep[i]:
-            condition = (ious[i] > iou_threshold) & (
-                categories[i] == categories)
-            keep[i + 1:] = np.where(condition[i + 1:], False, keep[i + 1:])
+            condition = (ious[i] > iou_threshold) & (categories[i] == categories)
+            keep[i + 1 :] = np.where(condition[i + 1 :], False, keep[i + 1 :])
 
     return keep[sort_index.argsort()]
 
@@ -452,8 +447,7 @@ def approximate_polygon(
     approximated_points = polygon
     while True:
         epsilon += epsilon_step
-        new_approximated_points = cv2.approxPolyDP(
-            polygon, epsilon, closed=True)
+        new_approximated_points = cv2.approxPolyDP(polygon, epsilon, closed=True)
         if len(new_approximated_points) > target_points:
             approximated_points = new_approximated_points
         else:
@@ -482,8 +476,7 @@ def extract_ultralytics_masks(yolov8_results) -> Optional[np.ndarray]:
         )
 
     top, left = int(pad[1]), int(pad[0])
-    bottom, right = int(
-        inference_shape[0] - pad[1]), int(inference_shape[1] - pad[0])
+    bottom, right = int(inference_shape[0] - pad[1]), int(inference_shape[1] - pad[0])
 
     mask_maps = []
     masks = yolov8_results.masks.data.cpu().numpy()
@@ -550,8 +543,7 @@ def process_roboflow_result(
             polygon = np.array(
                 [[point["x"], point["y"]] for point in prediction["points"]], dtype=int
             )
-            mask = polygon_to_mask(
-                polygon, resolution_wh=(image_width, image_height))
+            mask = polygon_to_mask(polygon, resolution_wh=(image_width, image_height))
             xyxy.append([x_min, y_min, x_max, y_max])
             class_id.append(prediction["class_id"])
             class_name.append(prediction["class"])
@@ -562,12 +554,10 @@ def process_roboflow_result(
 
     xyxy = np.array(xyxy) if len(xyxy) > 0 else np.empty((0, 4))
     confidence = np.array(confidence) if len(confidence) > 0 else np.empty(0)
-    class_id = np.array(class_id).astype(
-        int) if len(class_id) > 0 else np.empty(0)
+    class_id = np.array(class_id).astype(int) if len(class_id) > 0 else np.empty(0)
     class_name = np.array(class_name) if len(class_name) > 0 else np.empty(0)
     masks = np.array(masks, dtype=bool) if len(masks) > 0 else None
-    tracker_id = np.array(tracker_ids).astype(
-        int) if len(tracker_ids) > 0 else None
+    tracker_id = np.array(tracker_ids).astype(int) if len(tracker_ids) > 0 else None
     data = {CLASS_NAME_DATA_FIELD: class_name}
 
     return xyxy, confidence, class_id, masks, tracker_id, data
@@ -660,10 +650,8 @@ def calculate_masks_centroids(masks: np.ndarray) -> np.ndarray:
         return np.tensordot(masks, indices, axes=axis)
 
     aggregation_axis = ([1, 2], [0, 1])
-    centroid_x = sum_over_mask(
-        horizontal_indices, aggregation_axis) / total_pixels
-    centroid_y = sum_over_mask(
-        vertical_indices, aggregation_axis) / total_pixels
+    centroid_x = sum_over_mask(horizontal_indices, aggregation_axis) / total_pixels
+    centroid_y = sum_over_mask(vertical_indices, aggregation_axis) / total_pixels
 
     return np.column_stack((centroid_x, centroid_y)).astype(int)
 
@@ -754,8 +742,7 @@ def merge_data(
             elif ndim > 1:
                 merged_data[key] = np.vstack(merged_data[key])
             else:
-                raise ValueError(
-                    f"Unexpected array dimension for key '{key}'.")
+                raise ValueError(f"Unexpected array dimension for key '{key}'.")
         else:
             raise ValueError(
                 f"Inconsistent data types for key '{key}'. Only np.ndarray and list "
@@ -800,7 +787,6 @@ def get_data_item(
             else:
                 raise TypeError(f"Unsupported index type: {type(index)}")
         else:
-            raise TypeError(
-                f"Unsupported data type for key '{key}': {type(value)}")
+            raise TypeError(f"Unsupported data type for key '{key}': {type(value)}")
 
     return subset_data

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -698,16 +698,18 @@ def merge_data(
                 "All data values within a single object must have equal length."
             )
 
-    data_keys = [set(data.keys()) for data in data_list]
-    data_keys = [key_set for key_set in data_keys if len(key_set) > 0]
-    if not data_keys:
+    keys_by_data = [set(data.keys()) for data in data_list]
+    keys_by_data = [keys for keys in keys_by_data if len(keys) > 0]
+    if not keys_by_data:
         return {}
 
-    common_keys = set.intersection(*data_keys)
-    all_keys = set.union(*data_keys)
+    common_keys = set.intersection(*keys_by_data)
+    all_keys = set.union(*keys_by_data)
     if common_keys != all_keys:
         raise ValueError(
-            f"All data dictionaries must have the same keys to merge. Found {data_keys}"
+            f"All sv.Detections.data dictionaries must have the same keys. Common "
+            f"keys: {common_keys}, but some dictionaries have additional keys: "
+            f"{all_keys.difference(common_keys)}."
         )
 
     merged_data = {key: [] for key in all_keys}

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -713,27 +713,10 @@ def merge_data(
     merged_data = {key: [] for key in all_keys}
     for data in data_list:
         for key in data:
-            if len(data[key]) == 0:
-                continue
             merged_data[key].append(data[key])
 
     for key in merged_data:
-        if len(merged_data[key]) == 0:
-            for data in data_list:
-                if key not in data:
-                    continue
-                data_type = type(data[key])
-                break
-            if data_type == np.ndarray:
-                merged_data[key] = np.array(merged_data[key])
-            elif data_type == list:
-                merged_data[key] = list(merged_data[key])
-            else:
-                raise ValueError(
-                    f"Inconsistent data types for key '{key}'. Only np.ndarray and list "
-                    f"types are allowed."
-                )
-        elif all(isinstance(item, list) for item in merged_data[key]):
+        if all(isinstance(item, list) for item in merged_data[key]):
             merged_data[key] = list(chain.from_iterable(merged_data[key]))
         elif all(isinstance(item, np.ndarray) for item in merged_data[key]):
             ndim = merged_data[key][0].ndim

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -678,7 +678,9 @@ def merge_data(
     Merges the data payloads of a list of Detections instances.
 
     Args:
-        data_list: The data payloads of the instances.
+        data_list: The data payloads of the Detections instances. Each data payload
+            is a dictionary with the same keys, and the values are either lists or
+            np.ndarray.
 
     Returns:
         A single data payload containing the merged data, preserving the original data

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -55,7 +55,8 @@ def box_iou_batch(boxes_true: np.ndarray, boxes_detection: np.ndarray) -> np.nda
     top_left = np.maximum(boxes_true[:, None, :2], boxes_detection[:, :2])
     bottom_right = np.minimum(boxes_true[:, None, 2:], boxes_detection[:, 2:])
 
-    area_inter = np.prod(np.clip(bottom_right - top_left, a_min=0, a_max=None), 2)
+    area_inter = np.prod(
+        np.clip(bottom_right - top_left, a_min=0, a_max=None), 2)
     return area_inter / (area_true[:, None] + area_detection - area_inter)
 
 
@@ -80,7 +81,8 @@ def _mask_iou_batch_split(
 
     masks_true_area = masks_true.sum(axis=(1, 2))
     masks_detection_area = masks_detection.sum(axis=(1, 2))
-    union_area = masks_true_area[:, None] + masks_detection_area - intersection_area
+    union_area = masks_true_area[:, None] + \
+        masks_detection_area - intersection_area
 
     return np.divide(
         intersection_area,
@@ -131,7 +133,8 @@ def mask_iou_batch(
         1,
     )
     for i in range(0, masks_true.shape[0], step):
-        ious.append(_mask_iou_batch_split(masks_true[i : i + step], masks_detection))
+        ious.append(_mask_iou_batch_split(
+            masks_true[i: i + step], masks_detection))
 
     return np.vstack(ious)
 
@@ -161,7 +164,8 @@ def resize_masks(masks: np.ndarray, max_dimension: int = 640) -> np.ndarray:
 
     resized_masks = masks[:, yv, xv]
 
-    resized_masks = resized_masks.reshape(masks.shape[0], new_height, new_width)
+    resized_masks = resized_masks.reshape(
+        masks.shape[0], new_height, new_width)
     return resized_masks
 
 
@@ -214,8 +218,9 @@ def mask_non_max_suppression(
     keep = np.ones(rows, dtype=bool)
     for i in range(rows):
         if keep[i]:
-            condition = (ious[i] > iou_threshold) & (categories[i] == categories)
-            keep[i + 1 :] = np.where(condition[i + 1 :], False, keep[i + 1 :])
+            condition = (ious[i] > iou_threshold) & (
+                categories[i] == categories)
+            keep[i + 1:] = np.where(condition[i + 1:], False, keep[i + 1:])
 
     return keep[sort_index.argsort()]
 
@@ -447,7 +452,8 @@ def approximate_polygon(
     approximated_points = polygon
     while True:
         epsilon += epsilon_step
-        new_approximated_points = cv2.approxPolyDP(polygon, epsilon, closed=True)
+        new_approximated_points = cv2.approxPolyDP(
+            polygon, epsilon, closed=True)
         if len(new_approximated_points) > target_points:
             approximated_points = new_approximated_points
         else:
@@ -476,7 +482,8 @@ def extract_ultralytics_masks(yolov8_results) -> Optional[np.ndarray]:
         )
 
     top, left = int(pad[1]), int(pad[0])
-    bottom, right = int(inference_shape[0] - pad[1]), int(inference_shape[1] - pad[0])
+    bottom, right = int(
+        inference_shape[0] - pad[1]), int(inference_shape[1] - pad[0])
 
     mask_maps = []
     masks = yolov8_results.masks.data.cpu().numpy()
@@ -543,7 +550,8 @@ def process_roboflow_result(
             polygon = np.array(
                 [[point["x"], point["y"]] for point in prediction["points"]], dtype=int
             )
-            mask = polygon_to_mask(polygon, resolution_wh=(image_width, image_height))
+            mask = polygon_to_mask(
+                polygon, resolution_wh=(image_width, image_height))
             xyxy.append([x_min, y_min, x_max, y_max])
             class_id.append(prediction["class_id"])
             class_name.append(prediction["class"])
@@ -554,10 +562,12 @@ def process_roboflow_result(
 
     xyxy = np.array(xyxy) if len(xyxy) > 0 else np.empty((0, 4))
     confidence = np.array(confidence) if len(confidence) > 0 else np.empty(0)
-    class_id = np.array(class_id).astype(int) if len(class_id) > 0 else np.empty(0)
+    class_id = np.array(class_id).astype(
+        int) if len(class_id) > 0 else np.empty(0)
     class_name = np.array(class_name) if len(class_name) > 0 else np.empty(0)
     masks = np.array(masks, dtype=bool) if len(masks) > 0 else None
-    tracker_id = np.array(tracker_ids).astype(int) if len(tracker_ids) > 0 else None
+    tracker_id = np.array(tracker_ids).astype(
+        int) if len(tracker_ids) > 0 else None
     data = {CLASS_NAME_DATA_FIELD: class_name}
 
     return xyxy, confidence, class_id, masks, tracker_id, data
@@ -650,8 +660,10 @@ def calculate_masks_centroids(masks: np.ndarray) -> np.ndarray:
         return np.tensordot(masks, indices, axes=axis)
 
     aggregation_axis = ([1, 2], [0, 1])
-    centroid_x = sum_over_mask(horizontal_indices, aggregation_axis) / total_pixels
-    centroid_y = sum_over_mask(vertical_indices, aggregation_axis) / total_pixels
+    centroid_x = sum_over_mask(
+        horizontal_indices, aggregation_axis) / total_pixels
+    centroid_y = sum_over_mask(
+        vertical_indices, aggregation_axis) / total_pixels
 
     return np.column_stack((centroid_x, centroid_y)).astype(int)
 
@@ -710,14 +722,6 @@ def merge_data(
             f"All data dictionaries must have the same keys to merge. Found {data_keys}"
         )
 
-    data_types = {}
-    for key in all_keys:
-        for data in data_list:
-            if key not in data:
-                continue
-            data_types[key] = type(data[key])
-            break
-
     merged_data = {key: [] for key in all_keys}
     for data in data_list:
         for key in data:
@@ -727,10 +731,20 @@ def merge_data(
 
     for key in merged_data:
         if len(merged_data[key]) == 0:
-            if data_types[key] == np.ndarray:
+            for data in data_list:
+                if key not in data:
+                    continue
+                data_type = type(data[key])
+                break
+            if data_type == np.ndarray:
                 merged_data[key] = np.array(merged_data[key])
-            else:
+            elif data_type == list:
                 merged_data[key] = list(merged_data[key])
+            else:
+                raise ValueError(
+                    f"Inconsistent data types for key '{key}'. Only np.ndarray and list "
+                    f"types are allowed."
+                )
         elif all(isinstance(item, list) for item in merged_data[key]):
             merged_data[key] = list(chain.from_iterable(merged_data[key]))
         elif all(isinstance(item, np.ndarray) for item in merged_data[key]):
@@ -740,7 +754,8 @@ def merge_data(
             elif ndim > 1:
                 merged_data[key] = np.vstack(merged_data[key])
             else:
-                raise ValueError(f"Unexpected array dimension for key '{key}'.")
+                raise ValueError(
+                    f"Unexpected array dimension for key '{key}'.")
         else:
             raise ValueError(
                 f"Inconsistent data types for key '{key}'. Only np.ndarray and list "
@@ -785,6 +800,7 @@ def get_data_item(
             else:
                 raise TypeError(f"Unsupported index type: {type(index)}")
         else:
-            raise TypeError(f"Unsupported data type for key '{key}': {type(value)}")
+            raise TypeError(
+                f"Unsupported data type for key '{key}': {type(value)}")
 
     return subset_data

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -33,73 +33,75 @@ DETECTIONS = Detections(
 # Merge test
 TEST_MASK = np.zeros((1000, 1000), dtype=bool)
 TEST_MASK[300:351, 200:251] = True
-TEST_DET_1 = mock_detections(
-    xyxy=[[10, 10, 20, 20], [30, 30, 40, 40], [50, 50, 60, 60]],
-    mask=[TEST_MASK, TEST_MASK, TEST_MASK],
-    confidence=[0.1, 0.2, 0.3],
-    class_id=[1, 2, 3],
-    tracker_id=[1, 2, 3],
+TEST_DET_1 = Detections(
+    xyxy=np.array([[10, 10, 20, 20], [30, 30, 40, 40], [50, 50, 60, 60]]),
+    mask=np.array([TEST_MASK, TEST_MASK, TEST_MASK]),
+    confidence=np.array([0.1, 0.2, 0.3]),
+    class_id=np.array([1, 2, 3]),
+    tracker_id=np.array([1, 2, 3]),
     data={
         "some_key": [1, 2, 3],
         "other_key": [["1", "2"], ["3", "4"], ["5", "6"]],
     },
 )
-TEST_DET_2 = mock_detections(
-    xyxy=[[70, 70, 80, 80], [90, 90, 100, 100]],
-    mask=[TEST_MASK, TEST_MASK],
-    confidence=[0.4, 0.5],
-    class_id=[4, 5],
-    tracker_id=[4, 5],
+TEST_DET_2 = Detections(
+    xyxy=np.array([[70, 70, 80, 80], [90, 90, 100, 100]]),
+    mask=np.array([TEST_MASK, TEST_MASK]),
+    confidence=np.array([0.4, 0.5]),
+    class_id=np.array([4, 5]),
+    tracker_id=np.array([4, 5]),
     data={
         "some_key": [4, 5],
         "other_key": [["7", "8"], ["9", "10"]],
     },
 )
-TEST_DET_1_2 = mock_detections(
-    xyxy=[
-        [10, 10, 20, 20],
-        [30, 30, 40, 40],
-        [50, 50, 60, 60],
-        [70, 70, 80, 80],
-        [90, 90, 100, 100],
-    ],
-    mask=[TEST_MASK, TEST_MASK, TEST_MASK, TEST_MASK, TEST_MASK],
-    confidence=[0.1, 0.2, 0.3, 0.4, 0.5],
-    class_id=[1, 2, 3, 4, 5],
-    tracker_id=[1, 2, 3, 4, 5],
+TEST_DET_1_2 = Detections(
+    xyxy=np.array(
+        [
+            [10, 10, 20, 20],
+            [30, 30, 40, 40],
+            [50, 50, 60, 60],
+            [70, 70, 80, 80],
+            [90, 90, 100, 100],
+        ]
+    ),
+    mask=np.array([TEST_MASK, TEST_MASK, TEST_MASK, TEST_MASK, TEST_MASK]),
+    confidence=np.array([0.1, 0.2, 0.3, 0.4, 0.5]),
+    class_id=np.array([1, 2, 3, 4, 5]),
+    tracker_id=np.array([1, 2, 3, 4, 5]),
     data={
         "some_key": [1, 2, 3, 4, 5],
         "other_key": [["1", "2"], ["3", "4"], ["5", "6"], ["7", "8"], ["9", "10"]],
     },
 )
-TEST_DET_ZERO_LENGTH = mock_detections(
+TEST_DET_ZERO_LENGTH = Detections(
     xyxy=np.empty((0, 4), dtype=np.float32),
     mask=np.empty((0, *TEST_MASK.shape), dtype=bool),
-    confidence=[],
-    class_id=[],
-    tracker_id=[],
+    confidence=np.empty((0,)),
+    class_id=np.empty((0,)),
+    tracker_id=np.empty((0,)),
     data={
         "some_key": [],
         "other_key": [],
     },
 )
-TEST_DET_NONE = mock_detections(
+TEST_DET_NONE = Detections(
     xyxy=np.empty((0, 4), dtype=np.float32),
 )
-TEST_DET_DIFFERENT_FIELDS = mock_detections(
-    xyxy=[[88, 88, 99, 99]],
-    mask=[np.logical_not(TEST_MASK)],
+TEST_DET_DIFFERENT_FIELDS = Detections(
+    xyxy=np.array([[88, 88, 99, 99]]),
+    mask=np.array([np.logical_not(TEST_MASK)]),
     confidence=None,
     class_id=None,
-    tracker_id=[9],
+    tracker_id=np.array([9]),
     data={"some_key": [9], "other_key": [["11", "12"]]},
 )
-TEST_DET_DIFFERENT_DATA = mock_detections(
-    xyxy=[[88, 88, 99, 99]],
-    mask=[np.logical_not(TEST_MASK)],
-    confidence=[0.9],
-    class_id=[9],
-    tracker_id=[9],
+TEST_DET_DIFFERENT_DATA = Detections(
+    xyxy=np.array([[88, 88, 99, 99]]),
+    mask=np.array([np.logical_not(TEST_MASK)]),
+    confidence=np.array([0.9]),
+    class_id=np.array([9]),
+    tracker_id=np.array([9]),
     data={
         "never_seen_key": [9],
     },

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -219,14 +219,17 @@ def test_getitem(
 @pytest.mark.parametrize(
     "detections_list, expected_result, exception",
     [
-        # Nothing
         ([], Detections.empty(), DoesNotRaise()),  # empty detections list
-        # Single
         (
             [Detections.empty()],
             Detections.empty(),
             DoesNotRaise(),
         ),  # single empty detections
+        (
+            [Detections.empty(), Detections.empty()],
+            Detections.empty(),
+            DoesNotRaise(),
+        ),  # two empty detections
         (
             [TEST_DET_1],
             TEST_DET_1,
@@ -237,12 +240,6 @@ def test_getitem(
             TEST_DET_NONE,
             DoesNotRaise(),
         ),  # Single weakly-defined detection
-        # Similar
-        (
-            [Detections.empty(), Detections.empty()],
-            Detections.empty(),
-            DoesNotRaise(),
-        ),  # Two empty
         (
             [TEST_DET_1, TEST_DET_2],
             TEST_DET_1_2,

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -42,7 +42,7 @@ TEST_DET_1 = mock_detections(
     data={
         "some_key": [1, 2, 3],
         "other_key": [["1", "2"], ["3", "4"], ["5", "6"]],
-    }
+    },
 )
 TEST_DET_2 = mock_detections(
     xyxy=[[70, 70, 80, 80], [90, 90, 100, 100]],
@@ -53,11 +53,16 @@ TEST_DET_2 = mock_detections(
     data={
         "some_key": [4, 5],
         "other_key": [["7", "8"], ["9", "10"]],
-    }
+    },
 )
 TEST_DET_1_2 = mock_detections(
-    xyxy=[[10, 10, 20, 20], [30, 30, 40, 40], [
-        50, 50, 60, 60], [70, 70, 80, 80], [90, 90, 100, 100]],
+    xyxy=[
+        [10, 10, 20, 20],
+        [30, 30, 40, 40],
+        [50, 50, 60, 60],
+        [70, 70, 80, 80],
+        [90, 90, 100, 100],
+    ],
     mask=[TEST_MASK, TEST_MASK, TEST_MASK, TEST_MASK, TEST_MASK],
     confidence=[0.1, 0.2, 0.3, 0.4, 0.5],
     class_id=[1, 2, 3, 4, 5],
@@ -65,7 +70,7 @@ TEST_DET_1_2 = mock_detections(
     data={
         "some_key": [1, 2, 3, 4, 5],
         "other_key": [["1", "2"], ["3", "4"], ["5", "6"], ["7", "8"], ["9", "10"]],
-    }
+    },
 )
 TEST_DET_ZERO_LENGTH = mock_detections(
     xyxy=np.empty((0, 4), dtype=np.float32),
@@ -76,7 +81,7 @@ TEST_DET_ZERO_LENGTH = mock_detections(
     data={
         "some_key": [],
         "other_key": [],
-    }
+    },
 )
 TEST_DET_NONE = mock_detections(
     xyxy=np.empty((0, 4), dtype=np.float32),
@@ -87,10 +92,7 @@ TEST_DET_DIFFERENT_FIELDS = mock_detections(
     confidence=None,
     class_id=None,
     tracker_id=[9],
-    data={
-        "some_key": [9],
-        "other_key": [["11", "12"]]
-    }
+    data={"some_key": [9], "other_key": [["11", "12"]]},
 )
 TEST_DET_DIFFERENT_DATA = mock_detections(
     xyxy=[[88, 88, 99, 99]],
@@ -100,11 +102,11 @@ TEST_DET_DIFFERENT_DATA = mock_detections(
     tracker_id=[9],
     data={
         "never_seen_key": [9],
-    }
+    },
 )
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "detections, index, expected_result, exception",
     [
         (
@@ -189,8 +191,7 @@ TEST_DET_DIFFERENT_DATA = mock_detections(
             DoesNotRaise(),
         ),  # take only first detection by index slice (1, 3)
         (DETECTIONS, 10, None, pytest.raises(IndexError)),  # index out of range
-        (DETECTIONS, [0, 2, 10], None, pytest.raises(
-            IndexError)),  # index out of range
+        (DETECTIONS, [0, 2, 10], None, pytest.raises(IndexError)),  # index out of range
         (DETECTIONS, np.array([0, 2, 10]), None, pytest.raises(IndexError)),
         (
             DETECTIONS,
@@ -213,12 +214,11 @@ def test_getitem(
         assert result == expected_result
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "detections_list, expected_result, exception",
     [
         # Nothing
         ([], Detections.empty(), DoesNotRaise()),  # empty detections list
-
         # Single
         (
             [Detections.empty()],
@@ -235,7 +235,6 @@ def test_getitem(
             TEST_DET_NONE,
             DoesNotRaise(),
         ),  # Single weakly-defined detection
-
         # Similar
         (
             [Detections.empty(), Detections.empty()],
@@ -247,13 +246,9 @@ def test_getitem(
             TEST_DET_1_2,
             DoesNotRaise(),
         ),  # Fields with same keys
-
         # Fields and empty
         (
-            [
-                TEST_DET_1,
-                Detections.empty()
-            ],
+            [TEST_DET_1, Detections.empty()],
             TEST_DET_1,
             DoesNotRaise(),
         ),  # single detection with fields
@@ -273,19 +268,18 @@ def test_getitem(
             TEST_DET_1,
             DoesNotRaise(),
         ),  # Single detection and None fields (+ missing Dict keys)
-
         # Errors: Non-zero-length differently defined keys & data
         (
             [TEST_DET_1, TEST_DET_DIFFERENT_FIELDS],
             None,
-            pytest.raises(ValueError)
+            pytest.raises(ValueError),
         ),  # Non-empty detections with different fields
         (
             [TEST_DET_1, TEST_DET_DIFFERENT_DATA],
             None,
             pytest.raises(ValueError),
         ),  # Non-empty detections with different data keys
-    ]
+    ],
 )
 def test_merge(
     detections_list: List[Detections],
@@ -297,7 +291,7 @@ def test_merge(
         assert result == expected_result
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "detections, anchor, expected_result, exception",
     [
         (
@@ -379,7 +373,7 @@ def test_get_anchor_coordinates(
         assert np.array_equal(result, expected_result)
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "detections_a, detections_b, expected_result",
     [
         (

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -1029,26 +1029,17 @@ def test_calculate_masks_centroids(
             pytest.raises(ValueError),
         ),  # two data dicts with the same field name and different length arrays values
         (
-            [
-                {},
-                {"test_1": [1, 2, 3]}
-            ],
+            [{}, {"test_1": [1, 2, 3]}],
             {"test_1": [1, 2, 3]},
             DoesNotRaise(),
         ),  # two data dicts; one empty and one non-empty dict
         (
-            [
-                {"test_1": [], "test_2": []},
-                {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}
-            ],
+            [{"test_1": [], "test_2": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],
             {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
             DoesNotRaise(),
         ),  # two data dicts; one empty and one non-empty dict; same keys
         (
-            [
-                {"test_1": []},
-                {"test_1": [1, 2, 3], "test_2": [4, 5, 6]}
-            ],
+            [{"test_1": []}, {"test_1": [1, 2, 3], "test_2": [4, 5, 6]}],
             None,
             pytest.raises(ValueError),
         ),  # two data dicts; one empty and one non-empty dict; different keys
@@ -1059,10 +1050,7 @@ def test_calculate_masks_centroids(
                     "test_2": [4, 5, 6],
                     "test_3": [7, 8, 9],
                 },
-                {
-                    "test_1": [1, 2, 3],
-                    "test_2": [4, 5, 6]
-                },
+                {"test_1": [1, 2, 3], "test_2": [4, 5, 6]},
             ],
             None,
             pytest.raises(ValueError),
@@ -1077,8 +1065,8 @@ def test_calculate_masks_centroids(
         ),  # some keys missing in one dict
         (
             [
-                {"test_1": [1, 2, 3], "test_2": ['a', 'b']},
-                {"test_1": [4, 5], "test_2": ['c', 'd', 'e']},
+                {"test_1": [1, 2, 3], "test_2": ["a", "b"]},
+                {"test_1": [4, 5], "test_2": ["c", "d", "e"]},
             ],
             None,
             pytest.raises(ValueError),

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -1012,6 +1012,29 @@ def test_calculate_masks_centroids(
             None,
             pytest.raises(ValueError),
         ),  # two data dicts with the same field name and different length arrays values
+        (
+            [{}, {"test_1": [1, 2, 3]}],
+            {"test_1": [1, 2, 3]},
+            DoesNotRaise(),
+        ),  # No keys in one dict
+        (
+            [{"test_1": [], "test_2": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],
+            {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
+            DoesNotRaise(),
+        ),  # Empty values dicts
+        (
+            [{"test_1": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],
+            {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
+            DoesNotRaise(),
+        ),  # Mix of missing key and empty values
+        (
+            [
+                {"test_1": [1, 2, 3]},
+                {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
+            ],
+            None,
+            pytest.raises(ValueError),
+        ),  # some keys missing in one dict
     ],
 )
 def test_merge_data(

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -1016,17 +1016,29 @@ def test_calculate_masks_centroids(
             [{}, {"test_1": [1, 2, 3]}],
             {"test_1": [1, 2, 3]},
             DoesNotRaise(),
-        ),  # No keys in one dict
+        ),  # Empty, no keys
         (
             [{"test_1": [], "test_2": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],
             {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
             DoesNotRaise(),
-        ),  # Empty values dicts
+        ),  # Empty, same keys
         (
-            [{"test_1": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],
-            {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
-            DoesNotRaise(),
-        ),  # Mix of missing key and empty values
+            [{"test_1": []}, {"test_1": [1, 2, 3], "test_2": [4, 5, 6]}],
+            None,
+            pytest.raises(ValueError),
+        ),  # Empty, missing key
+        (
+            [
+                {
+                    "test_1": [1, 2, 3],
+                    "test_2": [4, 5, 6],
+                    "test_3": [7, 8, 9],
+                },
+                {"test_1": [1, 2, 3], "test_2": [4, 5, 6]},
+            ],
+            None,
+            pytest.raises(ValueError),
+        ),  # Empty, too many keys
         (
             [
                 {"test_1": [1, 2, 3]},
@@ -1044,6 +1056,9 @@ def test_merge_data(
 ):
     with exception:
         result = merge_data(data_list=data_list)
+        if expected_result is None:
+            assert False, f"Expected an error, but got result {result}"
+
         for key in result:
             if isinstance(result[key], np.ndarray):
                 assert np.array_equal(

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -913,11 +913,27 @@ def test_calculate_masks_centroids(
         ),  # single data dict with a single field name and empty list values
         (
             [
+                {"test_1": []},
+                {"test_1": []},
+            ],
+            {"test_1": []},
+            DoesNotRaise(),
+        ),  # two data dicts with the same field name and empty list values
+        (
+            [
                 {"test_1": np.array([])},
             ],
             {"test_1": np.array([])},
             DoesNotRaise(),
         ),  # single data dict with a single field name and empty np.array values
+        (
+            [
+                {"test_1": np.array([])},
+                {"test_1": np.array([])},
+            ],
+            {"test_1": np.array([])},
+            DoesNotRaise(),
+        ),  # two data dicts with the same field name and empty np.array values
         (
             [
                 {"test_1": [1, 2, 3]},
@@ -932,7 +948,7 @@ def test_calculate_masks_centroids(
             ],
             {"test_1": [3, 2, 1]},
             DoesNotRaise(),
-        ),  # two data dicts with the same field name and empty and list values
+        ),  # two data dicts with the same field name; one of with empty list as value
         (
             [
                 {"test_1": [1, 2, 3]},
@@ -1013,20 +1029,29 @@ def test_calculate_masks_centroids(
             pytest.raises(ValueError),
         ),  # two data dicts with the same field name and different length arrays values
         (
-            [{}, {"test_1": [1, 2, 3]}],
+            [
+                {},
+                {"test_1": [1, 2, 3]}
+            ],
             {"test_1": [1, 2, 3]},
             DoesNotRaise(),
-        ),  # Empty, no keys
+        ),  # two data dicts; one empty and one non-empty dict
         (
-            [{"test_1": [], "test_2": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],
+            [
+                {"test_1": [], "test_2": []},
+                {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}
+            ],
             {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
             DoesNotRaise(),
-        ),  # Empty, same keys
+        ),  # two data dicts; one empty and one non-empty dict; same keys
         (
-            [{"test_1": []}, {"test_1": [1, 2, 3], "test_2": [4, 5, 6]}],
+            [
+                {"test_1": []},
+                {"test_1": [1, 2, 3], "test_2": [4, 5, 6]}
+            ],
             None,
             pytest.raises(ValueError),
-        ),  # Empty, missing key
+        ),  # two data dicts; one empty and one non-empty dict; different keys
         (
             [
                 {
@@ -1034,11 +1059,14 @@ def test_calculate_masks_centroids(
                     "test_2": [4, 5, 6],
                     "test_3": [7, 8, 9],
                 },
-                {"test_1": [1, 2, 3], "test_2": [4, 5, 6]},
+                {
+                    "test_1": [1, 2, 3],
+                    "test_2": [4, 5, 6]
+                },
             ],
             None,
             pytest.raises(ValueError),
-        ),  # Empty, too many keys
+        ),  # two data dicts; one with three keys, one with two keys
         (
             [
                 {"test_1": [1, 2, 3]},
@@ -1047,6 +1075,14 @@ def test_calculate_masks_centroids(
             None,
             pytest.raises(ValueError),
         ),  # some keys missing in one dict
+        (
+            [
+                {"test_1": [1, 2, 3], "test_2": ['a', 'b']},
+                {"test_1": [4, 5], "test_2": ['c', 'd', 'e']},
+            ],
+            None,
+            pytest.raises(ValueError),
+        ),  # different value lengths for the same key
     ],
 )
 def test_merge_data(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -21,11 +21,14 @@ def mock_detections(
         xyxy=np.array(xyxy, dtype=np.float32),
         mask=(mask if mask is None else np.array(mask, dtype=bool)),
         confidence=(
-            confidence if confidence is None else np.array(confidence, dtype=np.float32)
+            confidence if confidence is None else np.array(
+                confidence, dtype=np.float32)
         ),
-        class_id=(class_id if class_id is None else np.array(class_id, dtype=int)),
+        class_id=(class_id if class_id is None else np.array(
+            class_id, dtype=int)),
         tracker_id=(
-            tracker_id if tracker_id is None else np.array(tracker_id, dtype=int)
+            tracker_id if tracker_id is None else np.array(
+                tracker_id, dtype=int)
         ),
         data=convert_data(data) if data else {},
     )
@@ -43,12 +46,15 @@ def mock_keypoints(
     return KeyPoints(
         xy=np.array(xy, dtype=np.float32),
         confidence=(
-            confidence if confidence is None else np.array(confidence, dtype=np.float32)
+            confidence if confidence is None else np.array(
+                confidence, dtype=np.float32)
         ),
-        class_id=(class_id if class_id is None else np.array(class_id, dtype=int)),
+        class_id=(class_id if class_id is None else np.array(
+            class_id, dtype=int)),
         data=convert_data(data) if data else {},
     )
 
 
 def assert_almost_equal(actual, expected, tolerance=1e-5):
-    assert abs(actual - expected) < tolerance, f"Expected {expected}, but got {actual}."
+    assert abs(
+        actual - expected) < tolerance, f"Expected {expected}, but got {actual}."

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -21,14 +21,11 @@ def mock_detections(
         xyxy=np.array(xyxy, dtype=np.float32),
         mask=(mask if mask is None else np.array(mask, dtype=bool)),
         confidence=(
-            confidence if confidence is None else np.array(
-                confidence, dtype=np.float32)
+            confidence if confidence is None else np.array(confidence, dtype=np.float32)
         ),
-        class_id=(class_id if class_id is None else np.array(
-            class_id, dtype=int)),
+        class_id=(class_id if class_id is None else np.array(class_id, dtype=int)),
         tracker_id=(
-            tracker_id if tracker_id is None else np.array(
-                tracker_id, dtype=int)
+            tracker_id if tracker_id is None else np.array(tracker_id, dtype=int)
         ),
         data=convert_data(data) if data else {},
     )
@@ -46,15 +43,12 @@ def mock_keypoints(
     return KeyPoints(
         xy=np.array(xy, dtype=np.float32),
         confidence=(
-            confidence if confidence is None else np.array(
-                confidence, dtype=np.float32)
+            confidence if confidence is None else np.array(confidence, dtype=np.float32)
         ),
-        class_id=(class_id if class_id is None else np.array(
-            class_id, dtype=int)),
+        class_id=(class_id if class_id is None else np.array(class_id, dtype=int)),
         data=convert_data(data) if data else {},
     )
 
 
 def assert_almost_equal(actual, expected, tolerance=1e-5):
-    assert abs(
-        actual - expected) < tolerance, f"Expected {expected}, but got {actual}."
+    assert abs(actual - expected) < tolerance, f"Expected {expected}, but got {actual}."


### PR DESCRIPTION
# Description

* `Detections.merge` now merges detections when some of them are `None` or empty.
* Missing keys in `data` should not be an issue, unless further detections containing new data in those.
* Expanded tests with the new behaviour.

See the tests to see expected behaviour.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

:notebook:  [Google Colab](https://colab.research.google.com/drive/1PQ3j_5hAbuh4ivHEsQV8sxKvIVDGK7j7?usp=sharing)
* (Slicer with segmentation model still fails, but with a different error)
* Roboflow model (with `data` is now merged with `Detections.empty` successfully).
* Multiple new tests were written - all pass.

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes:
