### PR TITLE
match the titles and the contents

### DIFF
--- a/docs/detection/utils.md
+++ b/docs/detection/utils.md
@@ -78,19 +78,19 @@ status: new
 :::supervision.detection.utils.pad_boxes
 
 <div class="md-typeset">
-  <h2><a href="#supervision.detection.utils.contains_holes">contains_holes</a></h2>
+  <h2><a href="#supervision.detection.utils.xywh_to_xyxy">xywh_to_xyxy</a></h2>
 </div>
 
 :::supervision.detection.utils.xywh_to_xyxy
 
 <div class="md-typeset">
-  <h2><a href="#supervision.detection.utils.xywh_to_xyxy">xywh_to_xyxy</a></h2>
+  <h2><a href="#supervision.detection.utils.xcycwh_to_xyxy">xcycwh_to_xyxy</a></h2>
 </div>
 
 :::supervision.detection.utils.xcycwh_to_xyxy
 
 <div class="md-typeset">
-  <h2><a href="#supervision.detection.utils.xcycwh_to_xyxy">xcycwh_to_xyxy</a></h2>
+  <h2><a href="#supervision.detection.utils.contains_holes">contains_holes</a></h2>
 </div>
 
 :::supervision.detection.utils.contains_holes


### PR DESCRIPTION
# Description

Edit the title and the content to match each other.

## Type of change

-   [X] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?


## Any specific deployment considerations

document changes

## Docs

-   [X] Docs updated? What were the changes:

match content to title, and change order of 'contain_holes' title.
![image](https://github.com/user-attachments/assets/295afb58-54d0-48fb-ad76-7fbb2e8837f4)

Thanks for your hard effort🙇‍♂️