### PR TITLE
detectron2 mask convert to detection

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -540,7 +540,9 @@ class Detections:
         return cls(
             xyxy=detectron2_results["instances"].pred_boxes.tensor.cpu().numpy(),
             confidence=detectron2_results["instances"].scores.cpu().numpy(),
-            mask=detectron2_results["instances"].pred_masks.detach().cpu().numpy(),
+            mask=detectron2_results["instances"].pred_masks.cpu().numpy()
+            if hasattr(detectron2_results["instances"], "pred_masks")
+            else None,
             class_id=detectron2_results["instances"]
             .pred_classes.cpu()
             .numpy()

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -540,7 +540,7 @@ class Detections:
         return cls(
             xyxy=detectron2_results["instances"].pred_boxes.tensor.cpu().numpy(),
             confidence=detectron2_results["instances"].scores.cpu().numpy(),
-            mask=detectron2_results['instances'].pred_masks.detach().cpu().numpy(),
+            mask=detectron2_results["instances"].pred_masks.detach().cpu().numpy(),
             class_id=detectron2_results["instances"]
             .pred_classes.cpu()
             .numpy()

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -540,6 +540,7 @@ class Detections:
         return cls(
             xyxy=detectron2_results["instances"].pred_boxes.tensor.cpu().numpy(),
             confidence=detectron2_results["instances"].scores.cpu().numpy(),
+            mask=detectron2_results['instances'].pred_masks.detach().cpu().numpy(),
             class_id=detectron2_results["instances"]
             .pred_classes.cpu()
             .numpy()


### PR DESCRIPTION
# Description
Copying segmentation masks from detectron2 predictions to the detection class. The resulting masks can be used for displaying with sv.MaskAnnotator(). 

## Type of change

Please delete options that are not relevant.
-   [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?
The code is executed:
detections = sv.Detections.from_detectron2(p_det)
bounding_box_annotator = sv.MaskAnnotator()
annotated_frame = bounding_box_annotator.annotate(
    scene=img.copy(),
    detections=detections,
)
