### PR TITLE
Revert flexible merging, Filter out empty detections

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -929,9 +929,7 @@ class Detections:
             ```
         """
         detections_list = [
-            detections
-            for detections in detections_list
-            if detections != Detections.empty()
+            detections for detections in detections_list if not is_empty(detections)
         ]
 
         if len(detections_list) == 0:
@@ -1398,3 +1396,9 @@ def validate_fields_both_defined_or_none(
                 f"Field '{attribute}' should be consistently None or not None in both "
                 "Detections."
             )
+
+
+def is_empty(detections: Detections) -> bool:
+    empty_detections = Detections.empty()
+    empty_detections.data = detections.data
+    return detections == empty_detections

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -878,6 +878,14 @@ class Detections:
             class_id=np.array([], dtype=int),
         )
 
+    def is_empty(self) -> bool:
+        """
+        Returns `True` if the `Detections` object is considered empty.
+        """
+        empty_detections = Detections.empty()
+        empty_detections.data = self.data
+        return self == empty_detections
+
     @classmethod
     def merge(cls, detections_list: List[Detections]) -> Detections:
         """
@@ -929,7 +937,7 @@ class Detections:
             ```
         """
         detections_list = [
-            detections for detections in detections_list if not is_empty(detections)
+            detections for detections in detections_list if not detections.is_empty()
         ]
 
         if len(detections_list) == 0:
@@ -1396,9 +1404,3 @@ def validate_fields_both_defined_or_none(
                 f"Field '{attribute}' should be consistently None or not None in both "
                 "Detections."
             )
-
-
-def is_empty(detections: Detections) -> bool:
-    empty_detections = Detections.empty()
-    empty_detections.data = detections.data
-    return detections == empty_detections

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -898,6 +898,10 @@ class Detections:
         For example, if merging Detections with 3 and 4 detected objects, this method
         will return a Detections with 7 objects (7 entries in `xyxy`, `mask`, etc).
 
+        !!! Note
+
+            When merging, empty `Detections` objects are ignored.
+
         Args:
             detections_list (List[Detections]): A list of Detections objects to merge.
 

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -928,6 +928,12 @@ class Detections:
             array([0.1, 0.2, 0.3])
             ```
         """
+        detections_list = [
+            detections
+            for detections in detections_list
+            if detections != Detections.empty()
+        ]
+
         if len(detections_list) == 0:
             return Detections.empty()
 
@@ -946,12 +952,13 @@ class Detections:
         def stack_or_none(name: str):
             if all(d.__getattribute__(name) is None for d in detections_list):
                 return None
