### PR TITLE
Proposal for lazy-loaded annotations.

### DIFF
--- a/test/dataset/formats/test_yolo.py
+++ b/test/dataset/formats/test_yolo.py
@@ -8,8 +8,9 @@ from supervision.dataset.formats.yolo import (
     _image_name_to_annotation_name,
     _with_mask,
     object_to_yolo,
-    yolo_annotations_to_detections,
+    yolo_annotations_to_lazy_detections,
 )
+from supervision.dataset.utils import load_lazy_detections
 from supervision.detection.core import Detections
 
 
@@ -178,9 +179,10 @@ def test_yolo_annotations_to_detections(
     exception: Exception,
 ) -> None:
     with exception:
-        result = yolo_annotations_to_detections(
+        result = yolo_annotations_to_lazy_detections(
             lines=lines, resolution_wh=resolution_wh, with_masks=with_masks
         )
+        result = load_lazy_detections(result)
         assert np.array_equal(result.xyxy, expected_result.xyxy)
         assert np.array_equal(result.class_id, expected_result.class_id)
         assert (


### PR DESCRIPTION
This branch contains a proposal for lazy-loading annotations for `DetectionsDataset`.

It's been tested scarcely - enough to show that memory usage does not grow when loading a large YOLO dataset. The main purpose is to have a code reference for further discussions.

# Description

* A LazyDict data structure calls a loading function when values are retrieved
* This enables us to conceptualize a `lazy_detections` objects, which store masks as polygons until loaded.
* Such polygons are placed in `data` along with `resolution_xy`
* The dataset can take either lazy-loaded or normal Detections
* So far, only `yolo_annotations_to_detections` was changed to produce lazy values.
* The dataset can still function as before - the main different users will see is the datatype for annotations input: `Union[Dict[str, Detections], LazyDict[str, Detections, Detections]`.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

`pytest` + loaded yolo dataset with it, comparing memory use and outputs with non-lazy method.

The memory use does not grow, and the results are the same.

I did not test this thoroughly so far.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
