### PR TITLE
fix typo in url

### DIFF
--- a/docs/how_to/track_objects.md
+++ b/docs/how_to/track_objects.md
@@ -32,7 +32,7 @@ download_assets(VideoAssets.PEOPLE_WALKING)
 First, you'll need to obtain predictions from your object detection or segmentation
 model. In this tutorial, we are using the YOLOv8 model as an example. However,
 Supervision is versatile and compatible with various models. Check this
-[link](latest/how_to/detect_and_annotate/#load-predictions-into-supervision)
+[link](/latest/how_to/detect_and_annotate/#load-predictions-into-supervision)
 for guidance on how to plug in other models.
 
 We will define a `callback` function, which will process each frame of the video


### PR DESCRIPTION
fix typo of url 'how_to/detect_and_annotate' to '/how_to/detect_and_annotate'

# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

fix relative link by adding '/' to connect correct document page.
from 'how_to/detect_and_annotate' to '/how_to/detect_and_annotate'


## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

previous was connected to 
`https://supervision.roboflow.com/latest/how_to/track_objects/latest/how_to/detect_and_annotate/#load-predictions-into-supervision`
![image](https://github.com/user-attachments/assets/cdc1cd91-fa06-434a-87b6-03ec56db46fe)

and now, it indicate right [path](https://supervision.roboflow.com/latest/how_to/detect_and_annotate/#load-predictions-into-supervision)
![image](https://github.com/user-attachments/assets/a6a97557-2fc0-4d53-8917-3c27240c3f2f)


## Any specific deployment considerations

very very tiny update for url in [docs](https://supervision.roboflow.com/latest/how_to/track_objects/#run-inference) 

## Docs

-   [X] Docs updated? What were the changes:
fix typo of link in document
