### PR TITLE
Missing return in another slicer callback

### DIFF
--- a/docs/how_to/detect_small_objects.md
+++ b/docs/how_to/detect_small_objects.md
@@ -282,7 +282,7 @@ objects within each, and aggregating the results.
 
     def callback(image_slice: np.ndarray) -> sv.Detections:
         results = model.infer(image_slice)[0]
-        detections = sv.Detections.from_inference(results)
+        return sv.Detections.from_inference(results)
 
     slicer = sv.InferenceSlicer(callback = callback)
     detections = slicer(image)


### PR DESCRIPTION
# Description

Updated docs that did not include a `return` in a slicer callback.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

## Any specific deployment considerations

## Docs

-   [x] Docs updated? What were the changes:
