### PR TITLE
Change how frames are skipped in the generator

### DIFF
--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -162,7 +162,7 @@ def get_video_frames_generator(
             should stop generating frames. If None, video will be read to the end.
         manual_seek (bool): If True, the generator will manually seek to the
             `start` frame by grabbing each frame, which is much slower. This is a
-            workaround for videos that don't open at all when you set the 'start' value.
+            workaround for videos that don't open at all when you set the `start` value.
 
     Returns:
         (Generator[np.ndarray, None, None]): A generator that yields the

--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -127,7 +127,6 @@ def _validate_and_setup_video(source_path: str, start: int, end: Optional[int]):
         raise Exception("Requested frames are outbound")
     start = max(start, 0)
     end = min(end, total_frames) if end is not None else total_frames
-    video.set(cv2.CAP_PROP_POS_FRAMES, start)
     return video, start, end
 
 
@@ -159,9 +158,12 @@ def get_video_frames_generator(
         ```
     """
     video, start, end = _validate_and_setup_video(source_path, start, end)
-    frame_position = start
+    frame_position = 0
     while True:
         success, frame = video.read()
+        if frame_position < start:
+            frame_position += 1
+            continue
         if not success or frame_position >= end:
             break
         yield frame

--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -118,7 +118,9 @@ class VideoSink:
         self.__writer.release()
 
 
-def _validate_and_setup_video(source_path: str, start: int, end: Optional[int], manual_seek: bool = False):
+def _validate_and_setup_video(
+    source_path: str, start: int, end: Optional[int], manual_seek: bool = False
+):
     video = cv2.VideoCapture(source_path)
     if not video.isOpened():
         raise Exception(f"Could not open video at {source_path}")
@@ -127,7 +129,7 @@ def _validate_and_setup_video(source_path: str, start: int, end: Optional[int], 
         raise Exception("Requested frames are outbound")
     start = max(start, 0)
     end = min(end, total_frames) if end is not None else total_frames
-    
+
     if manual_seek:
         while start > 0:
             success = video.grab()
@@ -136,12 +138,16 @@ def _validate_and_setup_video(source_path: str, start: int, end: Optional[int], 
             start -= 1
     elif start > 0:
         video.set(cv2.CAP_PROP_POS_FRAMES, start)
-    
+
     return video, start, end
 
 
 def get_video_frames_generator(
-    source_path: str, stride: int = 1, start: int = 0, end: Optional[int] = None, manual_seek: bool = False
+    source_path: str,
+    stride: int = 1,
+    start: int = 0,
+    end: Optional[int] = None,
+    manual_seek: bool = False,
 ) -> Generator[np.ndarray, None, None]:
     """
     Get a generator that yields the frames of the video.


### PR DESCRIPTION
# Description

For some videos, e.g. the one in #1345, the frame generator generates no frames. This happens when `video.get(cv2.CAP_PROP_POS_FRAMES, x)` is called, even when `x = video.get(cv2.CAP_PROP_FRAME_COUNT)`.

Since we use this to skip the first N frames, we can do it manually instead by retrieving and dropping them.

This has the potential to affect many codebases, so thorough tests are needed.

At the very least. this should work on:
1. Videos in` supervision.assets`
2. ~~Videos in #1345~~ Already tested.
3. 5 videos from different online sources, ideally with different video formats.
4. Bonus: I had some GoPro videos that had invalid frames at the start. I should test with those.

Please delete options that are not relevant.
-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally on Videos of #1345

## Any specific deployment considerations

## Docs

-   [ ] Docs updated? What were the changes:
