### PR TITLE
Fix/detections merge only filter out empty

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -928,6 +928,12 @@ class Detections:
             array([0.1, 0.2, 0.3])
             ```
         """
+        detections_list = [
+            detections
+            for detections in detections_list
+            if detections != Detections.empty()
+        ]
+
         if len(detections_list) == 0:
             return Detections.empty()
 

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -929,9 +929,7 @@ class Detections:
             ```
         """
         detections_list = [
-            detections
-            for detections in detections_list
-            if detections != Detections.empty()
+            detections for detections in detections_list if not is_empty(detections)
         ]
 
         if len(detections_list) == 0:
@@ -1397,3 +1395,9 @@ def validate_fields_both_defined_or_none(
                 f"Field '{attribute}' should be consistently None or not None in both "
                 "Detections."
             )
+
+
+def is_empty(detections: Detections) -> bool:
+    empty_detections = Detections.empty()
+    empty_detections.data = detections.data
+    return detections == empty_detections

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -278,6 +278,22 @@ def test_getitem(
             None,
             pytest.raises(ValueError),
         ),  # Non-empty detections with different data keys
+        (
+            [
+                mock_detections(
+                    xyxy=[[10, 10, 20, 20]],
+                    class_id=[1],
+                    mask=[np.zeros((4, 4), dtype=bool)],
+                ),
+                Detections.empty(),
+            ],
+            mock_detections(
+                xyxy=[[10, 10, 20, 20]],
+                class_id=[1],
+                mask=[np.zeros((4, 4), dtype=bool)],
+            ),
+            DoesNotRaise(),
+        ),  # Segmentation + Empty
     ],
 )
 def test_merge(


### PR DESCRIPTION
# Description

`Detections.merge` creates an invalid `Detections` object when the following are true:
1. Detections 1 have `confidence=None` or `class_id=None`, and is of length > 0.
2. Detections 2 are created with `Detections.empty()`, so have `confidence=np.empty` and `class_id=np.empty`. 

This results in a detection of mixed lengths: `len(xyxy) > 0`, `len(confidence) == 0`.

---

This proposed solution:
1. Adds one test case showing the error
2. Adds a filter discarding empty detections at the start of Detections.merge.
3. Does NOT revert the flexible merge rules introduced in https://github.com/roboflow/supervision/pull/1177

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

1 Test case + Colab: https://colab.research.google.com/drive/1KWsVmbS6pCPdy5yPyHtwiJfGkf7NX5g7?usp=sharing

## Any specific deployment considerations

Alternative solutions:
1. Remove `class_id` and `confidence` from `Detections.empty`
2. `is_empty` can be simplified if we removed the data set in `from_inference`
3. Alternative PR: also revert flexible merge: #1255 
    * If we clean up `Detections.empty`, then reverting flexible merge wouldn't be needed.
