### PR TITLE
Remove cursor pointer on hover

### DIFF
--- a/docs/stylesheets/cookbooks-card.css
+++ b/docs/stylesheets/cookbooks-card.css
@@ -24,7 +24,6 @@
     border-radius: 0.5rem;
     padding: 1rem;
     transition: transform 0.2s ease-in-out; /* Smooth transition for the transform */
-    cursor: pointer;
 }
 
 .repo-card:hover {


### PR DESCRIPTION
The cursor pointer is misleading because it makes the element seem clickable, like a button or link. However, when I click it, nothing happens, which is frustrating. Thank you.

# Description

- Remove the `cursor` property from the `.repo-card` class.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested it with `poetry run pytest`.
