### PR TITLE
Fix mask_annotate for int dtypes

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -357,7 +357,7 @@ class MaskAnnotator(BaseAnnotator):
                 else custom_color_lookup,
             )
             mask = detections.mask[detection_idx]
-            colored_mask[mask] = color.as_bgr()
+            colored_mask[mask.astype(bool)] = color.as_bgr()
 
         cv2.addWeighted(
             colored_mask, self.opacity, scene, 1 - self.opacity, 0, dst=scene


### PR DESCRIPTION
# Description

When using the sv.MaskAnnotator.annotate() function and providing masks as non-bool dtype, the code hangs unexpectedly long for large image shapes and will not produce the correct mask outputs. Below code provides a minimal reproduction
```python
import numpy as np
import supervision as sv

image = np.zeros((2560,2560,3), dtype=np.uint8)
masks = np.zeros((2560,2560), dtype=np.uint8)
masks[:1280] = 1

# This works as intended
# masks = np.array([masks], dtype=bool)

# This does not
masks = np.array([masks], dtype=int)

detections = sv.Detections(
    xyxy=sv.mask_to_xyxy(masks=masks),
    class_id=np.ones(1, dtype=int),
    mask=masks
)

mask_annotator = sv.MaskAnnotator()
out = mask_annotator.annotate(scene=image.copy(), detections=detections)
```

This PR addresses this by simply converting each mask to bool when constructing the colored overlay mask.

## Type of change

Please delete options that are not relevant.

-   [ x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

All tests pass.

## Any specific deployment considerations

This PR might result in unexpected mask annotations when the user input is of dtype float, or if one masks contains multiple unique integer values (e.g. semantic segmentation output). All non-zero values will then become True and masked as the same object.  Perhaps an additional check or warning should be given when masks are not in the expected format. 