-            stack_list = [
-                d.__getattribute__(name)
-                for d in detections_list
-                if d.__getattribute__(name) is not None
-            ]
-            return np.vstack(stack_list) if name == "mask" else np.hstack(stack_list)
+            if any(d.__getattribute__(name) is None for d in detections_list):
+                raise ValueError(f"All or none of the '{name}' fields must be None")
+            return (
+                np.vstack([d.__getattribute__(name) for d in detections_list])
+                if name == "mask"
+                else np.hstack([d.__getattribute__(name) for d in detections_list])
+            )
 
         mask = stack_or_none("mask")
         confidence = stack_or_none("confidence")

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -631,6 +631,10 @@ def merge_data(
     if not data_list:
         return {}
 
+    all_keys_sets = [set(data.keys()) for data in data_list]
+    if not all(keys_set == all_keys_sets[0] for keys_set in all_keys_sets):
+        raise ValueError("All data dictionaries must have the same keys to merge.")
+
     for data in data_list:
         lengths = [len(value) for value in data.values()]
         if len(set(lengths)) > 1:
@@ -638,21 +642,7 @@ def merge_data(
                 "All data values within a single object must have equal length."
             )
 
-    keys_by_data = [set(data.keys()) for data in data_list]
-    keys_by_data = [keys for keys in keys_by_data if len(keys) > 0]
-    if not keys_by_data:
-        return {}
-
-    common_keys = set.intersection(*keys_by_data)
-    all_keys = set.union(*keys_by_data)
-    if common_keys != all_keys:
-        raise ValueError(
-            f"All sv.Detections.data dictionaries must have the same keys. Common "
-            f"keys: {common_keys}, but some dictionaries have additional keys: "
-            f"{all_keys.difference(common_keys)}."
-        )
-
-    merged_data = {key: [] for key in all_keys}
+    merged_data = {key: [] for key in all_keys_sets[0]}
     for data in data_list:
         for key in data:
             merged_data[key].append(data[key])

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -245,7 +245,6 @@ def test_getitem(
             TEST_DET_1_2,
             DoesNotRaise(),
         ),  # Fields with same keys
-        # Fields and empty
         (
             [TEST_DET_1, Detections.empty()],
             TEST_DET_1,
@@ -264,9 +263,9 @@ def test_getitem(
                 TEST_DET_1,
                 TEST_DET_NONE,
             ],
-            TEST_DET_1,
-            DoesNotRaise(),
-        ),  # Single detection and None fields (+ missing Dict keys)
+            None,
+            pytest.raises(ValueError),
+        ),  # Empty detection, but not Detections.empty()
         # Errors: Non-zero-length differently defined keys & data
         (
             [TEST_DET_1, TEST_DET_DIFFERENT_FIELDS],
@@ -278,6 +277,22 @@ def test_getitem(
             None,
             pytest.raises(ValueError),
         ),  # Non-empty detections with different data keys
+        (
+            [
+                mock_detections(
+                    xyxy=[[10, 10, 20, 20]],
+                    class_id=[1],
+                    mask=[np.zeros((4, 4), dtype=bool)],
+                ),
+                Detections.empty(),
+            ],
+            mock_detections(
+                xyxy=[[10, 10, 20, 20]],
+                class_id=[1],
+                mask=[np.zeros((4, 4), dtype=bool)],
+            ),
+            DoesNotRaise(),
+        ),  # Segmentation + Empty
     ],
 )
 def test_merge(
@@ -285,6 +300,9 @@ def test_merge(
     expected_result: Optional[Detections],
     exception: Exception,
 ) -> None:
+    print(len(detections_list))
+    for det in detections_list:
+        print(det)
     with exception:
         result = Detections.merge(detections_list=detections_list)
         assert result == expected_result

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -300,9 +300,6 @@ def test_merge(
     expected_result: Optional[Detections],
     exception: Exception,
 ) -> None:
-    print(len(detections_list))
-    for det in detections_list:
-        print(det)
     with exception:
         result = Detections.merge(detections_list=detections_list)
         assert result == expected_result

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -720,8 +720,8 @@ def test_calculate_masks_centroids(
         ),  # two data dicts with the same field name and different length arrays values
         (
             [{}, {"test_1": [1, 2, 3]}],
-            {"test_1": [1, 2, 3]},
-            DoesNotRaise(),
+            None,
+            pytest.raises(ValueError),
         ),  # two data dicts; one empty and one non-empty dict
         (
             [{"test_1": [], "test_2": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],


### PR DESCRIPTION
# Description

`Detections.merge` creates an invalid `Detections` object when the following are true:
1. Detections 1 have `confidence=None` or `class_id=None`, and is of length > 0.
2. Detections 2 are created with `Detections.empty()`, so have `confidence=np.empty` and `class_id=np.empty`. 

This results in a detection of mixed lengths: `len(xyxy) > 0`, `len(confidence) == 0`.

---

This proposed solution:
1. Adds one test case showing the error
2. Adds a filter discarding empty detections at the start of Detections.merge.
3. Reverts the flexible merging introduced in https://github.com/roboflow/supervision/pull/1177
    * I suggest doing a diff with `0.20.0` to check.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

1 Test case + Colab: https://colab.research.google.com/drive/1KWsVmbS6pCPdy5yPyHtwiJfGkf7NX5g7?usp=sharing

## Any specific deployment considerations

Alternative solutions:
1. Remove `class_id` and `confidence` from `Detections.empty`
2. `is_empty` can be simplified if we removed the data set in `from_inference`
3. Alternative PR: do not revert flexible merge: #1256 
    * If we clean up `Detections.empty`, then reverting flexible merge won't be needed.
