### PR TITLE
Add BackgroundColorAnnotator

### DIFF
--- a/docs/detection/annotators.md
+++ b/docs/detection/annotators.md
@@ -450,7 +450,8 @@ status: new
 
     <div class="result" markdown>
 
-        ![background-overlay-annotator-example](https://media.roboflow.com/supervision-annotator-examples/background-color-annotator-example-purple.png)
+    ![background-overlay-annotator-example](https://media.roboflow.com/supervision-annotator-examples/background-color-annotator-example-purple.png)
+
     </div>
 
 <div class="md-typeset">

--- a/docs/detection/annotators.md
+++ b/docs/detection/annotators.md
@@ -433,6 +433,26 @@ status: new
 
     </div>
 
+=== "Background Color"
+
+    ```python
+    import supervision as sv
+
+    image = ...
+    detections = sv.Detections(...)
+
+    blur_annotator = sv.BackgroundColorAnnotator()
+    annotated_frame = blur_annotator.annotate(
+        scene=image.copy(),
+        detections=detections
+    )
+    ```
+
+    <div class="result" markdown>
+
+        ![background-color-annotator-example](https://media.roboflow.com/supervision-annotator-examples/background-color-annotator-example-purple.png)
+    </div>
+
 <div class="md-typeset">
     <h2><a href="#supervision.annotators.core.BoxAnnotator">BoxAnnotator</a></h2>
 </div>
@@ -552,6 +572,12 @@ status: new
 </div>
 
 :::supervision.annotators.core.CropAnnotator
+
+<div class="md-typeset">
+    <h2><a href="#supervision.annotators.core.BackgroundColorAnnotator">BackgroundColorAnnotator</a></h2>
+</div>
+
+:::supervision.annotators.core.BackgroundColorAnnotator
 
 <div class="md-typeset">
     <h2><a href="#supervision.annotators.core.ColorLookup">ColorLookup</a></h2>

--- a/docs/detection/annotators.md
+++ b/docs/detection/annotators.md
@@ -441,8 +441,8 @@ status: new
     image = ...
     detections = sv.Detections(...)
 
-    blur_annotator = sv.BackgroundColorAnnotator()
-    annotated_frame = blur_annotator.annotate(
+    background_overlay_annotator = sv.BackgroundOverlayAnnotator()
+    annotated_frame = background_overlay_annotator.annotate(
         scene=image.copy(),
         detections=detections
     )
@@ -450,7 +450,7 @@ status: new
 
     <div class="result" markdown>
 
-        ![background-color-annotator-example](https://media.roboflow.com/supervision-annotator-examples/background-color-annotator-example-purple.png)
+        ![background-overlay-annotator-example](https://media.roboflow.com/supervision-annotator-examples/background-color-annotator-example-purple.png)
     </div>
 
 <div class="md-typeset">
@@ -574,10 +574,10 @@ status: new
 :::supervision.annotators.core.CropAnnotator
 
 <div class="md-typeset">
-    <h2><a href="#supervision.annotators.core.BackgroundColorAnnotator">BackgroundColorAnnotator</a></h2>
+    <h2><a href="#supervision.annotators.core.BackgroundOverlayAnnotator">BackgroundOverlayAnnotator</a></h2>
 </div>
 
-:::supervision.annotators.core.BackgroundColorAnnotator
+:::supervision.annotators.core.BackgroundOverlayAnnotator
 
 <div class="md-typeset">
     <h2><a href="#supervision.annotators.core.ColorLookup">ColorLookup</a></h2>

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -111,5 +111,3 @@ from supervision.utils.video import (
     get_video_frames_generator,
     process_video,
 )
-
-print("test!")

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -7,6 +7,7 @@ except importlib_metadata.PackageNotFoundError:
     __version__ = "development"
 
 from supervision.annotators.core import (
+    BackgroundColorAnnotator,
     BlurAnnotator,
     BoundingBoxAnnotator,
     BoxAnnotator,
@@ -28,7 +29,6 @@ from supervision.annotators.core import (
     RoundBoxAnnotator,
     TraceAnnotator,
     TriangleAnnotator,
-    BackgroundColorAnnotator
 )
 from supervision.annotators.utils import ColorLookup
 from supervision.classification.core import Classifications
@@ -112,4 +112,4 @@ from supervision.utils.video import (
     process_video,
 )
 
-print('test!')
+print("test!")

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -7,7 +7,7 @@ except importlib_metadata.PackageNotFoundError:
     __version__ = "development"
 
 from supervision.annotators.core import (
-    BackgroundColorAnnotator,
+    BackgroundOverlayAnnotator,
     BlurAnnotator,
     BoundingBoxAnnotator,
     BoxAnnotator,

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -28,6 +28,7 @@ from supervision.annotators.core import (
     RoundBoxAnnotator,
     TraceAnnotator,
     TriangleAnnotator,
+    BackgroundColorAnnotator
 )
 from supervision.annotators.utils import ColorLookup
 from supervision.classification.core import Classifications
@@ -110,3 +111,5 @@ from supervision.utils.video import (
     get_video_frames_generator,
     process_video,
 )
+
+print('test!')

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2259,3 +2259,80 @@ class CropAnnotator(BaseAnnotator):
             )
         elif position == Position.BOTTOM_RIGHT:
             return (anchor_x, anchor_y), (anchor_x + width, anchor_y + height)
+
+
+class BackgroundColorAnnotator(BaseAnnotator):
+    """
+    A class for drawing background colors outside of detected box or mask regions.
+
+    !!! warning
+
+        This annotator uses `sv.Detections.mask`.
+    """
+
+    def __init__(
+        self,
+        color: Color = Color.BLACK,
+        opacity: float = 0.5,
+        force_box: bool = False,
+    ):
+        """
+        Args:
+            color (Color): The color to use for annotating detections.
+            opacity (float): Opacity of the overlay mask. Must be between `0` and `1`.
+        """
+        self.color: Color = color
+        self.opacity = opacity
+        self.force_box = force_box
+
+    @ensure_cv2_image_for_annotation
+    def annotate(
+        self,
+        scene: ImageType,
+        detections: Detections
+    ) -> ImageType:
+        """
+        Annotates the given scene with masks based on the provided detections.
+
+        Args:
+            scene (ImageType): The image where masks will be drawn.
+                `ImageType` is a flexible type, accepting either `numpy.ndarray`
+                or `PIL.Image.Image`.
+            detections (Detections): Object detections to annotate.
+
+        Returns:
+            The annotated image, matching the type of `scene` (`numpy.ndarray`
+                or `PIL.Image.Image`)
+
+        Example:
+            ```python
+            import supervision as sv
+
+            image = ...
+            detections = sv.Detections(...)
+
+            background_color_annotator = sv.BackgroundColorAnnotator()
+            annotated_frame = background_color_annotator.annotate(
+                scene=image.copy(),
+                detections=detections
+            )
+            ```
+
+        ![background-color-annotator-example](https://media.roboflow.com/
+        supervision-annotator-examples/background-color-annotator-example-purple.png)
+        """
+
+        colored_mask = np.full_like(scene, self.color.as_bgr(), dtype=np.uint8)
+
+        cv2.addWeighted(scene, 1 - self.opacity, colored_mask, self.opacity, 0, dst=colored_mask)
+
+        if detections.mask is None or self.force_box:
+            for detection_idx in range(len(detections)):
+                x1, y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
+                colored_mask[y1:y2, x1:x2] = scene[y1:y2, x1:x2]
+        else:
+            for mask in detections.mask:
+                colored_mask[mask] = scene[mask]
+
+        return colored_mask
+    

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
-from PIL import Image, ImageDraw, ImageFont
+from PIL import ImageDraw, ImageFont
 
 from supervision.annotators.base import BaseAnnotator, ImageType
 from supervision.annotators.utils import (

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
-from PIL import ImageDraw, ImageFont, Image
+from PIL import Image, ImageDraw, ImageFont
 
 from supervision.annotators.base import BaseAnnotator, ImageType
 from supervision.annotators.utils import (

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2261,7 +2261,7 @@ class CropAnnotator(BaseAnnotator):
             return (anchor_x, anchor_y), (anchor_x + width, anchor_y + height)
 
 
-class BackgroundColorAnnotator(BaseAnnotator):
+class BackgroundOverlayAnnotator(BaseAnnotator):
     """
     A class for drawing a colored overlay on the background of an image outside
     the region of detections.
@@ -2315,17 +2315,16 @@ class BackgroundColorAnnotator(BaseAnnotator):
             image = ...
             detections = sv.Detections(...)
 
-            background_color_annotator = sv.BackgroundColorAnnotator()
-            annotated_frame = background_color_annotator.annotate(
+            background_overlay_annotator = sv.BackgroundOverlayAnnotator()
+            annotated_frame = background_overlay_annotator.annotate(
                 scene=image.copy(),
                 detections=detections
             )
             ```
 
-        ![background-color-annotator-example](https://media.roboflow.com/
+        ![background-overlay-annotator-example](https://media.roboflow.com/
         supervision-annotator-examples/background-color-annotator-example-purple.png)
         """
-
         colored_mask = np.full_like(scene, self.color.as_bgr(), dtype=np.uint8)
 
         cv2.addWeighted(
@@ -2339,4 +2338,5 @@ class BackgroundColorAnnotator(BaseAnnotator):
             for mask in detections.mask:
                 colored_mask[mask] = scene[mask]
 
-        return np.copyto(scene, colored_mask)
+        np.copyto(scene, colored_mask)
+        return scene

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2286,11 +2286,7 @@ class BackgroundColorAnnotator(BaseAnnotator):
         self.force_box = force_box
 
     @ensure_cv2_image_for_annotation
-    def annotate(
-        self,
-        scene: ImageType,
-        detections: Detections
-    ) -> ImageType:
+    def annotate(self, scene: ImageType, detections: Detections) -> ImageType:
         """
         Annotates the given scene with masks based on the provided detections.
 
@@ -2324,7 +2320,9 @@ class BackgroundColorAnnotator(BaseAnnotator):
 
         colored_mask = np.full_like(scene, self.color.as_bgr(), dtype=np.uint8)
 
-        cv2.addWeighted(scene, 1 - self.opacity, colored_mask, self.opacity, 0, dst=colored_mask)
+        cv2.addWeighted(
+            scene, 1 - self.opacity, colored_mask, self.opacity, 0, dst=colored_mask
+        )
 
         if detections.mask is None or self.force_box:
             for detection_idx in range(len(detections)):
@@ -2335,4 +2333,3 @@ class BackgroundColorAnnotator(BaseAnnotator):
                 colored_mask[mask] = scene[mask]
 
         return colored_mask
-    

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2263,7 +2263,13 @@ class CropAnnotator(BaseAnnotator):
 
 class BackgroundColorAnnotator(BaseAnnotator):
     """
-    A class for drawing background colors outside of detected box or mask regions.
+    A class for drawing a colored overlay on the background of an image outside
+    the region of detections.
+
+    If masks are provided, the background is colored outside the masks.
+    If masks are not provided, the background is colored outside the bounding boxes.
+
+    You can use the `force_box` parameter to force the annotator to use bounding boxes.
 
     !!! warning
 
@@ -2280,6 +2286,8 @@ class BackgroundColorAnnotator(BaseAnnotator):
         Args:
             color (Color): The color to use for annotating detections.
             opacity (float): Opacity of the overlay mask. Must be between `0` and `1`.
+            force_box (bool): If `True`, forces the annotator to use bounding boxes when
+                masks are provided in the supplied sv.Detections.
         """
         self.color: Color = color
         self.opacity = opacity
@@ -2288,7 +2296,7 @@ class BackgroundColorAnnotator(BaseAnnotator):
     @ensure_cv2_image_for_annotation
     def annotate(self, scene: ImageType, detections: Detections) -> ImageType:
         """
-        Annotates the given scene with masks based on the provided detections.
+        Applies a colored overlay to the scene outside of the detected regions.
 
         Args:
             scene (ImageType): The image where masks will be drawn.
@@ -2325,8 +2333,7 @@ class BackgroundColorAnnotator(BaseAnnotator):
         )
 
         if detections.mask is None or self.force_box:
-            for detection_idx in range(len(detections)):
-                x1, y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
+            for x1, y1, x2, y2 in detections.xyxy.astype(int):
                 colored_mask[y1:y2, x1:x2] = scene[y1:y2, x1:x2]
         else:
             for mask in detections.mask:

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2339,4 +2339,4 @@ class BackgroundColorAnnotator(BaseAnnotator):
             for mask in detections.mask:
                 colored_mask[mask] = scene[mask]
 
-        return Image.fromarray(colored_mask[:, :, ::-1])
+        return np.copyto(scene, colored_mask)

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2339,4 +2339,4 @@ class BackgroundColorAnnotator(BaseAnnotator):
             for mask in detections.mask:
                 colored_mask[mask] = scene[mask]
 
-        return Image.fromarray(colored_mask)
+        return Image.fromarray(colored_mask)[..., ::-1]

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2339,4 +2339,4 @@ class BackgroundColorAnnotator(BaseAnnotator):
             for mask in detections.mask:
                 colored_mask[mask] = scene[mask]
 
-        return Image.fromarray(colored_mask)[..., ::-1]
+        return Image.fromarray(colored_mask[:, :, ::-1])

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
-from PIL import ImageDraw, ImageFont
+from PIL import ImageDraw, ImageFont, Image
 
 from supervision.annotators.base import BaseAnnotator, ImageType
 from supervision.annotators.utils import (
@@ -2339,4 +2339,4 @@ class BackgroundColorAnnotator(BaseAnnotator):
             for mask in detections.mask:
                 colored_mask[mask] = scene[mask]
 
-        return colored_mask
+        return Image.fromarray(colored_mask)


### PR DESCRIPTION
# Description

This PR adds a new `sv.BackgroundColorAnnotator` that highlights all regions outside of a list of bounding boxes or masks.

## Type of change

-   [X] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can test this feature using the following Colab:

https://colab.research.google.com/drive/18GLw4TR-au9DUmAeWU30M7BFJ_00BlxO?usp=sharing

## Any specific deployment considerations

N/A

## Docs

N/A
