### PR TITLE
Move OBB boxes

### DIFF
--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 
-from supervision import config
+from supervision.config import ORIENTED_BOX_COORDINATES as o_b_c
 from supervision.detection.core import Detections
 from supervision.detection.overlap_filter import OverlapFilter, validate_overlap_filter
 from supervision.detection.utils import move_boxes, move_masks, move_obb_boxes
@@ -29,9 +29,9 @@ def move_detections(
         (sv.Detections) repositioned Detections object.
     """
     detections.xyxy = move_boxes(xyxy=detections.xyxy, offset=offset)
-    if config.ORIENTED_BOX_COORDINATES in detections.data:
-        detections.data[config.ORIENTED_BOX_COORDINATES] = move_obb_boxes(
-            xyxyxyxy=detections.data[config.ORIENTED_BOX_COORDINATES], offset=offset
+    if o_b_c in detections.data:
+        detections.data[o_b_c] = move_obb_boxes(
+            xyxyxyxy=detections.data[o_b_c], offset=offset
         )
     if detections.mask is not None:
         if resolution_wh is None:

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -9,6 +9,7 @@ from supervision.detection.overlap_filter import OverlapFilter, validate_overlap
 from supervision.detection.utils import move_boxes, move_masks, move_obb_boxes
 from supervision.utils.image import crop_image
 from supervision.utils.internal import SupervisionWarnings
+from supervision import config
 
 
 def move_detections(
@@ -28,9 +29,9 @@ def move_detections(
         (sv.Detections) repositioned Detections object.
     """
     detections.xyxy = move_boxes(xyxy=detections.xyxy, offset=offset)
-    if "ORIENTED_BOX_COORDINATES" in detections.data:
-        detections.data["ORIENTED_BOX_COORDINATES"] = move_obb_boxes(
-            xyss=detections.data["ORIENTED_BOX_COORDINATES"], offset=offset
+    if config.ORIENTED_BOX_COORDINATES in detections.data:
+        detections.data[config.ORIENTED_BOX_COORDINATES] = move_obb_boxes(
+            xyxyxyxy=detections.data[config.ORIENTED_BOX_COORDINATES], offset=offset
         )
     if detections.mask is not None:
         if resolution_wh is None:

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -28,9 +28,9 @@ def move_detections(
         (sv.Detections) repositioned Detections object.
     """
     detections.xyxy = move_boxes(xyxy=detections.xyxy, offset=offset)
-    if "xyxyxyxy" in detections.data:
-        detections.data["xyxyxyxy"] = move_obb_boxes(
-            xyxyxyxy=detections.data["xyxyxyxy"], offset=offset
+    if "ORIENTED_BOX_COORDINATES" in detections.data:
+        detections.data["ORIENTED_BOX_COORDINATES"] = move_obb_boxes(
+            xyss=detections.data["ORIENTED_BOX_COORDINATES"], offset=offset
         )
     if detections.mask is not None:
         if resolution_wh is None:

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from supervision.detection.core import Detections
 from supervision.detection.overlap_filter import OverlapFilter, validate_overlap_filter
-from supervision.detection.utils import move_boxes, move_masks
+from supervision.detection.utils import move_boxes, move_masks, move_obb_boxes
 from supervision.utils.image import crop_image
 from supervision.utils.internal import SupervisionWarnings
 
@@ -28,6 +28,8 @@ def move_detections(
         (sv.Detections) repositioned Detections object.
     """
     detections.xyxy = move_boxes(xyxy=detections.xyxy, offset=offset)
+    if 'xyxyxyxy' in detections:
+        detections.xyxyxyxy = move_obb_boxes(xyxyxyxy = detections.xyxyxyxy, offset = offset) 
     if detections.mask is not None:
         if resolution_wh is None:
             raise ValueError(

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -28,9 +28,9 @@ def move_detections(
         (sv.Detections) repositioned Detections object.
     """
     detections.xyxy = move_boxes(xyxy=detections.xyxy, offset=offset)
-    if "xyxyxyxy" in detections:
-        detections.xyxyxyxy = move_obb_boxes(
-            xyxyxyxy=detections.xyxyxyxy, offset=offset
+    if "xyxyxyxy" in detections.data:
+        detections.data["xyxyxyxy"] = move_obb_boxes(
+            xyxyxyxy=detections.data["xyxyxyxy"], offset=offset
         )
     if detections.mask is not None:
         if resolution_wh is None:

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -28,8 +28,10 @@ def move_detections(
         (sv.Detections) repositioned Detections object.
     """
     detections.xyxy = move_boxes(xyxy=detections.xyxy, offset=offset)
-    if 'xyxyxyxy' in detections:
-        detections.xyxyxyxy = move_obb_boxes(xyxyxyxy = detections.xyxyxyxy, offset = offset) 
+    if "xyxyxyxy" in detections:
+        detections.xyxyxyxy = move_obb_boxes(
+            xyxyxyxy=detections.xyxyxyxy, offset=offset
+        )
     if detections.mask is not None:
         if resolution_wh is None:
             raise ValueError(

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -4,12 +4,12 @@ from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 
+from supervision import config
 from supervision.detection.core import Detections
 from supervision.detection.overlap_filter import OverlapFilter, validate_overlap_filter
 from supervision.detection.utils import move_boxes, move_masks, move_obb_boxes
 from supervision.utils.image import crop_image
 from supervision.utils.internal import SupervisionWarnings
-from supervision import config
 
 
 def move_detections(

--- a/supervision/detection/tools/inference_slicer.py
+++ b/supervision/detection/tools/inference_slicer.py
@@ -4,10 +4,10 @@ from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 
-from supervision.config import ORIENTED_BOX_COORDINATES as o_b_c
+from supervision.config import ORIENTED_BOX_COORDINATES
 from supervision.detection.core import Detections
 from supervision.detection.overlap_filter import OverlapFilter, validate_overlap_filter
-from supervision.detection.utils import move_boxes, move_masks, move_obb_boxes
+from supervision.detection.utils import move_boxes, move_masks, move_oriented_boxes
 from supervision.utils.image import crop_image
 from supervision.utils.internal import SupervisionWarnings
 
@@ -29,9 +29,9 @@ def move_detections(
         (sv.Detections) repositioned Detections object.
     """
     detections.xyxy = move_boxes(xyxy=detections.xyxy, offset=offset)
-    if o_b_c in detections.data:
-        detections.data[o_b_c] = move_obb_boxes(
-            xyxyxyxy=detections.data[o_b_c], offset=offset
+    if ORIENTED_BOX_COORDINATES in detections.data:
+        detections.data[ORIENTED_BOX_COORDINATES] = move_oriented_boxes(
+            xyxyxyxy=detections.data[ORIENTED_BOX_COORDINATES], offset=offset
         )
     if detections.mask is not None:
         if resolution_wh is None:

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -596,8 +596,9 @@ def move_boxes(
     return xyxy + np.hstack([offset, offset])
 
 
-def move_obb_boxes(xyss: npt.NDArray[np.float64], offset: npt.NDArray[np.int32]
-                  ) -> npt.NDArray[np.float64]:
+def move_obb_boxes(
+    xyss: npt.NDArray[np.float64], offset: npt.NDArray[np.int32]
+) -> npt.NDArray[np.float64]:
     """
     Parameters:
         xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 4, 2)` containing the

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -612,17 +612,23 @@ def move_obb_boxes(xyxyxyxy, offset):
         import numpy as np
         import supervision as sv
 
-        xyxyxyxy: np.array([[10, 10, 20, 20, 30, 30, 40, 40],
-                            [20, 20, 30, 30, 40, 40, 50, 50]])
+        xyxyxyxy: np.array([[[10., 10.],
+                            [20., 20.],
+                            [30., 30.],
+                            [40., 40.]]])
         offset = np.array([5, 10])
 
         sv.move_obb_boxes(xyxyxyxy=xyxyxyxy, offset=offset)
-        #[[15 20 25 30 35 40 45 50]
-        #[25 30 35 40 45 50 55 60]]
+        #[[[15., 20.],
+        #[25., 30.],
+        #[35., 40.],
+        #[45., 50.]]]
         ```
     """
 
-    return xyxyxyxy + np.hstack([offset, offset, offset, offset])
+    return xyxyxyxy + np.hstack([offset, offset, offset, offset]).reshape(
+        xyxyxyxy.shape
+    )
 
 
 def move_masks(

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -596,9 +596,8 @@ def move_boxes(
     return xyxy + np.hstack([offset, offset])
 
 
-def move_obb_boxes(
-    xyss: npt.NDArray[np.float64], offset: npt.NDArray[np.int32]
-) -> npt.NDArray[np.float64]:
+def move_obb_boxes(xyxyxyxy: npt.NDArray[np.float64], offset: npt.NDArray[np.int32]
+                  ) -> npt.NDArray[np.float64]:
     """
     Parameters:
         xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 4, 2)` containing the
@@ -630,7 +629,7 @@ def move_obb_boxes(
     """
     return [
         xys + np.hstack([offset, offset, offset, offset]).reshape(xys.shape)
-        for xys in xyss
+        for xys in xyxyxyxy
     ]
 
 

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -601,7 +601,7 @@ def move_obb_boxes(xyxyxyxy, offset):
     Parameters:
         xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 4, 2)` containing the
         bounding boxes coordinates in format
-        `n * [[x1, y1], [x2, y2],[x3, y3], [x4, y4]]`
+        `n[[x1, y1], [x2, y2],[x3, y3], [x4, y4]]`
         offset (np.array): An array of shape `(2,)` containing offset values
         in format is `[dx, dy]`.
 

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -595,6 +595,7 @@ def move_boxes(
     """
     return xyxy + np.hstack([offset, offset])
 
+
 def move_obb_boxes(xyxyxyxy, offset):
     """
     Parameters:
@@ -604,7 +605,7 @@ def move_obb_boxes(xyxyxyxy, offset):
             is `[dx, dy]`.
 
     Returns:
-        npt.NDArray[np.float64]: Repositioned oriented bounding boxes. 
+        npt.NDArray[np.float64]: Repositioned oriented bounding boxes.
 
     Examples:
         ```python
@@ -622,6 +623,7 @@ def move_obb_boxes(xyxyxyxy, offset):
     """
 
     return xyxyxyxy + np.hstack([offset, offset, offset, offset])
+
 
 def move_masks(
     masks: npt.NDArray[np.bool_],

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -599,10 +599,11 @@ def move_boxes(
 def move_obb_boxes(xyxyxyxy, offset):
     """
     Parameters:
-        xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 8)` containing the
-            bounding boxes coordinates in format `[x1, y1, x2, y2,x3, y3, x4, y4]`
-        offset (np.array): An array of shape `(2,)` containing offset values in format
-            is `[dx, dy]`.
+        xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 4, 2)` containing the
+        bounding boxes coordinates in format
+        `n * [[x1, y1], [x2, y2],[x3, y3], [x4, y4]]`
+        offset (np.array): An array of shape `(2,)` containing offset values
+        in format is `[dx, dy]`.
 
     Returns:
         npt.NDArray[np.float64]: Repositioned oriented bounding boxes.
@@ -625,10 +626,10 @@ def move_obb_boxes(xyxyxyxy, offset):
         #[45., 50.]]]
         ```
     """
-
-    return xyxyxyxy + np.hstack([offset, offset, offset, offset]).reshape(
-        xyxyxyxy.shape
-    )
+    return [
+        xys + np.hstack([offset, offset, offset, offset]).reshape(xys.shape)
+        for xys in xyxyxyxy
+    ]
 
 
 def move_masks(

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -596,7 +596,8 @@ def move_boxes(
     return xyxy + np.hstack([offset, offset])
 
 
-def move_obb_boxes(xyxyxyxy, offset):
+def move_obb_boxes(xyss: npt.NDArray[np.float64], offset: npt.NDArray[np.int32]
+                  ) -> npt.NDArray[np.float64]:
     """
     Parameters:
         xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 4, 2)` containing the
@@ -619,7 +620,7 @@ def move_obb_boxes(xyxyxyxy, offset):
                             [40., 40.]]])
         offset = np.array([5, 10])
 
-        sv.move_obb_boxes(xyxyxyxy=xyxyxyxy, offset=offset)
+        sv.move_obb_boxes(xyss, offset=offset)
         #[[[15., 20.],
         #[25., 30.],
         #[35., 40.],
@@ -628,7 +629,7 @@ def move_obb_boxes(xyxyxyxy, offset):
     """
     return [
         xys + np.hstack([offset, offset, offset, offset]).reshape(xys.shape)
-        for xys in xyxyxyxy
+        for xys in xyss
     ]
 
 

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -595,6 +595,33 @@ def move_boxes(
     """
     return xyxy + np.hstack([offset, offset])
 
+def move_obb_boxes(xyxyxyxy, offset):
+    """
+    Parameters:
+        xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 8)` containing the
+            bounding boxes coordinates in format `[x1, y1, x2, y2,x3, y3, x4, y4]`
+        offset (np.array): An array of shape `(2,)` containing offset values in format
+            is `[dx, dy]`.
+
+    Returns:
+        npt.NDArray[np.float64]: Repositioned oriented bounding boxes. 
+
+    Examples:
+        ```python
+        import numpy as np
+        import supervision as sv
+
+        xyxyxyxy: np.array([[10, 10, 20, 20, 30, 30, 40, 40],
+                            [20, 20, 30, 30, 40, 40, 50, 50]])
+        offset = np.array([5, 10])
+
+        sv.move_obb_boxes(xyxyxyxy=xyxyxyxy, offset=offset)
+        #[[15 20 25 30 35 40 45 50]
+        #[25 30 35 40 45 50 55 60]]
+        ```
+    """
+
+    return xyxyxyxy + np.hstack([offset, offset, offset, offset])
 
 def move_masks(
     masks: npt.NDArray[np.bool_],

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -596,42 +596,59 @@ def move_boxes(
     return xyxy + np.hstack([offset, offset])
 
 
-def move_obb_boxes(
+def move_oriented_boxes(
     xyxyxyxy: npt.NDArray[np.float64], offset: npt.NDArray[np.int32]
 ) -> npt.NDArray[np.float64]:
     """
     Parameters:
-        xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 4, 2)` containing the
-        bounding boxes coordinates in format
-        `n[[x1, y1], [x2, y2],[x3, y3], [x4, y4]]`
-        offset (np.array): An array of shape `(2,)` containing offset values
-        in format is `[dx, dy]`.
+    xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 4, 2)` containing the
+    oriented bounding boxes coordinates in format
+    `[[x1, y1], [x2, y2], [x3, y3], [x3, y3]]`
+    offset (np.array): An array of shape `(2,)` containing offset values in format
+        is `[dx, dy]`.
 
     Returns:
-        npt.NDArray[np.float64]: Repositioned oriented bounding boxes.
+    npt.NDArray[np.float64]: Repositioned bounding boxes.
 
     Examples:
-        ```python
-        import numpy as np
-        import supervision as sv
+    ```python
+    import numpy as np
+    import supervision as sv
 
-        xyxyxyxy: np.array([[[10., 10.],
-                            [20., 20.],
-                            [30., 30.],
-                            [40., 40.]]])
-        offset = np.array([5, 10])
+    xyxyxyxy = np.array([
+        [
+            [20, 10],
+            [10, 20],
+            [20, 30],
+            [30, 20]
+        ],
+        [
+            [30 ,30],
+            [20, 40],
+            [30, 50],
+            [40, 40]
+        ]
+    ])
+    offset = np.array([5, 5])
 
-        sv.move_obb_boxes(xyss, offset=offset)
-        #[[[15., 20.],
-        #[25., 30.],
-        #[35., 40.],
-        #[45., 50.]]]
-        ```
+    sv.move_oriented_boxes(xyxy=xyxy, offset=offset)
+    # array([
+    #     [
+    #         [25, 15],
+    #         [15, 25],
+    #         [25, 35],
+    #         [35, 25]
+    #     ],
+    #     [
+    #         [35, 35],
+    #         [25, 45],
+    #         [35, 55],
+    #         [45, 45]
+    #     ]
+    # ])
+    ```
     """
-    return [
-        xys + np.hstack([offset, offset, offset, offset]).reshape(xys.shape)
-        for xys in xyxyxyxy
-    ]
+    return xyxyxyxy + offset
 
 
 def move_masks(

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -596,8 +596,9 @@ def move_boxes(
     return xyxy + np.hstack([offset, offset])
 
 
-def move_obb_boxes(xyxyxyxy: npt.NDArray[np.float64], offset: npt.NDArray[np.int32]
-                  ) -> npt.NDArray[np.float64]:
+def move_obb_boxes(
+    xyxyxyxy: npt.NDArray[np.float64], offset: npt.NDArray[np.int32]
+) -> npt.NDArray[np.float64]:
     """
     Parameters:
         xyxyxyxy (npt.NDArray[np.float64]): An array of shape `(n, 4, 2)` containing the


### PR DESCRIPTION
# Description
Issue: draw wrong OrientedBoxAnnotator with InferenceSlicer #1339
Resolution: create function *utils:move_obb_boxes (as suggested by LinasKo), with a call inside *tools/inference_slicer:move_detections

List any dependencies that are required for this change.
No new dependencies required

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?
created detection-like object (single and multiple detections) based on the submitted issue, passed to the function and verified results

## Docs

I did not change any documentation
