### PR TITLE
fix `VertexLabelAnnotator` text position within text box

### DIFF
--- a/supervision/keypoint/annotators.py
+++ b/supervision/keypoint/annotators.py
@@ -354,7 +354,7 @@ class VertexLabelAnnotator:
             cv2.putText(
                 img=scene,
                 text=text,
-                org=(box[0], box[1] + self.text_padding),
+                org=(box[0], box[3] + self.text_padding),
                 fontFace=font,
                 fontScale=self.text_scale,
                 color=self.text_color.as_rgb(),

--- a/supervision/keypoint/annotators.py
+++ b/supervision/keypoint/annotators.py
@@ -354,7 +354,7 @@ class VertexLabelAnnotator:
             cv2.putText(
                 img=scene,
                 text=text,
-                org=(box[0], box[3] + self.text_padding),
+                org=(box[0], box[3]),
                 fontFace=font,
                 fontScale=self.text_scale,
                 color=self.text_color.as_rgb(),


### PR DESCRIPTION
# Description

Fix: Text is not vertically centered inside text box. 

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update