### PR TITLE
fix: 🐞 yolo obb condition check set or for newer and older version

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -240,7 +240,7 @@ class Detections:
             Class names values can be accessed using `detections["class_name"]`.
         """  # noqa: E501 // docs
 
-        if "obb" in ultralytics_results and ultralytics_results.obb is not None:
+        if hasattr(ultralytics_results, "obb") and ultralytics_results.obb is not None:
             class_id = ultralytics_results.obb.cls.cpu().numpy().astype(int)
             class_names = np.array([ultralytics_results.names[i] for i in class_id])
             oriented_box_coordinates = ultralytics_results.obb.xyxyxyxy.cpu().numpy()


### PR DESCRIPTION
### Description 

It fixes #1219.

We added "obb" key check added in #1093 and latest ultralytics package does not have that key.  I changed to "obb" check "and" to "or" and I tested with obb/detection/seg  all of them works.  