### PR TITLE
fix `from_matplotlib` when Matplotlib colormaps does not provide `colors` property

### DIFF
--- a/supervision/draw/color.py
+++ b/supervision/draw/color.py
@@ -352,11 +352,17 @@ class ColorPalette:
         supervision-annotator-examples/visualized_color_palette.png)
         """  # noqa: E501 // docs
         mpl_palette = plt.get_cmap(palette_name, color_count)
-        colors = [
+
+        if hasattr(mpl_palette, 'colors'):
+            colors = mpl_palette.colors
+        else:
+            colors = [mpl_palette(i / (color_count - 1)) for i in range(color_count)]
+
+        return cls([
             Color(int(r * 255), int(g * 255), int(b * 255))
-            for r, g, b, _ in mpl_palette.colors
-        ]
-        return cls(colors)
+            for r, g, b, _
+            in colors
+        ])
 
     def by_idx(self, idx: int) -> Color:
         """

--- a/supervision/draw/color.py
+++ b/supervision/draw/color.py
@@ -353,16 +353,14 @@ class ColorPalette:
         """  # noqa: E501 // docs
         mpl_palette = plt.get_cmap(palette_name, color_count)
 
-        if hasattr(mpl_palette, 'colors'):
+        if hasattr(mpl_palette, "colors"):
             colors = mpl_palette.colors
         else:
             colors = [mpl_palette(i / (color_count - 1)) for i in range(color_count)]
 
-        return cls([
-            Color(int(r * 255), int(g * 255), int(b * 255))
-            for r, g, b, _
-            in colors
-        ])
+        return cls(
+            [Color(int(r * 255), int(g * 255), int(b * 255)) for r, g, b, _ in colors]
+        )
 
     def by_idx(self, idx: int) -> Color:
         """


### PR DESCRIPTION
# Description

Fix for https://github.com/roboflow/supervision/issues/1369.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## Test

Google Colab https://colab.research.google.com/drive/1cRxvuuJe8jrQYt8kepwUGRcAU80T9N-y?usp=sharing testing the change. 
