### PR TITLE
[TriangleAnnotator, DotAnnotator] - allow customization of the contour color #1403

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -927,7 +927,7 @@ class DotAnnotator(BaseAnnotator):
         position: Position = Position.CENTER,
         color_lookup: ColorLookup = ColorLookup.CLASS,
         outline_thickness: int = 0,
-        outline_color: Union[Color, ColorPalette] | None = None,
+        outline_color: Union[Color, ColorPalette] = Color.BLACK,
     ):
         """
         Args:
@@ -947,7 +947,7 @@ class DotAnnotator(BaseAnnotator):
         self.position: Position = position
         self.color_lookup: ColorLookup = color_lookup
         self.outline_thickness = outline_thickness
-        self.outline_color: Union[Color, ColorPalette] | None = outline_color
+        self.outline_color: Union[Color, ColorPalette] = outline_color
 
     @ensure_cv2_image_for_annotation
     def annotate(
@@ -1002,22 +1002,19 @@ class DotAnnotator(BaseAnnotator):
 
             cv2.circle(scene, center, self.radius, color.as_bgr(), -1)
             if self.outline_thickness:
-                outline_color_bgr = (0, 0, 0)
-                if self.outline_color:
-                    outline_color = resolve_color(
-                        color=self.outline_color,
-                        detections=detections,
-                        detection_idx=detection_idx,
-                        color_lookup=self.color_lookup
-                        if custom_color_lookup is None
-                        else custom_color_lookup,
-                    )
-                    outline_color_bgr = outline_color.as_bgr()
+                outline_color = resolve_color(
+                    color=self.outline_color,
+                    detections=detections,
+                    detection_idx=detection_idx,
+                    color_lookup=self.color_lookup
+                    if custom_color_lookup is None
+                    else custom_color_lookup,
+                )
                 cv2.circle(
                     scene,
                     center,
                     self.radius,
-                    outline_color_bgr,
+                    outline_color.as_bgr(),
                     self.outline_thickness,
                 )
         return scene
@@ -1764,7 +1761,7 @@ class TriangleAnnotator(BaseAnnotator):
         position: Position = Position.TOP_CENTER,
         color_lookup: ColorLookup = ColorLookup.CLASS,
         outline_thickness: int = 0,
-        outline_color: Union[Color, ColorPalette] | None = None,
+        outline_color: Union[Color, ColorPalette] = Color.BLACK,
     ):
         """
         Args:
@@ -1786,7 +1783,7 @@ class TriangleAnnotator(BaseAnnotator):
         self.position: Position = position
         self.color_lookup: ColorLookup = color_lookup
         self.outline_thickness: int = outline_thickness
-        self.outline_color: Union[Color, ColorPalette] | None = outline_color
+        self.outline_color: Union[Color, ColorPalette] = outline_color
 
     @ensure_cv2_image_for_annotation
     def annotate(
@@ -1849,22 +1846,19 @@ class TriangleAnnotator(BaseAnnotator):
 
             cv2.fillPoly(scene, [vertices], color.as_bgr())
             if self.outline_thickness:
-                outline_color_bgr = (0, 0, 0)
-                if self.outline_color:
-                    outline_color = resolve_color(
-                        color=self.outline_color,
-                        detections=detections,
-                        detection_idx=detection_idx,
-                        color_lookup=self.color_lookup
-                        if custom_color_lookup is None
-                        else custom_color_lookup,
-                    )
-                    outline_color_bgr = outline_color.as_bgr()
+                outline_color = resolve_color(
+                    color=self.outline_color,
+                    detections=detections,
+                    detection_idx=detection_idx,
+                    color_lookup=self.color_lookup
+                    if custom_color_lookup is None
+                    else custom_color_lookup,
+                )
                 cv2.polylines(
                     scene,
                     [vertices],
                     True,
-                    outline_color_bgr,
+                    outline_color.as_bgr(),
                     thickness=self.outline_thickness,
                 )
         return scene

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -927,6 +927,7 @@ class DotAnnotator(BaseAnnotator):
         position: Position = Position.CENTER,
         color_lookup: ColorLookup = ColorLookup.CLASS,
         outline_thickness: int = 0,
+        outline_color: Union[Color, ColorPalette] | None = None,
     ):
         """
         Args:
@@ -937,12 +938,16 @@ class DotAnnotator(BaseAnnotator):
             color_lookup (ColorLookup): Strategy for mapping colors to annotations.
                 Options are `INDEX`, `CLASS`, `TRACK`.
             outline_thickness (int): Thickness of the outline of the dot.
+            outline_color (Union[Color, ColorPalette]): The color or color palette to
+            use for outline. It is activated by setting outline_thickness to a value
+            greater than 0.
         """
         self.color: Union[Color, ColorPalette] = color
         self.radius: int = radius
         self.position: Position = position
         self.color_lookup: ColorLookup = color_lookup
         self.outline_thickness = outline_thickness
