### PR TITLE
Add cheatsheet links in supervision docs, readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ len(dataset)
 
 ## 🎬 tutorials
 
-Want to learn how to use Supervision? Explore our [how-to guides](https://supervision.roboflow.com/develop/how_to/detect_and_annotate/), [end-to-end examples](https://github.com/roboflow/supervision/tree/develop/examples), and [cookbooks](https://supervision.roboflow.com/develop/cookbooks/)!
+Want to learn how to use Supervision? Explore our [how-to guides](https://supervision.roboflow.com/develop/how_to/detect_and_annotate/), [end-to-end examples](https://github.com/roboflow/supervision/tree/develop/examples), [cheatsheet](https://roboflow.github.io/cheatsheet-supervision/), and [cookbooks](https://supervision.roboflow.com/develop/cookbooks/)!
 
 <br/>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,4 +146,13 @@ You can install `supervision` in a
 
     Master the techniques to selectively filter and focus on objects within a specific zone
 
+-   **Cheatsheet**
+
+    ***
+
+    Access a quick reference guide to the most common `supervision` functions
+
+    [:octicons-arrow-right-24: Cheatsheet](https://roboflow.github.io/cheatsheet-supervision/)
+
+
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
         - Geometry: utils/geometry.md
     - Assets: assets.md
   - Cookbooks: cookbooks.md
+  - Cheatsheet: https://roboflow.github.io/cheatsheet-supervision/
   - Contribute:
     - Contributing: contributing.md
     - Code of Conduct: code_of_conduct.md


### PR DESCRIPTION
# Description

Supervision cheatsheet was previously only posted on LinkedIn.

This change adds mention to it in supervision docs:
1. Readme
2. Nav bar (top bar)
3. Quickstart Cards at the bottom

## Type of change

-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

mkdocs serve

## Any specific deployment considerations

## Docs

-   [x] Docs updated? What were the changes:

Added cheatsheet to:
1. Readme
2. Nav bar (top bar)
3. Quickstart Cards at the bottom
