### PR TITLE
Feat/inference slicer segmentation

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -831,9 +831,10 @@ class Detections:
 
         This method takes a list of Detections objects and combines their
         respective fields (`xyxy`, `mask`, `confidence`, `class_id`, and `tracker_id`)
-        into a single Detections object. If all elements in a field are not
-        `None`, the corresponding field will be stacked.
-        Otherwise, the field will be set to `None`.
+        into a single Detections object.
+
+        For example, if merging Detections with 3 and 4 detected objects, this method
+        will return a Detections with 7 objects (7 entries in `xyxy`, `mask`, etc).
 
         Args:
             detections_list (List[Detections]): A list of Detections objects to merge.
@@ -891,13 +892,12 @@ class Detections:
         def stack_or_none(name: str):
             if all(d.__getattribute__(name) is None for d in detections_list):
                 return None
-            if any(d.__getattribute__(name) is None for d in detections_list):
-                raise ValueError(f"All or none of the '{name}' fields must be None")
-            return (
-                np.vstack([d.__getattribute__(name) for d in detections_list])
-                if name == "mask"
-                else np.hstack([d.__getattribute__(name) for d in detections_list])
-            )
+            stack_list = [
+                d.__getattribute__(name)
+                for d in detections_list
+                if d.__getattribute__(name) is not None
+            ]
+            return np.vstack(stack_list) if name == "mask" else np.hstack(stack_list)
 
         mask = stack_or_none("mask")
         confidence = stack_or_none("confidence")

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -592,6 +592,46 @@ def move_boxes(xyxy: np.ndarray, offset: np.ndarray) -> np.ndarray:
     return xyxy + np.hstack([offset, offset])
 
 
