### PR TITLE
Updated overlay_image function in CropAnnotator

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2089,7 +2089,7 @@ class CropAnnotator(BaseAnnotator):
                 anchor=anchor, crop_wh=crop_wh, position=self.position
             )
             scene = overlay_image(
-                scene=scene, inserted_image=resized_crop, anchor=(x1, y1)
+                image=scene, overlay=resized_crop, anchor=(x1, y1)
             )
             color = resolve_color(
                 color=self.border_color,

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2088,9 +2088,7 @@ class CropAnnotator(BaseAnnotator):
             (x1, y1), (x2, y2) = self.calculate_crop_coordinates(
                 anchor=anchor, crop_wh=crop_wh, position=self.position
             )
-            scene = overlay_image(
-                image=scene, overlay=resized_crop, anchor=(x1, y1)
-            )
+            scene = overlay_image(image=scene, overlay=resized_crop, anchor=(x1, y1))
             color = resolve_color(
                 color=self.border_color,
                 detections=detections,


### PR DESCRIPTION
# Description

Fixes #1301 

The overlay_image function in the used in the `CropAnnotator` class [here](https://github.com/roboflow/supervision/blob/f00dcede1a2e0e3bca0f403ed4a0d23e16cde937/supervision/annotators/core.py#L2105) had different parameters as compared to the overlay_image function defined over [here](https://github.com/roboflow/supervision/blob/f00dcede1a2e0e3bca0f403ed4a0d23e16cde937/supervision/utils/image.py#L293). Soo fixed that issue by changing it in the `CropAnnotator` class.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I will update a [colab](https://colab.research.google.com/drive/1P7iwFNeg2uv35ZhqnjXhu6rbPfrbfTTW?usp=sharing) notebook showing the changes and running the code. 

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
