### PR TITLE
Dynamically select Detections member variables

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -23,7 +23,7 @@ from supervision.detection.utils import (
     xywh_to_xyxy,
 )
 from supervision.geometry.core import Position
-from supervision.utils.internal import deprecated
+from supervision.utils.internal import deprecated, get_instance_variables
 from supervision.validators import validate_detections_fields
 
 
@@ -1379,7 +1379,7 @@ def validate_fields_both_defined_or_none(
     Raises:
         ValueError: If one field is None and the other is not, for any of the fields.
     """
-    attributes = ["mask", "confidence", "class_id", "tracker_id"]
+    attributes = get_instance_variables(detections_1)
     for attribute in attributes:
         value_1 = getattr(detections_1, attribute)
         value_2 = getattr(detections_2, attribute)

--- a/supervision/utils/internal.py
+++ b/supervision/utils/internal.py
@@ -144,14 +144,12 @@ class classproperty(property):
         return self.fget(owner_cls)
 
 
-def get_instance_variables(cls: Any, include_properties=False) -> Set[str]:
+def get_instance_variables(instance: Any, include_properties=False) -> Set[str]:
     """
-    Get the non-private variables of a class or instance.
-    Some variables are only during initialization, so passing an instance
-    is more reliable.
+    Get the public variables of a class instance.
 
     Args:
-        cls (Any): The class or instance
+        instance (Any): The class or instance
         include_properties (bool): Whether to include properties in the result
 
     Usage:
@@ -161,20 +159,22 @@ def get_instance_variables(cls: Any, include_properties=False) -> Set[str]:
         # Returns ["xyxy", "mask", "confidence", ..., "data"]
         ```
     """
+    if isinstance(instance, type):
+        raise ValueError("Only class instances are supported, not classes.")
+
     fields = set(
         (
             name
-            for name, val in inspect.getmembers(cls)
-            if not name.startswith("__") and not callable(val)
+            for name, val in inspect.getmembers(instance)
+            if not callable(val) and not name.startswith("_")
         )
     )
 
     if not include_properties:
-        class_type = cls if isinstance(cls, type) else type(cls)
         properties = set(
             (
                 name
-                for name, val in inspect.getmembers(class_type)
+                for name, val in inspect.getmembers(instance.__class__)
                 if isinstance(val, property)
             )
         )

--- a/supervision/utils/internal.py
+++ b/supervision/utils/internal.py
@@ -149,14 +149,14 @@ def get_instance_variables(instance: Any, include_properties=False) -> Set[str]:
     Get the public variables of a class instance.
 
     Args:
-        instance (Any): The class or instance
+        instance (Any): The instance of a class
         include_properties (bool): Whether to include properties in the result
 
     Usage:
         ```python
         detections = Detections(xyxy=np.array([1,2,3,4]))
         variables = get_class_variables(detections)
-        # Returns ["xyxy", "mask", "confidence", ..., "data"]
+        # ["xyxy", "mask", "confidence", ..., "data"]
         ```
     """
     if isinstance(instance, type):

--- a/test/utils/test_internal.py
+++ b/test/utils/test_internal.py
@@ -1,4 +1,6 @@
 from contextlib import ExitStack as DoesNotRaise
+from dataclasses import dataclass
+from typing import Any, Set
 
 import numpy as np
 import pytest
@@ -7,25 +9,111 @@ from supervision.detection.core import Detections
 from supervision.utils.internal import get_instance_variables
 
 
+class MockClass:
+    def __init__(self):
+        self.public = 0
+        self._protected = 1
+        self.__private = 2
+
+    def public_method(self):
+        pass
+
+    def _protected_method(self):
+        pass
+
+    def __private_method(self):
+        pass
+
+    @property
+    def public_property(self):
+        return 0
+
+    @property
+    def _protected_property(self):
+        return 1
+
+    @property
+    def __private_property(self):
+        return 2
+
+
+@dataclass
+class MockDataclass:
+    public: int = 0
+    _protected: int = 1
+    __private: int = 2
+
+    def public_method(self):
+        pass
+
+    def _protected_method(self):
+        pass
+
+    def __private_method(self):
+        pass
+
+    @property
+    def public_property(self):
+        return 0
+
+    @property
+    def _protected_property(self):
+        return 1
+
+    @property
+    def __private_property(self):
+        return 2
+
+
 @pytest.mark.parametrize(
     "input_obj, include_properties, expected, exception",
     [
         (
+            MockClass,
+            False,
+            None,
+            pytest.raises(ValueError),
+        ),
+        (
+            MockClass(),
+            False,
+            {"public"},
+            DoesNotRaise(),
+        ),
+        (
+            MockClass(),
+            True,
+            {"public", "public_property"},
+            DoesNotRaise(),
+        ),
+        (
+            MockDataclass(),
+            False,
+            {"public"},
+            DoesNotRaise(),
+        ),
+        (
+            MockDataclass(),
+            True,
+            {"public", "public_property"},
+            DoesNotRaise(),
+        ),
+        (
             Detections,
             False,
-            {"class_id", "confidence", "mask", "tracker_id"},
-            DoesNotRaise(),
+            None,
+            pytest.raises(ValueError),
+        ),
+        (
+            Detections,
+            True,
+            None,
+            pytest.raises(ValueError),
         ),
         (
             Detections.empty(),
             False,
             {"xyxy", "class_id", "confidence", "mask", "tracker_id", "data"},
-            DoesNotRaise(),
-        ),
-        (
-            Detections,
-            True,
-            {"class_id", "confidence", "mask", "tracker_id", "area", "box_area"},
             DoesNotRaise(),
         ),
         (
@@ -76,10 +164,19 @@ from supervision.utils.internal import get_instance_variables
             },
             DoesNotRaise(),
         ),
+        (
+            Detections.empty(),
+            False,
+            {"xyxy", "class_id", "confidence", "mask", "tracker_id", "data"},
+            DoesNotRaise(),
+        ),
     ],
 )
 def test_get_instance_variables(
-    input_obj, include_properties, expected, exception
+    input_obj: Any, include_properties: bool, expected: Set[str], exception: Exception
 ) -> None:
-    result = get_instance_variables(input_obj, include_properties=include_properties)
-    assert result == expected
+    with exception:
+        result = get_instance_variables(
+            input_obj, include_properties=include_properties
+        )
+        assert result == expected

--- a/test/utils/test_internal.py
+++ b/test/utils/test_internal.py
@@ -1,5 +1,5 @@
 from contextlib import ExitStack as DoesNotRaise
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Set
 
 import numpy as np
@@ -43,6 +43,14 @@ class MockDataclass:
     _protected: int = 1
     __private: int = 2
 
+    public_field: int = field(default=0)
+    _protected_field: int = field(default=1)
+    __private_field: int = field(default=2)
+
+    public_field_with_factory: dict = field(default_factory=dict)
+    _protected_field_with_factory: dict = field(default_factory=dict)
+    __private_field_with_factory: dict = field(default_factory=dict)
+
     def public_method(self):
         pass
 
@@ -66,7 +74,7 @@ class MockDataclass:
 
 
 @pytest.mark.parametrize(
-    "input_obj, include_properties, expected, exception",
+    "input_instance, include_properties, expected, exception",
     [
         (
             MockClass,
@@ -89,13 +97,13 @@ class MockDataclass:
         (
             MockDataclass(),
             False,
-            {"public"},
+            {"public", "public_field", "public_field_with_factory"},
             DoesNotRaise(),
         ),
         (
             MockDataclass(),
             True,
-            {"public", "public_property"},
+            {"public", "public_field", "public_field_with_factory", "public_property"},
             DoesNotRaise(),
         ),
         (
@@ -173,10 +181,13 @@ class MockDataclass:
     ],
 )
 def test_get_instance_variables(
-    input_obj: Any, include_properties: bool, expected: Set[str], exception: Exception
+    input_instance: Any,
+    include_properties: bool,
+    expected: Set[str],
+    exception: Exception,
 ) -> None:
     with exception:
         result = get_instance_variables(
-            input_obj, include_properties=include_properties
+            input_instance, include_properties=include_properties
         )
         assert result == expected

--- a/test/utils/test_internal.py
+++ b/test/utils/test_internal.py
@@ -1,5 +1,7 @@
-import pytest
 from contextlib import ExitStack as DoesNotRaise
+
+import pytest
+
 from supervision.detection.core import Detections
 from supervision.utils.internal import get_instance_variables
 
@@ -11,28 +13,39 @@ from supervision.utils.internal import get_instance_variables
             Detections,
             False,
             {"class_id", "confidence", "mask", "tracker_id"},
-            DoesNotRaise()
+            DoesNotRaise(),
         ),
         (
             Detections.empty(),
             False,
             {"xyxy", "class_id", "confidence", "mask", "tracker_id", "data"},
-            DoesNotRaise()
+            DoesNotRaise(),
         ),
         (
             Detections,
             True,
             {"class_id", "confidence", "mask", "tracker_id", "area", "box_area"},
-            DoesNotRaise()
+            DoesNotRaise(),
         ),
         (
             Detections.empty(),
             True,
-            {"xyxy", "class_id", "confidence", "mask", "tracker_id", "data", "area", "box_area"},
-            DoesNotRaise()
+            {
+                "xyxy",
+                "class_id",
+                "confidence",
+                "mask",
+                "tracker_id",
+                "data",
+                "area",
+                "box_area",
+            },
+            DoesNotRaise(),
         ),
     ],
 )
-def test_get_instance_variables(input_obj, include_properties, expected, exception) -> None:
+def test_get_instance_variables(
+    input_obj, include_properties, expected, exception
+) -> None:
     result = get_instance_variables(input_obj, include_properties=include_properties)
     assert result == expected

--- a/test/utils/test_internal.py
+++ b/test/utils/test_internal.py
@@ -1,5 +1,6 @@
 from contextlib import ExitStack as DoesNotRaise
 
+import numpy as np
 import pytest
 
 from supervision.detection.core import Detections
@@ -39,6 +40,39 @@ from supervision.utils.internal import get_instance_variables
                 "data",
                 "area",
                 "box_area",
+            },
+            DoesNotRaise(),
+        ),
+        (
+            Detections(xyxy=np.array([[1, 2, 3, 4]])),
+            False,
+            {
+                "xyxy",
+                "class_id",
+                "confidence",
+                "mask",
+                "tracker_id",
+                "data",
+            },
+            DoesNotRaise(),
+        ),
+        (
+            Detections(
+                xyxy=np.array([[1, 2, 3, 4], [5, 6, 7, 8]]),
+                class_id=np.array([1, 2]),
+                confidence=np.array([0.1, 0.2]),
+                mask=np.array([[[1]], [[2]]]),
+                tracker_id=np.array([1, 2]),
+                data={"key_1": [1, 2], "key_2": [3, 4]},
+            ),
+            False,
+            {
+                "xyxy",
+                "class_id",
+                "confidence",
+                "mask",
+                "tracker_id",
+                "data",
             },
             DoesNotRaise(),
         ),

--- a/test/utils/test_internal.py
+++ b/test/utils/test_internal.py
@@ -1,0 +1,38 @@
+import pytest
+from contextlib import ExitStack as DoesNotRaise
+from supervision.detection.core import Detections
+from supervision.utils.internal import get_instance_variables
+
+
+@pytest.mark.parametrize(
+    "input_obj, include_properties, expected, exception",
+    [
+        (
+            Detections,
+            False,
+            {"class_id", "confidence", "mask", "tracker_id"},
+            DoesNotRaise()
+        ),
+        (
+            Detections.empty(),
+            False,
+            {"xyxy", "class_id", "confidence", "mask", "tracker_id", "data"},
+            DoesNotRaise()
+        ),
+        (
+            Detections,
+            True,
+            {"class_id", "confidence", "mask", "tracker_id", "area", "box_area"},
+            DoesNotRaise()
+        ),
+        (
+            Detections.empty(),
+            True,
+            {"xyxy", "class_id", "confidence", "mask", "tracker_id", "data", "area", "box_area"},
+            DoesNotRaise()
+        ),
+    ],
+)
+def test_get_instance_variables(input_obj, include_properties, expected, exception) -> None:
+    result = get_instance_variables(input_obj, include_properties=include_properties)
+    assert result == expected


### PR DESCRIPTION
# Description

When checking if both fields are `None` or defined in two detection to be merged, we'd hardcode the fields.

This change allows getting the programmatically.
Note that it requires an instance of the class.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Ran locally, added and ran very basic tests.
Colab: https://colab.research.google.com/drive/193L8OHsEsdhQEenDNwKbGdtPyE68cUbW?usp=sharing

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes:
