### PR TITLE
Fix bug where florence2 returns normalized xyxy regions

### DIFF
--- a/supervision/detection/lmm.py
+++ b/supervision/detection/lmm.py
@@ -174,7 +174,9 @@ def from_florence_2(
             match is not None
         ), f"Expected string to end in location tags, but got {result}"
 
+        w, h = resolution_wh
         xyxy = np.array([match.groups()], dtype=np.float32)
+        xyxy *= np.array([w, h, w, h]) / 1000
         result_string = result[: match.start()]
         labels = np.array([result_string])
         return xyxy, labels, None, None

--- a/test/detection/test_lmm_florence_2.py
+++ b/test/detection/test_lmm_florence_2.py
@@ -237,7 +237,7 @@ from supervision.detection.lmm import from_florence_2
             DoesNotRaise(),
         ),
         (  # Region to Category: detected
-            {"<REGION_TO_CATEGORY>": "some object<loc_3><loc_4><loc_5><loc_6>"},
+            {"<REGION_TO_CATEGORY>": "some object<loc_300><loc_400><loc_500><loc_600>"},
             (10, 10),
             (
                 np.array([[3, 4, 5, 6]], dtype=np.float32),
@@ -254,11 +254,11 @@ from supervision.detection.lmm import from_florence_2
             DoesNotRaise(),
         ),
         (  # Region to Description: detected
-            {"<REGION_TO_DESCRIPTION>": "some description<loc_3><loc_4><loc_5><loc_6>"},
+            {"<REGION_TO_DESCRIPTION>": "descr<loc_300><loc_400><loc_500><loc_600>"},
             (10, 10),
             (
                 np.array([[3, 4, 5, 6]], dtype=np.float32),
-                np.array(["some description"]),
+                np.array(["descr"]),
                 None,
                 None,
             ),


### PR DESCRIPTION
# Description

Florence 2 would previously return normalized xyxy regions. It should be corrected to box coordinates.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested in Colab: https://colab.research.google.com/drive/1Lq9LcIVlgVlUpHDBKcVYbXp7ZuY20K7g#scrollTo=P_Vkd5gcxbqW

## Any specific deployment considerations

Change any Colabs where boxes are explicitly de-normalized.

## Docs

-   [ ] Docs updated? What were the changes:
