### PR TITLE
Optimize line zone and add unit tests

### DIFF
--- a/supervision/detection/line_zone.py
+++ b/supervision/detection/line_zone.py
@@ -53,16 +53,17 @@ class LineZone:
         # 7, 2
         ```
     """  # noqa: E501 // docs
+
     def __init__(
-            self,
-            start: Point,
-            end: Point,
-            triggering_anchors: Iterable[Position] = (
-                    Position.TOP_LEFT,
-                    Position.TOP_RIGHT,
-                    Position.BOTTOM_LEFT,
-                    Position.BOTTOM_RIGHT,
-            ),
+        self,
+        start: Point,
+        end: Point,
+        triggering_anchors: Iterable[Position] = (
+            Position.TOP_LEFT,
+            Position.TOP_RIGHT,
+            Position.BOTTOM_LEFT,
+            Position.BOTTOM_RIGHT,
+        ),
     ):
         """
         Args:
@@ -77,7 +78,9 @@ class LineZone:
         self._vector = Vector(start=start, end=end)
         if self._vector.magnitude == 0:
             raise ValueError("The magnitude of the line cannot be zero.")
-        vector, rotation, translation = self._transform_to_vertical_at_zero(self._vector)
+        vector, rotation, translation = self._transform_to_vertical_at_zero(
+            self._vector
+        )
         self.limits = self.calculate_region_of_interest_limits(vector=self._vector)
         self._transformed_vector = vector
         self._rotation = rotation
@@ -162,7 +165,9 @@ class LineZone:
         min_vector_y = min(vector.start.y, vector.end.y)
         max_anchor_y = np.max(all_anchors[:, :, 1], axis=0)
         min_anchor_y = np.min(all_anchors[:, :, 1], axis=0)
-        in_limits = np.logical_and(max_anchor_y <= max_vector_y, min_anchor_y >= min_vector_y)
+        in_limits = np.logical_and(
+            max_anchor_y <= max_vector_y, min_anchor_y >= min_vector_y
+        )
         trigger_out = np.min(all_anchors[:, :, 0], axis=0) < 0
         trigger_in = np.max(all_anchors[:, :, 0], axis=0) >= 0
         for i, tracker_id in enumerate(detections.tracker_id):
@@ -213,7 +218,7 @@ class LineZone:
 
     @staticmethod
     def _transform_to_vertical_at_zero(
-            vector: Vector,
+        vector: Vector,
     ) -> Tuple[Vector, np.ndarray, np.ndarray]:
         """
         Translate and rotate vector so that it is vertical, centered at zero.
@@ -244,6 +249,7 @@ class LineZone:
             end=Point(x=vector[0], y=vector[1]),
         )
         return vector, rotation, translation
+
 
 class LineZoneAnnotator:
     def __init__(

--- a/test/detection/test_line_counter.py
+++ b/test/detection/test_line_counter.py
@@ -14,61 +14,61 @@ from test.test_utils import mock_detections
     "vector, expected_result, exception",
     [
         (
-                Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=0.0)),
-                None,
-                pytest.raises(ValueError),
+            Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=0.0)),
+            None,
+            pytest.raises(ValueError),
         ),
         (
-                Vector(start=Point(x=1.0, y=1.0), end=Point(x=1.0, y=1.0)),
-                None,
-                pytest.raises(ValueError),
+            Vector(start=Point(x=1.0, y=1.0), end=Point(x=1.0, y=1.0)),
+            None,
+            pytest.raises(ValueError),
         ),
         (
-                Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=4.0)),
-                (
-                        Vector(start=Point(x=0.0, y=0.0), end=Point(x=-1.0, y=0.0)),
-                        Vector(start=Point(x=0.0, y=4.0), end=Point(x=1.0, y=4.0)),
-                ),
-                DoesNotRaise(),
+            Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=4.0)),
+            (
+                Vector(start=Point(x=0.0, y=0.0), end=Point(x=-1.0, y=0.0)),
+                Vector(start=Point(x=0.0, y=4.0), end=Point(x=1.0, y=4.0)),
+            ),
+            DoesNotRaise(),
         ),
         (
-                Vector(Point(0.0, 0.0), Point(4.0, 0.0)),
-                (
-                        Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=1.0)),
-                        Vector(start=Point(x=4.0, y=0.0), end=Point(x=4.0, y=-1.0)),
-                ),
-                DoesNotRaise(),
+            Vector(Point(0.0, 0.0), Point(4.0, 0.0)),
+            (
+                Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=1.0)),
+                Vector(start=Point(x=4.0, y=0.0), end=Point(x=4.0, y=-1.0)),
+            ),
+            DoesNotRaise(),
         ),
         (
-                Vector(Point(0.0, 0.0), Point(3.0, 4.0)),
-                (
-                        Vector(start=Point(x=0, y=0), end=Point(x=-0.8, y=0.6)),
-                        Vector(start=Point(x=3, y=4), end=Point(x=3.8, y=3.4)),
-                ),
-                DoesNotRaise(),
+            Vector(Point(0.0, 0.0), Point(3.0, 4.0)),
+            (
+                Vector(start=Point(x=0, y=0), end=Point(x=-0.8, y=0.6)),
+                Vector(start=Point(x=3, y=4), end=Point(x=3.8, y=3.4)),
+            ),
+            DoesNotRaise(),
         ),
         (
-                Vector(Point(0.0, 0.0), Point(4.0, 3.0)),
-                (
-                        Vector(start=Point(x=0, y=0), end=Point(x=-0.6, y=0.8)),
-                        Vector(start=Point(x=4, y=3), end=Point(x=4.6, y=2.2)),
-                ),
-                DoesNotRaise(),
+            Vector(Point(0.0, 0.0), Point(4.0, 3.0)),
+            (
+                Vector(start=Point(x=0, y=0), end=Point(x=-0.6, y=0.8)),
+                Vector(start=Point(x=4, y=3), end=Point(x=4.6, y=2.2)),
+            ),
+            DoesNotRaise(),
         ),
         (
-                Vector(Point(0.0, 0.0), Point(3.0, -4.0)),
-                (
-                        Vector(start=Point(x=0, y=0), end=Point(x=0.8, y=0.6)),
-                        Vector(start=Point(x=3, y=-4), end=Point(x=2.2, y=-4.6)),
-                ),
-                DoesNotRaise(),
+            Vector(Point(0.0, 0.0), Point(3.0, -4.0)),
+            (
+                Vector(start=Point(x=0, y=0), end=Point(x=0.8, y=0.6)),
+                Vector(start=Point(x=3, y=-4), end=Point(x=2.2, y=-4.6)),
+            ),
+            DoesNotRaise(),
         ),
     ],
 )
 def test_calculate_region_of_interest_limits(
-        vector: Vector,
-        expected_result: Optional[Tuple[Vector, Vector]],
-        exception: Exception,
+    vector: Vector,
+    expected_result: Optional[Tuple[Vector, Vector]],
+    exception: Exception,
 ) -> None:
     with exception:
         result = LineZone.calculate_region_of_interest_limits(vector=vector)
@@ -79,96 +79,133 @@ def test_calculate_region_of_interest_limits(
     "vector, bbox_sequence, expected_count_in, expected_count_out",
     [
         (
-                Vector(
-                    Point(0, 0),
-                    Point(0, 100),
-                ),
-                [
-                    [100, 50, 120, 70],
-                    [-100, 50, -80, 70],
-                ],
-                [False, False],
-                [False, True],
+            Vector(
+                Point(0, 0),
+                Point(0, 100),
+            ),
+            [
+                [100, 50, 120, 70],
+                [-100, 50, -80, 70],
+            ],
+            [False, False],
+            [False, True],
         ),
         (
-                Vector(
-                    Point(0, 0),
-                    Point(0, 100),
-                ),
-                [
-                    [-100, 50, -80, 70],
-                    [100, 50, 120, 70],
-                ],
-                [False, True],
-                [False, False],
+            Vector(
+                Point(0, 0),
+                Point(0, 100),
+            ),
+            [
+                [-100, 50, -80, 70],
+                [100, 50, 120, 70],
+            ],
+            [False, True],
+            [False, False],
         ),
         (
-                Vector(
-                    Point(0, 0),
-                    Point(0, 100),
-                ),
-                [
-                    [-100, 50, -80, 70],
-                    [-10, 50, 20, 70],
-                    [100, 50, 120, 70],
-                ],
-                [False, False, True],
-                [False, False, False],
+            Vector(
+                Point(0, 0),
+                Point(0, 100),
+            ),
+            [
+                [-100, 50, -80, 70],
+                [-10, 50, 20, 70],
+                [100, 50, 120, 70],
+            ],
+            [False, False, True],
+            [False, False, False],
         ),
         (
-                Vector(
-                    Point(0, 0),
-                    Point(100, 100),
-                ),
-                [
-                    [50, 45, 70, 30],
-                    [40, 50, 50, 40],
-                    [0, 50, 10, 40],
-                ],
-                [False, False, False],
-                [False, False, True],
+            Vector(
+                Point(0, 0),
+                Point(100, 100),
+            ),
+            [
+                [50, 45, 70, 30],
+                [40, 50, 50, 40],
+                [0, 50, 10, 40],
+            ],
+            [False, False, False],
+            [False, False, True],
         ),
         (
-                Vector(
-                    Point(0, 0),
-                    Point(100, 0),
-                ),
-                [
-                    [50, -45, 70, -30],
-                    [40, 50, 50, 40],
-                ],
-                [False, False],
-                [False, True],
+            Vector(
+                Point(0, 0),
+                Point(100, 0),
+            ),
+            [
+                [50, -45, 70, -30],
+                [40, 50, 50, 40],
+            ],
+            [False, False],
+            [False, True],
         ),
         (
-                Vector(
-                    Point(0, 0),
-                    Point(0, -100),
-                ),
-                [
-                    [100, -50, 120, -70],
-                    [-100, -50, -80, -70],
-                ],
-                [False, True],
-                [False, False],
+            Vector(
+                Point(0, 0),
+                Point(0, -100),
+            ),
+            [
+                [100, -50, 120, -70],
+                [-100, -50, -80, -70],
+            ],
+            [False, True],
+            [False, False],
         ),
         (
-                Vector(
-                    Point(0, 0),
-                    Point(50, 100),
-                ),
-                [
-                    [50, 50, 70, 30],
-                    [40, 50, 50, 40],
-                    [0, 50, 10, 40],
-                ],
-                [False, False, False],
-                [False, False, True],
+            Vector(
+                Point(0, 0),
+                Point(50, 100),
+            ),
+            [
+                [50, 50, 70, 30],
+                [40, 50, 50, 40],
+                [0, 50, 10, 40],
+            ],
+            [False, False, False],
+            [False, False, True],
+        ),
+        (
+            Vector(
+                Point(0, 0),
+                Point(0, 100),
+            ),
+            [
+                [100, 50, 120, 70],
+                [-100, 50, -80, 70],
+                [100, 50, 120, 70],
+                [-100, 50, -80, 70],
+                [100, 50, 120, 70],
+                [-100, 50, -80, 70],
+                [100, 50, 120, 70],
+                [-100, 50, -80, 70],
+            ],
+            [False, False, True, False, True, False, True, False],
+            [False, True, False, True, False, True, False, True],
+        ),
+        (
+            Vector(
+                Point(0, 0),
+                Point(-100, 0),
+            ),
+            [
+                [-50, 70, -40, 50],
+                [-50, -70, -40, -50],
+                [-50, 70, -40, 50],
+                [-50, -70, -40, -50],
+                [-50, 70, -40, 50],
+                [-50, -70, -40, -50],
+                [-50, 70, -40, 50],
+                [-50, -70, -40, -50],
+            ],
+            [False, False, True, False, True, False, True, False],
+            [False, True, False, True, False, True, False, True],
         ),
     ],
 )
-def test_line_zone_single_detection_single_pass(
-        vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]) -> None:
+def test_line_zone_single_detection(
+    vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]
+) -> None:
     line_zone = LineZone(start=vector.start, end=vector.end)
     for i, bbox in enumerate(bbox_sequence):
         detections = mock_detections(
@@ -178,51 +215,64 @@ def test_line_zone_single_detection_single_pass(
         count_in, count_out = line_zone.trigger(detections)
         assert count_in[0] == expected_count_in[i]
         assert count_out[0] == expected_count_out[i]
-        assert line_zone.in_count == sum(expected_count_in[:(i+1)])
-        assert line_zone.out_count == sum(expected_count_out[:(i+1)])
+        assert line_zone.in_count == sum(expected_count_in[: (i + 1)])
+        assert line_zone.out_count == sum(expected_count_out[: (i + 1)])
 
 
 @pytest.mark.parametrize(
     "vector, bbox_sequence, expected_count_in, expected_count_out, crossing_anchors",
     [
         (
-                Vector(
-                    Point(0, 0),
-                    Point(100, 100),
-                ),
-                [
-                    [50, 30, 60, 20],
-                    [20, 50, 40, 30],
-                ],
-                [False, False],
-                [False, True],
-                [Position.TOP_LEFT, Position.TOP_RIGHT, Position.BOTTOM_LEFT],
+            Vector(
+                Point(0, 0),
+                Point(100, 100),
+            ),
+            [
+                [50, 30, 60, 20],
+                [20, 50, 40, 30],
+            ],
+            [False, False],
+            [False, True],
+            [Position.TOP_LEFT, Position.TOP_RIGHT, Position.BOTTOM_LEFT],
         ),
         (
-                Vector(
-                    Point(0, 0),
-                    Point(0, 100),
-                ),
-                [
-                    [-100, 50, -80, 70],
-                    [-100, 50, 120, 70],
-                ],
-                [False, True],
-                [False, False],
-                [Position.TOP_RIGHT, Position.BOTTOM_RIGHT],
+            Vector(
+                Point(0, 0),
+                Point(0, 100),
+            ),
+            [
+                [-100, 50, -80, 70],
+                [-100, 50, 120, 70],
+            ],
+            [False, True],
+            [False, False],
+            [Position.TOP_RIGHT, Position.BOTTOM_RIGHT],
         ),
     ],
 )
-def test_line_zone_single_detection_single_pass2(
-        vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool], crossing_anchors
+def test_line_zone_single_detection_on_subset_of_anchors(
+    vector,
+    bbox_sequence,
+    expected_count_in: list[bool],
+    expected_count_out: list[bool],
+    crossing_anchors,
 ) -> None:
     def powerset(s):
         return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
 
-    for anchors in powerset([Position.TOP_LEFT, Position.TOP_RIGHT, Position.BOTTOM_LEFT, Position.BOTTOM_RIGHT]):
+    for anchors in powerset(
+        [
+            Position.TOP_LEFT,
+            Position.TOP_RIGHT,
+            Position.BOTTOM_LEFT,
+            Position.BOTTOM_RIGHT,
+        ]
+    ):
         if not anchors:
             continue
-        line_zone = LineZone(start=vector.start, end=vector.end, triggering_anchors=anchors)
+        line_zone = LineZone(
+            start=vector.start, end=vector.end, triggering_anchors=anchors
+        )
         for i, bbox in enumerate(bbox_sequence):
             detections = mock_detections(
                 xyxy=[bbox],
@@ -241,95 +291,58 @@ def test_line_zone_single_detection_single_pass2(
     "vector, bbox_sequence, expected_count_in, expected_count_out",
     [
         (
-                Vector(
-                    Point(0, 0),
-                    Point(0, 100),
-                ),
-                [
-                    [100, 50, 120, 70],
-                    [-100, 50, -80, 70],
-                    [100, 50, 120, 70],
-                    [-100, 50, -80, 70],
-                    [100, 50, 120, 70],
-                    [-100, 50, -80, 70],
-                    [100, 50, 120, 70],
-                    [-100, 50, -80, 70],
-                ],
-                [False, False, True, False, True, False, True, False],
-                [False, True, False, True, False, True, False, True],
+            Vector(
+                Point(0, 0),
+                Point(0, 100),
+            ),
+            [
+                [[100, 50, 120, 70], [100, 50, 120, 70]],
+                [[-100, 50, -80, 70], [100, 50, 120, 70]],
+                [[100, 50, 120, 70], [100, 50, 120, 70]],
+            ],
+            [[False, False], [False, False], [True, False]],
+            [[False, False], [True, False], [False, False]],
         ),
         (
-                Vector(
-                    Point(0, 0),
-                    Point(-100, 0),
-                ),
-                [
-                    [-50, 70, -40, 50],
-                    [-50, -70, -40, -50],
-                    [-50, 70, -40, 50],
-                    [-50, -70, -40, -50],
-                    [-50, 70, -40, 50],
-                    [-50, -70, -40, -50],
-                    [-50, 70, -40, 50],
-                    [-50, -70, -40, -50],
-                ],
-                [False, False, True, False, True, False, True, False],
-                [False, True, False, True, False, True, False, True],
+            Vector(
+                Point(0, 0),
+                Point(-100, 0),
+            ),
+            [
+                [[-50, 70, -40, 50], [-80, -50, -70, -40]],
+                [[-50, -70, -40, -50], [-80, 50, -70, 40]],
+                [[-50, 70, -40, 50], [-80, 50, -70, 40]],
+                [[-50, -70, -40, -50], [-80, 50, -70, 40]],
+                [[-50, 70, -40, 50], [-80, 50, -70, 40]],
+                [[-50, -70, -40, -50], [-80, 50, -70, 40]],
+                [[-50, 70, -40, 50], [-80, 50, -70, 40]],
+                [[-50, -70, -40, -50], [-80, -50, -70, -40]],
+            ],
+            [
+                (False, False),
+                (False, True),
+                (True, False),
+                (False, False),
+                (True, False),
+                (False, False),
+                (True, False),
+                (False, False),
+            ],
+            [
+                (False, False),
+                (True, False),
+                (False, False),
+                (True, False),
+                (False, False),
+                (True, False),
+                (False, False),
+                (True, True),
+            ],
         ),
     ],
 )
-def test_line_zone_multiple_passes(
-        vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]
-) -> None:
-    line_zone = LineZone(start=vector.start, end=vector.end)
-    for i, bbox in enumerate(bbox_sequence):
-        detections = mock_detections(
-            xyxy=[bbox],
-            tracker_id=[i for i in range(0, 1)],
-        )
-        count_in, count_out = line_zone.trigger(detections)
-        assert count_in[0] == expected_count_in[i]
-        assert count_out[0] == expected_count_out[i]
-
-
-@pytest.mark.parametrize(
-    "vector, bbox_sequence, expected_count_in, expected_count_out",
-    [
-        (
-                Vector(
-                    Point(0, 0),
-                    Point(0, 100),
-                ),
-                [
-                    [[100, 50, 120, 70], [100, 50, 120, 70]],
-                    [[-100, 50, -80, 70], [100, 50, 120, 70]],
-                    [[100, 50, 120, 70], [100, 50, 120, 70]]
-                ],
-                [[False, False], [False, False], [True, False]],
-                [[False, False], [True, False], [False, False]],
-        ),
-        (
-                Vector(
-                    Point(0, 0),
-                    Point(-100, 0),
-                ),
-                [
-                    [[-50, 70, -40, 50], [-80, -50, -70, -40]],
-                    [[-50, -70, -40, -50], [-80, 50, -70, 40]],
-                    [[-50, 70, -40, 50], [-80, 50, -70, 40]],
-                    [[-50, -70, -40, -50], [-80, 50, -70, 40]],
-                    [[-50, 70, -40, 50], [-80, 50, -70, 40]],
-                    [[-50, -70, -40, -50], [-80, 50, -70, 40]],
-                    [[-50, 70, -40, 50], [-80, 50, -70, 40]],
-                    [[-50, -70, -40, -50], [-80, -50, -70, -40]],
-                ],
-                [(False, False), (False,True), (True, False), (False,False) ,(True,False), (False, False), (True,False), (False, False)],
-                [(False, False), (True,False), (False,False), (True,False), (False,False), (True,False), (False,False), (True, True)],
-        ),
-    ],
-)
-def test_line_zone_multiple_passes2(
-        vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]
+def test_line_zone_multiple_detections(
+    vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]
 ) -> None:
     line_zone = LineZone(start=vector.start, end=vector.end)
     for i, bboxes in enumerate(bbox_sequence):
@@ -346,24 +359,24 @@ def test_line_zone_multiple_passes2(
     "vector, bbox_sequence",
     [
         (
-                Vector(
-                    Point(0, 0),
-                    Point(0, 100),
-                ),
-                [
-                    [100, 50, 120, 70],
-                    [-100, 50, -80, 70],
-                ]
+            Vector(
+                Point(0, 0),
+                Point(0, 100),
+            ),
+            [
+                [100, 50, 120, 70],
+                [-100, 50, -80, 70],
+            ],
         ),
         (
-                Vector(
-                    Point(0, 0),
-                    Point(0, 100),
-                ),
-                [
-                    [-100, 50, -80, 70],
-                    [100, 50, 120, 70],
-                ]
+            Vector(
+                Point(0, 0),
+                Point(0, 100),
+            ),
+            [
+                [-100, 50, -80, 70],
+                [100, 50, 120, 70],
+            ],
         ),
     ],
 )

--- a/test/detection/test_line_counter.py
+++ b/test/detection/test_line_counter.py
@@ -1,13 +1,13 @@
 from contextlib import ExitStack as DoesNotRaise
 from itertools import chain, combinations
+from test.test_utils import mock_detections
 from typing import Optional, Tuple
 
 import numpy as np
 import pytest
 
-from supervision import LineZone, Detections
-from supervision.geometry.core import Point, Vector, Position
-from test.test_utils import mock_detections
+from supervision import Detections, LineZone
+from supervision.geometry.core import Point, Position, Vector
 
 
 @pytest.mark.parametrize(

--- a/test/detection/test_line_counter.py
+++ b/test/detection/test_line_counter.py
@@ -1,72 +1,379 @@
 from contextlib import ExitStack as DoesNotRaise
+from itertools import chain, combinations
 from typing import Optional, Tuple
 
+import numpy as np
 import pytest
 
-from supervision import LineZone
-from supervision.geometry.core import Point, Vector
+from supervision import LineZone, Detections
+from supervision.geometry.core import Point, Vector, Position
+from test.test_utils import mock_detections
 
 
 @pytest.mark.parametrize(
     "vector, expected_result, exception",
     [
         (
-            Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=0.0)),
-            None,
-            pytest.raises(ValueError),
+                Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=0.0)),
+                None,
+                pytest.raises(ValueError),
         ),
         (
-            Vector(start=Point(x=1.0, y=1.0), end=Point(x=1.0, y=1.0)),
-            None,
-            pytest.raises(ValueError),
+                Vector(start=Point(x=1.0, y=1.0), end=Point(x=1.0, y=1.0)),
+                None,
+                pytest.raises(ValueError),
         ),
         (
-            Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=4.0)),
-            (
-                Vector(start=Point(x=0.0, y=0.0), end=Point(x=-1.0, y=0.0)),
-                Vector(start=Point(x=0.0, y=4.0), end=Point(x=1.0, y=4.0)),
-            ),
-            DoesNotRaise(),
+                Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=4.0)),
+                (
+                        Vector(start=Point(x=0.0, y=0.0), end=Point(x=-1.0, y=0.0)),
+                        Vector(start=Point(x=0.0, y=4.0), end=Point(x=1.0, y=4.0)),
+                ),
+                DoesNotRaise(),
         ),
         (
-            Vector(Point(0.0, 0.0), Point(4.0, 0.0)),
-            (
-                Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=1.0)),
-                Vector(start=Point(x=4.0, y=0.0), end=Point(x=4.0, y=-1.0)),
-            ),
-            DoesNotRaise(),
+                Vector(Point(0.0, 0.0), Point(4.0, 0.0)),
+                (
+                        Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=1.0)),
+                        Vector(start=Point(x=4.0, y=0.0), end=Point(x=4.0, y=-1.0)),
+                ),
+                DoesNotRaise(),
         ),
         (
-            Vector(Point(0.0, 0.0), Point(3.0, 4.0)),
-            (
-                Vector(start=Point(x=0, y=0), end=Point(x=-0.8, y=0.6)),
-                Vector(start=Point(x=3, y=4), end=Point(x=3.8, y=3.4)),
-            ),
-            DoesNotRaise(),
+                Vector(Point(0.0, 0.0), Point(3.0, 4.0)),
+                (
+                        Vector(start=Point(x=0, y=0), end=Point(x=-0.8, y=0.6)),
+                        Vector(start=Point(x=3, y=4), end=Point(x=3.8, y=3.4)),
+                ),
+                DoesNotRaise(),
         ),
         (
-            Vector(Point(0.0, 0.0), Point(4.0, 3.0)),
-            (
-                Vector(start=Point(x=0, y=0), end=Point(x=-0.6, y=0.8)),
-                Vector(start=Point(x=4, y=3), end=Point(x=4.6, y=2.2)),
-            ),
-            DoesNotRaise(),
+                Vector(Point(0.0, 0.0), Point(4.0, 3.0)),
+                (
+                        Vector(start=Point(x=0, y=0), end=Point(x=-0.6, y=0.8)),
+                        Vector(start=Point(x=4, y=3), end=Point(x=4.6, y=2.2)),
+                ),
+                DoesNotRaise(),
         ),
         (
-            Vector(Point(0.0, 0.0), Point(3.0, -4.0)),
-            (
-                Vector(start=Point(x=0, y=0), end=Point(x=0.8, y=0.6)),
-                Vector(start=Point(x=3, y=-4), end=Point(x=2.2, y=-4.6)),
-            ),
-            DoesNotRaise(),
+                Vector(Point(0.0, 0.0), Point(3.0, -4.0)),
+                (
+                        Vector(start=Point(x=0, y=0), end=Point(x=0.8, y=0.6)),
+                        Vector(start=Point(x=3, y=-4), end=Point(x=2.2, y=-4.6)),
+                ),
+                DoesNotRaise(),
         ),
     ],
 )
 def test_calculate_region_of_interest_limits(
-    vector: Vector,
-    expected_result: Optional[Tuple[Vector, Vector]],
-    exception: Exception,
+        vector: Vector,
+        expected_result: Optional[Tuple[Vector, Vector]],
+        exception: Exception,
 ) -> None:
     with exception:
         result = LineZone.calculate_region_of_interest_limits(vector=vector)
         assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "vector, bbox_sequence, expected_count_in, expected_count_out",
+    [
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(0, 100),
+                ),
+                [
+                    [100, 50, 120, 70],
+                    [-100, 50, -80, 70],
+                ],
+                [False, False],
+                [False, True],
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(0, 100),
+                ),
+                [
+                    [-100, 50, -80, 70],
+                    [100, 50, 120, 70],
+                ],
+                [False, True],
+                [False, False],
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(0, 100),
+                ),
+                [
+                    [-100, 50, -80, 70],
+                    [-10, 50, 20, 70],
+                    [100, 50, 120, 70],
+                ],
+                [False, False, True],
+                [False, False, False],
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(100, 100),
+                ),
+                [
+                    [50, 45, 70, 30],
+                    [40, 50, 50, 40],
+                    [0, 50, 10, 40],
+                ],
+                [False, False, False],
+                [False, False, True],
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(100, 0),
+                ),
+                [
+                    [50, -45, 70, -30],
+                    [40, 50, 50, 40],
+                ],
+                [False, False],
+                [False, True],
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(0, -100),
+                ),
+                [
+                    [100, -50, 120, -70],
+                    [-100, -50, -80, -70],
+                ],
+                [False, True],
+                [False, False],
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(50, 100),
+                ),
+                [
+                    [50, 50, 70, 30],
+                    [40, 50, 50, 40],
+                    [0, 50, 10, 40],
+                ],
+                [False, False, False],
+                [False, False, True],
+        ),
+    ],
+)
+def test_line_zone_single_detection_single_pass(
+        vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]) -> None:
+    line_zone = LineZone(start=vector.start, end=vector.end)
+    for i, bbox in enumerate(bbox_sequence):
+        detections = mock_detections(
+            xyxy=[bbox],
+            tracker_id=[i for i in range(0, 1)],
+        )
+        count_in, count_out = line_zone.trigger(detections)
+        assert count_in[0] == expected_count_in[i]
+        assert count_out[0] == expected_count_out[i]
+        assert line_zone.in_count == sum(expected_count_in[:(i+1)])
+        assert line_zone.out_count == sum(expected_count_out[:(i+1)])
+
+
+@pytest.mark.parametrize(
+    "vector, bbox_sequence, expected_count_in, expected_count_out, crossing_anchors",
+    [
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(100, 100),
+                ),
+                [
+                    [50, 30, 60, 20],
+                    [20, 50, 40, 30],
+                ],
+                [False, False],
+                [False, True],
+                [Position.TOP_LEFT, Position.TOP_RIGHT, Position.BOTTOM_LEFT],
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(0, 100),
+                ),
+                [
+                    [-100, 50, -80, 70],
+                    [-100, 50, 120, 70],
+                ],
+                [False, True],
+                [False, False],
+                [Position.TOP_RIGHT, Position.BOTTOM_RIGHT],
+        ),
+    ],
+)
+def test_line_zone_single_detection_single_pass2(
+        vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool], crossing_anchors
+) -> None:
+    def powerset(s):
+        return chain.from_iterable(combinations(s, r) for r in range(len(s) + 1))
+
+    for anchors in powerset([Position.TOP_LEFT, Position.TOP_RIGHT, Position.BOTTOM_LEFT, Position.BOTTOM_RIGHT]):
+        if not anchors:
+            continue
+        line_zone = LineZone(start=vector.start, end=vector.end, triggering_anchors=anchors)
+        for i, bbox in enumerate(bbox_sequence):
+            detections = mock_detections(
+                xyxy=[bbox],
+                tracker_id=[i for i in range(0, 1)],
+            )
+            count_in, count_out = line_zone.trigger(detections)
+            if all(anchor in crossing_anchors for anchor in anchors):
+                assert count_in == expected_count_in[i]
+                assert count_out == expected_count_out[i]
+            else:
+                assert np.all(not count_in)
+                assert np.all(not count_out)
+
+
+@pytest.mark.parametrize(
+    "vector, bbox_sequence, expected_count_in, expected_count_out",
+    [
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(0, 100),
+                ),
+                [
+                    [100, 50, 120, 70],
+                    [-100, 50, -80, 70],
+                    [100, 50, 120, 70],
+                    [-100, 50, -80, 70],
+                    [100, 50, 120, 70],
+                    [-100, 50, -80, 70],
+                    [100, 50, 120, 70],
+                    [-100, 50, -80, 70],
+                ],
+                [False, False, True, False, True, False, True, False],
+                [False, True, False, True, False, True, False, True],
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(-100, 0),
+                ),
+                [
+                    [-50, 70, -40, 50],
+                    [-50, -70, -40, -50],
+                    [-50, 70, -40, 50],
+                    [-50, -70, -40, -50],
+                    [-50, 70, -40, 50],
+                    [-50, -70, -40, -50],
+                    [-50, 70, -40, 50],
+                    [-50, -70, -40, -50],
+                ],
+                [False, False, True, False, True, False, True, False],
+                [False, True, False, True, False, True, False, True],
+        ),
+    ],
+)
+def test_line_zone_multiple_passes(
+        vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]
+) -> None:
+    line_zone = LineZone(start=vector.start, end=vector.end)
+    for i, bbox in enumerate(bbox_sequence):
+        detections = mock_detections(
+            xyxy=[bbox],
+            tracker_id=[i for i in range(0, 1)],
+        )
+        count_in, count_out = line_zone.trigger(detections)
+        assert count_in[0] == expected_count_in[i]
+        assert count_out[0] == expected_count_out[i]
+
+
+@pytest.mark.parametrize(
+    "vector, bbox_sequence, expected_count_in, expected_count_out",
+    [
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(0, 100),
+                ),
+                [
+                    [[100, 50, 120, 70], [100, 50, 120, 70]],
+                    [[-100, 50, -80, 70], [100, 50, 120, 70]],
+                    [[100, 50, 120, 70], [100, 50, 120, 70]]
+                ],
+                [[False, False], [False, False], [True, False]],
+                [[False, False], [True, False], [False, False]],
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(-100, 0),
+                ),
+                [
+                    [[-50, 70, -40, 50], [-80, -50, -70, -40]],
+                    [[-50, -70, -40, -50], [-80, 50, -70, 40]],
+                    [[-50, 70, -40, 50], [-80, 50, -70, 40]],
+                    [[-50, -70, -40, -50], [-80, 50, -70, 40]],
+                    [[-50, 70, -40, 50], [-80, 50, -70, 40]],
+                    [[-50, -70, -40, -50], [-80, 50, -70, 40]],
+                    [[-50, 70, -40, 50], [-80, 50, -70, 40]],
+                    [[-50, -70, -40, -50], [-80, -50, -70, -40]],
+                ],
+                [(False, False), (False,True), (True, False), (False,False) ,(True,False), (False, False), (True,False), (False, False)],
+                [(False, False), (True,False), (False,False), (True,False), (False,False), (True,False), (False,False), (True, True)],
+        ),
+    ],
+)
+def test_line_zone_multiple_passes2(
+        vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]
+) -> None:
+    line_zone = LineZone(start=vector.start, end=vector.end)
+    for i, bboxes in enumerate(bbox_sequence):
+        detections = mock_detections(
+            xyxy=bboxes,
+            tracker_id=[i for i in range(0, len(bboxes))],
+        )
+        count_in, count_out = line_zone.trigger(detections)
+        assert np.all(count_in == expected_count_in[i])
+        assert np.all(count_out == expected_count_out[i])
+
+
+@pytest.mark.parametrize(
+    "vector, bbox_sequence",
+    [
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(0, 100),
+                ),
+                [
+                    [100, 50, 120, 70],
+                    [-100, 50, -80, 70],
+                ]
+        ),
+        (
+                Vector(
+                    Point(0, 0),
+                    Point(0, 100),
+                ),
+                [
+                    [-100, 50, -80, 70],
+                    [100, 50, 120, 70],
+                ]
+        ),
+    ],
+)
+def test_line_zone_does_not_count_detections_without_tracker_id(vector, bbox_sequence):
+    line_zone = LineZone(start=vector.start, end=vector.end)
+    for bbox in bbox_sequence:
+        detections = Detections(
+            xyxy=np.array([bbox]).reshape((-1, 4)),
+            tracker_id=np.array([None for _ in range(0, 1)]),
+        )
+        count_in, count_out = line_zone.trigger(detections)
+        assert np.all(not count_in)
+        assert np.all(not count_out)

--- a/test/detection/test_line_counter.py
+++ b/test/detection/test_line_counter.py
@@ -1,7 +1,7 @@
 from contextlib import ExitStack as DoesNotRaise
 from itertools import chain, combinations
 from test.test_utils import mock_detections
-from typing import Optional, Tuple, List
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pytest

--- a/test/detection/test_line_counter.py
+++ b/test/detection/test_line_counter.py
@@ -1,7 +1,7 @@
 from contextlib import ExitStack as DoesNotRaise
 from itertools import chain, combinations
 from test.test_utils import mock_detections
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import numpy as np
 import pytest
@@ -204,7 +204,7 @@ def test_calculate_region_of_interest_limits(
     ],
 )
 def test_line_zone_single_detection(
-    vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]
+    vector, bbox_sequence, expected_count_in: List[bool], expected_count_out: List[bool]
 ) -> None:
     line_zone = LineZone(start=vector.start, end=vector.end)
     for i, bbox in enumerate(bbox_sequence):
@@ -253,8 +253,8 @@ def test_line_zone_single_detection(
 def test_line_zone_single_detection_on_subset_of_anchors(
     vector,
     bbox_sequence,
-    expected_count_in: list[bool],
-    expected_count_out: list[bool],
+    expected_count_in: List[bool],
+    expected_count_out: List[bool],
     crossing_anchors,
 ) -> None:
     def powerset(s):
@@ -342,7 +342,7 @@ def test_line_zone_single_detection_on_subset_of_anchors(
     ],
 )
 def test_line_zone_multiple_detections(
-    vector, bbox_sequence, expected_count_in: list[bool], expected_count_out: list[bool]
+    vector, bbox_sequence, expected_count_in: List[bool], expected_count_out: List[bool]
 ) -> None:
     line_zone = LineZone(start=vector.start, end=vector.end)
     for i, bboxes in enumerate(bbox_sequence):


### PR DESCRIPTION
# Description

My experiences with supervision's tracking indicate that (quite surprisingly) in some cases  [LineZone](https://github.com/roboflow/supervision/blob/develop/supervision/detection/line_zone.py#L12C7-L12C15) may be a bottleneck. 
Think about edge computing scenarios - where detection model is small and one tracks a lot of objects. In such cases every FPS counts. 
The following is a cProfile output for Yolov8m + ByteTrack + LineZone run 10 times on [market square video](https://github.com/roboflow/supervision/blob/develop/supervision/assets/list.py#L30). 

![image](https://github.com/roboflow/supervision/assets/37670208/0a4829eb-cfd2-4464-889d-83b9de3e1b02)

As you can see the cost of LineZone is already quite considerable. Now, consider that there are not a lot of objects (average of 35 per frame) and that the easiest, most common approach to improving counting precision is adding more lines and averaging results. 
For these reasons, in my usage of supervision, I've had to optimize [LineZone](https://github.com/roboflow/supervision/blob/develop/supervision/detection/line_zone.py#L12C7-L12C15).
The new implementation takes only 0.74 seconds on market square example compared to 11.1s seconds of the old implementation. To support this change I've added unit tests for LineZone. 

Note that quite unnecessarily internals of LineZone are exposed through two public static methods - [calculate_region_of_interest_limits](https://github.com/roboflow/supervision/blob/develop/supervision/detection/line_zone.py#L86) and [is_point_in_limits](https://github.com/roboflow/supervision/blob/develop/supervision/detection/line_zone.py#L118). I can only guess that it's because unit tests were just written for parts (encapsulated in those two methods) of LineZone code. These methods should not be public because they expose specifics of how line counting is implemented, hindering any attempts at changing the method (as is in this case). I've left those two methods unchanged, because I don't want to break peoples' code (even though those two methods were not documented as a part of API), but I've added docstring with warning that they are not a part of the API. 


## Type of change

Please delete options that are not relevant.

-   [x] Feature optimization (non-breaking change which optimizes existing functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?
New LineZone unit tests.