+        self.outline_color: Union[Color, ColorPalette] | None = outline_color
 
     @ensure_cv2_image_for_annotation
     def annotate(
@@ -997,8 +1002,23 @@ class DotAnnotator(BaseAnnotator):
 
             cv2.circle(scene, center, self.radius, color.as_bgr(), -1)
             if self.outline_thickness:
+                outline_color_bgr = (0, 0, 0)
+                if self.outline_color:
+                    outline_color = resolve_color(
+                        color=self.outline_color,
+                        detections=detections,
+                        detection_idx=detection_idx,
+                        color_lookup=self.color_lookup
+                        if custom_color_lookup is None
+                        else custom_color_lookup,
+                    )
+                    outline_color_bgr = outline_color.as_bgr()
                 cv2.circle(
-                    scene, center, self.radius, (0, 0, 0), self.outline_thickness
+                    scene,
+                    center,
+                    self.radius,
+                    outline_color_bgr,
+                    self.outline_thickness,
                 )
         return scene
 
@@ -1744,6 +1764,7 @@ class TriangleAnnotator(BaseAnnotator):
         position: Position = Position.TOP_CENTER,
         color_lookup: ColorLookup = ColorLookup.CLASS,
         outline_thickness: int = 0,
+        outline_color: Union[Color, ColorPalette] | None = None,
     ):
         """
         Args:
@@ -1755,6 +1776,9 @@ class TriangleAnnotator(BaseAnnotator):
             color_lookup (ColorLookup): Strategy for mapping colors to annotations.
                 Options are `INDEX`, `CLASS`, `TRACK`.
             outline_thickness (int): Thickness of the outline of the triangle.
+            outline_color (Union[Color, ColorPalette]): The color or color palette to
+            use for outline. It is activated by setting outline_thickness to a value
+            greater than 0.
         """
         self.color: Union[Color, ColorPalette] = color
         self.base: int = base
@@ -1762,6 +1786,7 @@ class TriangleAnnotator(BaseAnnotator):
         self.position: Position = position
         self.color_lookup: ColorLookup = color_lookup
         self.outline_thickness: int = outline_thickness
+        self.outline_color: Union[Color, ColorPalette] | None = outline_color
 
     @ensure_cv2_image_for_annotation
     def annotate(
@@ -1824,8 +1849,23 @@ class TriangleAnnotator(BaseAnnotator):
 
             cv2.fillPoly(scene, [vertices], color.as_bgr())
             if self.outline_thickness:
+                outline_color_bgr = (0, 0, 0)
+                if self.outline_color:
+                    outline_color = resolve_color(
+                        color=self.outline_color,
+                        detections=detections,
+                        detection_idx=detection_idx,
+                        color_lookup=self.color_lookup
+                        if custom_color_lookup is None
+                        else custom_color_lookup,
+                    )
+                    outline_color_bgr = outline_color.as_bgr()
                 cv2.polylines(
-                    scene, [vertices], True, (0, 0, 0), thickness=self.outline_thickness
+                    scene,
+                    [vertices],
+                    True,
+                    outline_color_bgr,
+                    thickness=self.outline_thickness,
                 )
         return scene
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -939,8 +939,8 @@ class DotAnnotator(BaseAnnotator):
                 Options are `INDEX`, `CLASS`, `TRACK`.
             outline_thickness (int): Thickness of the outline of the dot.
             outline_color (Union[Color, ColorPalette]): The color or color palette to
-            use for outline. It is activated by setting outline_thickness to a value
-            greater than 0.
+                use for outline. It is activated by setting outline_thickness to a value
+                greater than 0.
         """
         self.color: Union[Color, ColorPalette] = color
         self.radius: int = radius
@@ -1774,8 +1774,8 @@ class TriangleAnnotator(BaseAnnotator):
                 Options are `INDEX`, `CLASS`, `TRACK`.
             outline_thickness (int): Thickness of the outline of the triangle.
             outline_color (Union[Color, ColorPalette]): The color or color palette to
-            use for outline. It is activated by setting outline_thickness to a value
-            greater than 0.
+                use for outline. It is activated by setting outline_thickness to a value
+                greater than 0.
         """
         self.color: Union[Color, ColorPalette] = color
         self.base: int = base


### PR DESCRIPTION
This PR introduces a new outline_color argument to the TriangleAnnotator and DotAnnotator classes, allowing users to customize the outline color when rendering annotations. Previously, while users could set outline_thickness to render an outline, the color was not configurable. With this enhancement, outline_color can now be set and will integrate seamlessly with the existing color_lookup system, accepting values of type Union[Color, ColorPalette].

Key Changes

Added outline_color argument to TriangleAnnotator and DotAnnotator.
Integrated outline_color with the existing color_lookup mechanism.
resolve https://github.com/roboflow/supervision/issues/1403

For testing purposes, please refer to the provided [Colab link](https://colab.research.google.com/drive/1Wz66ql9LsH-PsTOwg8JlmpSSHOn9fOQV?usp=sharing).

Please review thank you :)