### PR TITLE
fix: correct typo in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ We love your input! Please see our [contributing guide](https://github.com/robof
           />
       </a>
       <img src="https://raw.githubusercontent.com/ultralytics/assets/main/social/logo-transparent.png" width="3%"/>
-      <a href="https://disuss.roboflow.com">
+      <a href="https://discuss.roboflow.com">
           <img
             src="https://media.roboflow.com/notebooks/template/icons/purple/forum.png?ik-sdk-version=javascript-1.4.3&updatedAt=1672949633584"
             width="3%"


### PR DESCRIPTION
fix: Correct typo in link URL from "disuss.roboflow.com" to "discuss.roboflow.com"

Please delete options that are not relevant.

-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tried opening the misspelled link. It did not open. I corrected the spelling. The link then opened. Solid testing.

## Any specific deployment considerations

No.

## Docs

-   [ X] Docs updated? What were the changes: the doc itself.
