### PR TITLE
tracker_id contents are never `None`

### DIFF
--- a/supervision/detection/line_zone.py
+++ b/supervision/detection/line_zone.py
@@ -140,6 +140,13 @@ class LineZone:
         if len(detections) == 0:
             return crossed_in, crossed_out
 
+        if detections.tracker_id is None:
+            print(
+                "Line zone conting skipped. LineZone requires tracker_id. Refer to "
+                "https://supervision.roboflow.com/latest/trackers for more information."
+            )
+            return crossed_in, crossed_out
+
         all_anchors = np.array(
             [
                 detections.get_anchors_coordinates(anchor)
@@ -148,9 +155,6 @@ class LineZone:
         )
 
         for i, tracker_id in enumerate(detections.tracker_id):
-            if tracker_id is None:
-                continue
-
             box_anchors = [Point(x=x, y=y) for x, y in all_anchors[:, i, :]]
 
             in_limits = all(

--- a/supervision/detection/line_zone.py
+++ b/supervision/detection/line_zone.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Dict, Iterable, Optional, Tuple
 
 import cv2
@@ -7,6 +8,7 @@ from supervision.detection.core import Detections
 from supervision.draw.color import Color
 from supervision.draw.utils import draw_text
 from supervision.geometry.core import Point, Position, Vector
+from supervision.utils.internal import SupervisionWarnings
 
 
 class LineZone:
@@ -141,9 +143,11 @@ class LineZone:
             return crossed_in, crossed_out
 
         if detections.tracker_id is None:
-            print(
-                "Line zone conting skipped. LineZone requires tracker_id. Refer to "
-                "https://supervision.roboflow.com/latest/trackers for more information."
+            warnings.warn(
+                "Line zone counting skipped. LineZone requires tracker_id. Refer to "
+                "https://supervision.roboflow.com/latest/trackers for more "
+                "information.",
+                category=SupervisionWarnings,
             )
             return crossed_in, crossed_out
 

--- a/supervision/detection/tools/smoother.py
+++ b/supervision/detection/tools/smoother.py
@@ -78,8 +78,6 @@ class DetectionsSmoother:
 
         for detection_idx in range(len(detections)):
             tracker_id = detections.tracker_id[detection_idx]
-            if tracker_id is None:
-                continue
 
             self.tracks[tracker_id].append(detections[detection_idx])
 

--- a/supervision/detection/tools/smoother.py
+++ b/supervision/detection/tools/smoother.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import defaultdict, deque
 from copy import deepcopy
 from typing import Optional
@@ -5,6 +6,7 @@ from typing import Optional
 import numpy as np
 
 from supervision.detection.core import Detections
+from supervision.utils.internal import SupervisionWarnings
 
 
 class DetectionsSmoother:
@@ -70,9 +72,11 @@ class DetectionsSmoother:
         """
 
         if detections.tracker_id is None:
-            print(
+            warnings.warn(
                 "Smoothing skipped. DetectionsSmoother requires tracker_id. Refer to "
-                "https://supervision.roboflow.com/latest/trackers for more information."
+                "https://supervision.roboflow.com/latest/trackers for more "
+                "information.",
+                category=SupervisionWarnings,
             )
             return detections
 


### PR DESCRIPTION
# Description

I've verified every instance of `tracker_id` in our repo, and found that its **contents** are never `None`.
The checks we have are not necessary.

In cases where `tracker_id` gets `-1` added, it is indeed filtered out very soon.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Basic tests of smoother and line counter can be found here: https://colab.research.google.com/drive/1_gajR0D_CZ4Z2dZ1y8SdVaWGbDZ0mBpl?usp=sharing

Even with no detections for longer periods of time, no errors (and no None values) are produced.

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes: