### PR TITLE
Fix typo in RichLabelAnnotator docs

### DIFF
--- a/docs/detection/annotators.md
+++ b/docs/detection/annotators.md
@@ -303,7 +303,7 @@ status: new
         font_path="<TTF_FONT_PATH>",
         text_position=sv.Position.CENTER
     )
-    annotated_frame = label_annotator.annotate(
+    annotated_frame = rich_label_annotator.annotate(
         scene=image.copy(),
         detections=detections,
         labels=labels


### PR DESCRIPTION
# Description

Fix typo in RichLabelAnnotators https://supervision.roboflow.com/latest/detection/annotators/#__tabbed_1_14 where variable name label label_annotator is corrected to rich_label_annotator.

## Type of change

Please delete options that are not relevant.

-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Followed the procedure using mkdocs to serve the documentation locally.

## Docs

-   [x] Docs updated? What were the changes: 
