### PR TITLE
Fix Cost Matrix containing NaN Values in ByteTrack

### DIFF
--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -56,7 +56,9 @@ def box_iou_batch(boxes_true: np.ndarray, boxes_detection: np.ndarray) -> np.nda
     bottom_right = np.minimum(boxes_true[:, None, 2:], boxes_detection[:, 2:])
 
     area_inter = np.prod(np.clip(bottom_right - top_left, a_min=0, a_max=None), 2)
-    return area_inter / (area_true[:, None] + area_detection - area_inter)
+    ious = area_inter / (area_true[:, None] + area_detection - area_inter)
+    ious = np.nan_to_num(ious)
+    return ious
 
 
 def _mask_iou_batch_split(

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -362,13 +362,6 @@ class ByteTrack:
         scores = tensors[:, 4]
         bboxes = tensors[:, :4]
 
-        bbox_areas = (bboxes[:, 2] - bboxes[:, 0]) * (bboxes[:, 3] - bboxes[:, 1])
-        valid_box_inds = bbox_areas > 0
-
-        class_ids = class_ids[valid_box_inds]
-        scores = scores[valid_box_inds]
-        bboxes = bboxes[valid_box_inds]
-
         remain_inds = scores > self.track_activation_threshold
         inds_low = scores > 0.1
         inds_high = scores < self.track_activation_threshold

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -362,6 +362,13 @@ class ByteTrack:
         scores = tensors[:, 4]
         bboxes = tensors[:, :4]
 
+        bbox_areas = (bboxes[:, 2] - bboxes[:, 0]) * (bboxes[:, 3] - bboxes[:, 1])
+        valid_box_inds = bbox_areas > 0
+
+        class_ids = class_ids[valid_box_inds]
+        scores = scores[valid_box_inds]
+        bboxes = bboxes[valid_box_inds]
+
         remain_inds = scores > self.track_activation_threshold
         inds_low = scores > 0.1
         inds_high = scores < self.track_activation_threshold


### PR DESCRIPTION
# Description

This change fixes issue #458. The object tracker was not able to handle detections that had a bounding box area of zero. I fixed this by filtering out the bounding boxes that have an area of zero in `update_with_tensors()`. 

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested this change by deliberately sending boxes with an area of 0 into the tracker. The tracker was able to handle this by simply ignoring those detections. [Colab notebook](https://colab.research.google.com/drive/1qDtagBbfLHVE8G-VhgBCOiK9H-GTP8c4?usp=sharing) with test code.
