### PR TITLE
let ByteTrack to maintain track ID per instance

### DIFF
--- a/supervision/tracker/byte_tracker/basetrack.py
+++ b/supervision/tracker/byte_tracker/basetrack.py
@@ -12,9 +12,8 @@ class TrackState(Enum):
 
 
 class BaseTrack:
-    _count = 0
-
     def __init__(self):
+        self._count = 0
         self.track_id = 0
         self.is_activated = False
         self.state = TrackState.New
@@ -34,18 +33,16 @@ class BaseTrack:
     def end_frame(self) -> int:
         return self.frame_id
 
-    @staticmethod
-    def next_id() -> int:
-        BaseTrack._count += 1
-        return BaseTrack._count
+    def next_id(self) -> int:
+        self._count += 1
+        return self._count
 
-    @staticmethod
-    def reset_counter():
-        BaseTrack._count = 0
-        BaseTrack.track_id = 0
-        BaseTrack.start_frame = 0
-        BaseTrack.frame_id = 0
-        BaseTrack.time_since_update = 0
+    def reset_counter(self):
+        self._count = 0
+        self.track_id = 0
+        self.start_frame = 0
+        self.frame_id = 0
+        self.time_since_update = 0
 
     def activate(self, *args):
         raise NotImplementedError

--- a/supervision/tracker/byte_tracker/basetrack.py
+++ b/supervision/tracker/byte_tracker/basetrack.py
@@ -38,7 +38,7 @@ class BaseTrack:
         self.frame_id = 0
         self.time_since_update = 0
 
-    def activate(self, *args):
+    def activate(self, *args, **kwargs):
         raise NotImplementedError
 
     def predict(self):

--- a/supervision/tracker/byte_tracker/basetrack.py
+++ b/supervision/tracker/byte_tracker/basetrack.py
@@ -13,7 +13,6 @@ class TrackState(Enum):
 
 class BaseTrack:
     def __init__(self):
-        self._count = 0
         self.track_id = 0
         self.is_activated = False
         self.state = TrackState.New
@@ -33,12 +32,7 @@ class BaseTrack:
     def end_frame(self) -> int:
         return self.frame_id
 
-    def next_id(self) -> int:
-        self._count += 1
-        return self._count
-
     def reset_counter(self):
-        self._count = 0
         self.track_id = 0
         self.start_frame = 0
         self.frame_id = 0

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -428,7 +428,9 @@ class ByteTrack:
             dists, thresh=0.7
         )
         for itracked, idet in matches:
-            unconfirmed[itracked].update(detections[idet], self.frame_id, self._next_id())
+            unconfirmed[itracked].update(
+                detections[idet], self.frame_id, self._next_id()
+            )
             activated_starcks.append(unconfirmed[itracked])
         for it in u_unconfirmed:
             track = unconfirmed[it]

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -15,7 +15,6 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score, class_ids, minimum_consecutive_frames):
         super().__init__()
         # wait activate
-        self._external_count = 0
         self._tlwh = np.asarray(tlwh, dtype=np.float32)
         self.kalman_filter = None
         self.mean, self.covariance = None, None

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -307,6 +307,7 @@ class ByteTrack:
         ensuring the tracker starts with a clean state for each new video.
         """
         self.frame_id = 0
+        self._count = 0
         self.tracked_tracks: List[STrack] = []
         self.lost_tracks: List[STrack] = []
         self.removed_tracks: List[STrack] = []

--- a/supervision/tracker/byte_tracker/matching.py
+++ b/supervision/tracker/byte_tracker/matching.py
@@ -20,7 +20,7 @@ def indices_to_matches(
 
 def linear_assignment(
     cost_matrix: np.ndarray, thresh: float
-) -> [np.ndarray, Tuple[int], Tuple[int, int]]:
+) -> Tuple[np.ndarray, Tuple[int], Tuple[int, int]]:
     if cost_matrix.size == 0:
         return (
             np.empty((0, 2), dtype=int),

--- a/test/tracker/test_byte_tracker.py
+++ b/test/tracker/test_byte_tracker.py
@@ -1,4 +1,5 @@
 from typing import List
+
 import numpy as np
 import pytest
 

--- a/test/tracker/test_byte_tracker.py
+++ b/test/tracker/test_byte_tracker.py
@@ -1,3 +1,4 @@
+from typing import List
 import numpy as np
 import pytest
 
@@ -30,7 +31,7 @@ import supervision as sv
     ],
 )
 def test_byte_tracker(
-    detections: list[sv.Detections],
+    detections: List[sv.Detections],
     expected_results: sv.Detections,
 ) -> None:
     byte_tracker = sv.ByteTrack()

--- a/test/tracker/test_byte_tracker.py
+++ b/test/tracker/test_byte_tracker.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+import supervision as sv
+
+
+@pytest.mark.parametrize(
+    "detections, expected_results",
+    [
+        (
+            [
+                sv.Detections(
+                    xyxy=np.array([[10, 10, 20, 20], [30, 30, 40, 40]]),
+                    class_id=np.array([1, 1]),
+                    confidence=np.array([1, 1]),
+                ),
+                sv.Detections(
+                    xyxy=np.array([[10, 10, 20, 20], [30, 30, 40, 40]]),
+                    class_id=np.array([1, 1]),
+                    confidence=np.array([1, 1]),
+                ),
+            ],
+            sv.Detections(
+                xyxy=np.array([[10, 10, 20, 20], [30, 30, 40, 40]]),
+                class_id=np.array([1, 1]),
+                confidence=np.array([1, 1]),
+                tracker_id=np.array([1, 2]),
+            )
+        ),
+    ],
+)
+def test_byte_tracker(
+    detections: list[sv.Detections],
+    expected_results: sv.Detections,
+) -> None:
+    byte_tracker = sv.ByteTrack()
+    tracked_detections = [byte_tracker.update_with_detections(d) for d in detections]
+    assert tracked_detections[-1] == expected_results

--- a/test/tracker/test_byte_tracker.py
+++ b/test/tracker/test_byte_tracker.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import supervision as sv
 
 
@@ -24,7 +25,7 @@ import supervision as sv
                 class_id=np.array([1, 1]),
                 confidence=np.array([1, 1]),
                 tracker_id=np.array([1, 2]),
-            )
+            ),
         ),
     ],
 )


### PR DESCRIPTION
# Description

`BaseTrack` implementation includes `_count` class var, similarly `STrack` implementation includes `_external_count` class var. This results in undesirable behavior when running more than one tracker in the same process. In [inference](https://github.com/roboflow/inference/pull/642) we added a block wrapping ByteTrack, if more than 1 video is processed, objects across videos will receive non-deterministic track IDs.

In this change class vars are removed and track ID assignment is handled by upper layer (`ByteTrack`)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Added unit test to cover this scenario.

## Any specific deployment considerations

N/A

## Docs

N/A