### PR TITLE
docs: calculate_optimal_text_scale, not calculate_optimal_font_scale

### DIFF
--- a/docs/utils/draw.md
+++ b/docs/utils/draw.md
@@ -41,7 +41,7 @@ comments: true
 :::supervision.draw.utils.draw_image
 
 <div class="md-typeset">
-    <h2><a href="#supervision.draw.utils.calculate_optimal_font_scale">calculate_optimal_font_scale</a></h2>
+    <h2><a href="#supervision.draw.utils.calculate_optimal_text_scale">calculate_optimal_text_scale</a></h2>
 </div>
 
 :::supervision.draw.utils.calculate_optimal_text_scale


### PR DESCRIPTION
`calculate_optimal_font_scale` does not exist.

# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

## Any specific deployment considerations

## Docs

-   [x] Docs updated? What were the changes:

```
<div class="md-typeset">
    <h2><a href="#supervision.draw.utils.calculate_optimal_text_scale">calculate_optimal_text_scale</a></h2>
</div>
```