+def move_masks(
+    masks: np.ndarray, offset: np.ndarray, desired_shape: Optional[np.ndarray] = None
+) -> np.ndarray:
+    """
+    Offset the masks in an array by the specified (x, y) amount.
+
+    Note the axis orders:
+
+    - `masks`: array of shape `(n, y, x)`
+    - `offset`: array of ints: `(x, y)`
+    - `desired_shape`: array of ints `(x, y)`
+
+    Args:
+        masks (np.ndarray): array of bools
+        offset (np.ndarray): An array of shape `(2,)` containing non-negative int values
+            `[dx, dy]`.
+        desired_shape (Tuple[int, int], optional): Final shape of the mask in the format
+            `(width, height)`. If provided, the masks will be padded to match this
+            shape. Note the axis order (x,y)!
+
+    Returns:
+        (np.ndarray) repositioned masks, optionally padded to the specified shape.
+    """
+    if offset[0] < 0 or offset[1] < 0:
+        raise ValueError(f"Offset values must be non-negative integers. Got: {offset}")
+
+    size_x, size_y = masks.shape[1:] + offset[::-1]
+    if desired_shape is not None:
+        size_x, size_y = desired_shape
+
+    mask_arr = np.full((masks.shape[0], size_y, size_x), False)
+    mask_arr[
+        :,
+        offset[1] : masks.shape[1] + offset[1],
+        offset[0] : masks.shape[2] + offset[0],
+    ] = masks
+
+    return mask_arr
+
+
 def scale_boxes(xyxy: np.ndarray, factor: float) -> np.ndarray:
     """
     Scale the dimensions of bounding boxes.

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -42,7 +42,7 @@ TEST_DET_1 = mock_detections(
     data={
         "some_key": [1, 2, 3],
         "other_key": [["1", "2"], ["3", "4"], ["5", "6"]],
-    }
+    },
 )
 TEST_DET_2 = mock_detections(
     xyxy=[[70, 70, 80, 80], [90, 90, 100, 100]],
@@ -53,11 +53,16 @@ TEST_DET_2 = mock_detections(
     data={
         "some_key": [4, 5],
         "other_key": [["7", "8"], ["9", "10"]],
-    }
+    },
 )
 TEST_DET_1_2 = mock_detections(
-    xyxy=[[10, 10, 20, 20], [30, 30, 40, 40], [
-        50, 50, 60, 60], [70, 70, 80, 80], [90, 90, 100, 100]],
+    xyxy=[
+        [10, 10, 20, 20],
+        [30, 30, 40, 40],
+        [50, 50, 60, 60],
+        [70, 70, 80, 80],
+        [90, 90, 100, 100],
+    ],
     mask=[TEST_MASK, TEST_MASK, TEST_MASK, TEST_MASK, TEST_MASK],
     confidence=[0.1, 0.2, 0.3, 0.4, 0.5],
     class_id=[1, 2, 3, 4, 5],
@@ -65,7 +70,7 @@ TEST_DET_1_2 = mock_detections(
     data={
         "some_key": [1, 2, 3, 4, 5],
         "other_key": [["1", "2"], ["3", "4"], ["5", "6"], ["7", "8"], ["9", "10"]],
-    }
+    },
 )
 TEST_DET_ZERO_LENGTH = mock_detections(
     xyxy=np.empty((0, 4), dtype=np.float32),
@@ -76,7 +81,7 @@ TEST_DET_ZERO_LENGTH = mock_detections(
     data={
         "some_key": [],
         "other_key": [],
-    }
+    },
 )
 TEST_DET_NONE = mock_detections(
     xyxy=np.empty((0, 4), dtype=np.float32),
@@ -87,10 +92,7 @@ TEST_DET_DIFFERENT_FIELDS = mock_detections(
     confidence=None,
     class_id=None,
     tracker_id=[9],
-    data={
-        "some_key": [9],
-        "other_key": [["11", "12"]]
-    }
+    data={"some_key": [9], "other_key": [["11", "12"]]},
 )
 TEST_DET_DIFFERENT_DATA = mock_detections(
     xyxy=[[88, 88, 99, 99]],
@@ -100,11 +102,11 @@ TEST_DET_DIFFERENT_DATA = mock_detections(
     tracker_id=[9],
     data={
         "never_seen_key": [9],
-    }
+    },
 )
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "detections, index, expected_result, exception",
     [
         (
@@ -189,8 +191,7 @@ TEST_DET_DIFFERENT_DATA = mock_detections(
             DoesNotRaise(),
         ),  # take only first detection by index slice (1, 3)
         (DETECTIONS, 10, None, pytest.raises(IndexError)),  # index out of range
-        (DETECTIONS, [0, 2, 10], None, pytest.raises(
-            IndexError)),  # index out of range
+        (DETECTIONS, [0, 2, 10], None, pytest.raises(IndexError)),  # index out of range
         (DETECTIONS, np.array([0, 2, 10]), None, pytest.raises(IndexError)),
         (
             DETECTIONS,
@@ -213,12 +214,11 @@ def test_getitem(
         assert result == expected_result
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "detections_list, expected_result, exception",
     [
         # Nothing
         ([], Detections.empty(), DoesNotRaise()),  # empty detections list
-
         # Single
         (
             [Detections.empty()],
@@ -235,7 +235,6 @@ def test_getitem(
             TEST_DET_NONE,
             DoesNotRaise(),
         ),  # Single weakly-defined detection
-
         # Similar
         (
             [Detections.empty(), Detections.empty()],
@@ -247,13 +246,9 @@ def test_getitem(
             TEST_DET_1_2,
             DoesNotRaise(),
         ),  # Fields with same keys
-
         # Fields and empty
         (
-            [
-                TEST_DET_1,
-                Detections.empty()
-            ],
+            [TEST_DET_1, Detections.empty()],
             TEST_DET_1,
             DoesNotRaise(),
         ),  # single detection with fields
@@ -273,19 +268,18 @@ def test_getitem(
             TEST_DET_1,
             DoesNotRaise(),
         ),  # Single detection and None fields (+ missing Dict keys)
-
         # Errors: Non-zero-length differently defined keys & data
         (
             [TEST_DET_1, TEST_DET_DIFFERENT_FIELDS],
             None,
-            pytest.raises(ValueError)
+            pytest.raises(ValueError),
         ),  # Non-empty detections with different fields
         (
             [TEST_DET_1, TEST_DET_DIFFERENT_DATA],
             None,
             pytest.raises(ValueError),
         ),  # Non-empty detections with different data keys
-    ]
+    ],
 )
 def test_merge(
     detections_list: List[Detections],
@@ -297,7 +291,7 @@ def test_merge(
         assert result == expected_result
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "detections, anchor, expected_result, exception",
     [
         (
@@ -379,7 +373,7 @@ def test_get_anchor_coordinates(
         assert np.array_equal(result, expected_result)
 
 
-@ pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "detections_a, detections_b, expected_result",
     [
         (

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -1012,6 +1012,29 @@ def test_calculate_masks_centroids(
             None,
             pytest.raises(ValueError),
         ),  # two data dicts with the same field name and different length arrays values
+        (
+            [{}, {"test_1": [1, 2, 3]}],
+            {"test_1": [1, 2, 3]},
+            DoesNotRaise(),
+        ),  # No keys in one dict
+        (
+            [{"test_1": [], "test_2": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],
+            {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
+            DoesNotRaise(),
+        ),  # Empty values dicts
+        (
+            [{"test_1": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],
+            {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
+            DoesNotRaise(),
+        ),  # Mix of missing key and empty values
+        (
+            [
+                {"test_1": [1, 2, 3]},
+                {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
+            ],
+            None,
+            pytest.raises(ValueError),
+        ),  # some keys missing in one dict
     ],
 )
 def test_merge_data(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -21,11 +21,14 @@ def mock_detections(
         xyxy=np.array(xyxy, dtype=np.float32),
         mask=(mask if mask is None else np.array(mask, dtype=bool)),
         confidence=(
-            confidence if confidence is None else np.array(confidence, dtype=np.float32)
+            confidence if confidence is None else np.array(
+                confidence, dtype=np.float32)
         ),
-        class_id=(class_id if class_id is None else np.array(class_id, dtype=int)),
+        class_id=(class_id if class_id is None else np.array(
+            class_id, dtype=int)),
         tracker_id=(
-            tracker_id if tracker_id is None else np.array(tracker_id, dtype=int)
+            tracker_id if tracker_id is None else np.array(
+                tracker_id, dtype=int)
         ),
         data=convert_data(data) if data else {},
     )
@@ -43,12 +46,15 @@ def mock_keypoints(
     return KeyPoints(
         xy=np.array(xy, dtype=np.float32),
         confidence=(
-            confidence if confidence is None else np.array(confidence, dtype=np.float32)
+            confidence if confidence is None else np.array(
+                confidence, dtype=np.float32)
         ),
-        class_id=(class_id if class_id is None else np.array(class_id, dtype=int)),
+        class_id=(class_id if class_id is None else np.array(
+            class_id, dtype=int)),
         data=convert_data(data) if data else {},
     )
 
 
 def assert_almost_equal(actual, expected, tolerance=1e-5):
-    assert abs(actual - expected) < tolerance, f"Expected {expected}, but got {actual}."
+    assert abs(
+        actual - expected) < tolerance, f"Expected {expected}, but got {actual}."

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -21,14 +21,11 @@ def mock_detections(
         xyxy=np.array(xyxy, dtype=np.float32),
         mask=(mask if mask is None else np.array(mask, dtype=bool)),
         confidence=(
-            confidence if confidence is None else np.array(
-                confidence, dtype=np.float32)
+            confidence if confidence is None else np.array(confidence, dtype=np.float32)
         ),
-        class_id=(class_id if class_id is None else np.array(
-            class_id, dtype=int)),
+        class_id=(class_id if class_id is None else np.array(class_id, dtype=int)),
         tracker_id=(
-            tracker_id if tracker_id is None else np.array(
-                tracker_id, dtype=int)
+            tracker_id if tracker_id is None else np.array(tracker_id, dtype=int)
         ),
         data=convert_data(data) if data else {},
     )
@@ -46,15 +43,12 @@ def mock_keypoints(
     return KeyPoints(
         xy=np.array(xy, dtype=np.float32),
         confidence=(
-            confidence if confidence is None else np.array(
-                confidence, dtype=np.float32)
+            confidence if confidence is None else np.array(confidence, dtype=np.float32)
         ),
-        class_id=(class_id if class_id is None else np.array(
-            class_id, dtype=int)),
+        class_id=(class_id if class_id is None else np.array(class_id, dtype=int)),
         data=convert_data(data) if data else {},
     )
 
 
 def assert_almost_equal(actual, expected, tolerance=1e-5):
-    assert abs(
-        actual - expected) < tolerance, f"Expected {expected}, but got {actual}."
+    assert abs(actual - expected) < tolerance, f"Expected {expected}, but got {actual}."


### PR DESCRIPTION
# Description

Prerequisites:
* #1177

This allows the slicer to merge segmentation masks.

Previously it would fail when attempting to stack slices of different sizes, as there'd be no attempts to move & pad the slices. The result is that each mask would be of size(slice), rather than size(image).

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Same notebook as for prior PR.
:notebook: [Google Colab](https://colab.research.google.com/drive/1PQ3j_5hAbuh4ivHEsQV8sxKvIVDGK7j7#scrollTo=SCTstIHfAhD7)

## Any specific deployment considerations

1. Non-max suppression wrecks the visuals for large images. Best way to test would be to merge the PRs adding Non-max merging & slicer filter selector, and then test with `NONE`.
2. It takes a lot of RAM and time, even for a small model. High-RAM env in Colab is needed.

## Docs

-   [ ] Docs updated? What were the changes:
