### PR TITLE
returned empty slice of detection instead of new empty detection object (bug fix)

### DIFF
--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -321,7 +321,7 @@ class ByteTrack:
             return detections[detections.tracker_id != -1]
 
         else:
-            detections = Detections.empty()
+            detections = detections[[]]
             detections.tracker_id = np.array([], dtype=int)
 
             return detections


### PR DESCRIPTION
This keeps the keys of the data field the same

# Description

Currently when there are no tracks an empty detections object is returned which doesn't have the keys of data field that were in the original detections field, with this change those keys are also kept.

List any dependencies that are required for this change.

N/A

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?
It was tested on my local branch now we have 
``` python
def test_keys_of_data_field(tracker, detection):
    """
    Test to verify that the keys of the .data field of the detection 
    and detection_with_tracking objects are the same.
    """
    detection_with_tracking = tracker.update_with_detections(detection)
    
    detection_keys = detection.data.keys()
    detection_with_tracking_keys = detection_with_tracking.data.keys()
    
    assert detection_keys == detection_with_tracking_keys, (
        f"Keys do not match: Detection keys: {detection_keys}, "
        f"Detection with tracking keys: {detection_with_tracking_keys}"
    )
```

YOUR_ANSWER

## Any specific deployment considerations
N/A

## Docs
N/A 
