### PR TITLE
Numpy upper limit: `<2.0.0`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4258,4 +4258,4 @@ desktop = ["opencv-python"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "e3d79f6c93041323b04c7b45e93bb3c4198b21889044004af8a0485a6145a207"
+content-hash = "19649609326e741c97bf1b32b28dc5dee72e18d9ce2a53c554980c81e0fe49a9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers=[
 
 [tool.poetry.dependencies]
 python = "^3.8"
-numpy = ">=1.21.2"
+numpy = ">=1.21.2,<2.0.0"
 scipy = [
     { version = "1.10.0", python = "<3.9" },
     { version = "^1.10.0", python = ">=3.9" }


### PR DESCRIPTION
# Description

As of a few days ago, an error is raised when attempting to load `cv2`, as it does not support numpy `2.0.0`. This results in our CI tests failing and may have consequences for end-users.

Until all our dependencies expand support, let's pin numpy to `<2.0.0`.  

See more: https://github.com/opencv/opencv-python/issues/943#issuecomment-2171817940

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

1. `pytest` passes
2. `poetry install --with dev` works
3. Verified that changes to the lock file are minimal
4. importing cv2 and numpy work
5. Hopefully CI builds succeeds, unlike in https://github.com/roboflow/supervision/pull/1286

## Any specific deployment considerations

I have not done anything with respect to versioning. We should think about releasing this as `0.21.1`.

## Docs
