### PR TITLE
Change CropAnnotator scale_factor from int to float

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2124,7 +2124,7 @@ class CropAnnotator(BaseAnnotator):
     def __init__(
         self,
         position: Position = Position.TOP_CENTER,
-        scale_factor: int = 2,
+        scale_factor: float = 2.0,
         border_color: Union[Color, ColorPalette] = ColorPalette.DEFAULT,
         border_thickness: int = 2,
         border_color_lookup: ColorLookup = ColorLookup.CLASS,
@@ -2133,7 +2133,7 @@ class CropAnnotator(BaseAnnotator):
         Args:
             position (Position): The anchor position for placing the cropped and scaled
                 part of the detection in the scene.
-            scale_factor (int): The factor by which to scale the cropped image part. A
+            scale_factor (float): The factor by which to scale the cropped image part. A
                 factor of 2, for example, would double the size of the cropped area,
                 allowing for a closer view of the detection.
             border_color (Union[Color, ColorPalette]): The color or color palette to
@@ -2143,7 +2143,7 @@ class CropAnnotator(BaseAnnotator):
                 annotations. Options are `INDEX`, `CLASS`, `TRACK`.
         """
         self.position: Position = position
-        self.scale_factor: int = scale_factor
+        self.scale_factor: float = scale_factor
         self.border_color: Union[Color, ColorPalette] = border_color
         self.border_thickness: int = border_thickness
         self.border_color_lookup: ColorLookup = border_color_lookup


### PR DESCRIPTION
# Description

`CropAnnotator`'s `scale_factor` is an int vs a float. It's [passed to `scale_image` here](https://github.com/roboflow/supervision/blob/e76dec7e1518cd286ea7391caf3a5766bbda1890/supervision/annotators/core.py#L2194) and that [accepts a float](https://github.com/roboflow/supervision/blob/65f2bbba5792257214bda8c812b2bd02c1710e1d/supervision/utils/image.py#L90).

Using a float is useful since it'll let you scale down (or up by less than 2x). This functionality already works, the type annotation is just wrong.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

[In this Colab notebook](https://colab.research.google.com/drive/1RDRFDOW90EyQsMuJLZThHLgPhGhoCTDs#scrollTo=EGUKXHHzXp3P).

![image](https://github.com/user-attachments/assets/600a66d1-011d-4f37-9d7c-57415f0492aa)

## Any specific deployment considerations

No

## Docs

-   [x] Docs updated? What were the changes: type annotations
