### PR TITLE
Refactor the metric benchmarks to use dataset lazy loading

### DIFF
--- a/supervision/metrics/detection.py
+++ b/supervision/metrics/detection.py
@@ -391,11 +391,10 @@ class ConfusionMatrix:
             ```
         """
         predictions, targets = [], []
-        for img_name, img in dataset.images.items():
-            predictions_batch = callback(img)
+        for _, image, annotation in dataset:
+            predictions_batch = callback(image)
             predictions.append(predictions_batch)
-            targets_batch = dataset.annotations[img_name]
-            targets.append(targets_batch)
+            targets.append(annotation)
         return cls.from_detections(
             predictions=predictions,
             targets=targets,
@@ -604,11 +603,10 @@ class MeanAveragePrecision:
             ```
         """
         predictions, targets = [], []
-        for img_name, img in dataset.images.items():
-            predictions_batch = callback(img)
+        for _, image, annotation in dataset:
+            predictions_batch = callback(image)
             predictions.append(predictions_batch)
-            targets_batch = dataset.annotations[img_name]
-            targets.append(targets_batch)
+            targets.append(annotation)
         return cls.from_detections(
             predictions=predictions,
             targets=targets,


### PR DESCRIPTION
# Description

[Supervision 0.22.0](https://supervision.roboflow.com/latest/changelog/#0220-jul-12-2024) introduced dataset lazy loading, allowing to load the images into memory only when necessary. Considering this, the `images` property in datasets classes will be deprecated in version 0.26.0, as it loads all images into memory.

This PR replaces the deprecated `for img_name, img in dataset.images.items():` present in the `benchmark` method of the `ConfusionMatrix` and `MeanAveragePrecision` classes for the recommended `for path, image, annotation in dataset:` loop.

## Type of change

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

After the code changes, the `benchmark` method of the `ConfusionMatrix` and `MeanAveragePrecision` stopped printing a deprecation warning, as it does not call the `dataset.images` property. Simply running the benchmark methods on any dataset with any model callback will work for testing purposes.

## Any specific deployment considerations

N/A

## Docs

N/A