### PR TITLE
Update "New" tags in docs, fixed typo in one heading

### DIFF
--- a/docs/cookbooks.md
+++ b/docs/cookbooks.md
@@ -1,7 +1,6 @@
 ---
 template: cookbooks.html
 comments: true
-status: new
 hide:
   - navigation
   - toc

--- a/docs/detection/annotators.md
+++ b/docs/detection/annotators.md
@@ -1,6 +1,5 @@
 ---
 comments: true
-status: new
 ---
 
 # Annotators

--- a/docs/detection/tools/line_zone.md
+++ b/docs/detection/tools/line_zone.md
@@ -1,5 +1,6 @@
 ---
 comments: true
+status: new
 ---
 
 <div class="md-typeset">

--- a/docs/detection/tools/save_detections.md
+++ b/docs/detection/tools/save_detections.md
@@ -1,6 +1,5 @@
 ---
 comments: true
-status: new
 ---
 
 # Save Detections

--- a/docs/detection/utils.md
+++ b/docs/detection/utils.md
@@ -1,6 +1,5 @@
 ---
 comments: true
-status: new
 ---
 
 # Detection Utils

--- a/docs/how_to/detect_and_annotate.md
+++ b/docs/how_to/detect_and_annotate.md
@@ -1,6 +1,5 @@
 ---
 comments: true
-status: new
 ---
 
 # Detect and Annotate

--- a/docs/how_to/save_detections.md
+++ b/docs/how_to/save_detections.md
@@ -1,6 +1,5 @@
 ---
 comments: true
-status: new
 ---
 
 # Save Detections

--- a/docs/trackers.md
+++ b/docs/trackers.md
@@ -1,6 +1,5 @@
 ---
 comments: true
-status: new
 ---
 
 # ByteTrack

--- a/docs/utils/image.md
+++ b/docs/utils/image.md
@@ -1,6 +1,5 @@
 ---
 comments: true
-status: new
 ---
 
 # Image Utils
@@ -12,7 +11,7 @@ status: new
 :::supervision.utils.image.crop_image
 
 <div class="md-typeset">
-    <h2><a href="#supervision.utils.image.scale_image">crop_image</a></h2>
+    <h2><a href="#supervision.utils.image.scale_image">scale_image</a></h2>
 </div>
 
 :::supervision.utils.image.scale_image

--- a/docs/utils/iterables.md
+++ b/docs/utils/iterables.md
@@ -1,6 +1,5 @@
 ---
 comments: true
-status: new
 ---
 
 # Iterables Utils


### PR DESCRIPTION
# Description

1. Removed old "New" tags, added tags to pages with large additions in 0.21.0
2. "crop" -> "scale" in one heading (as two entries for crop were present)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

`mkdocs serve` -> 👀 

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:
1. New / old tags
2. crop -> scale in one heading (as two entries for crop were present)