### PR TITLE
Adds playground workflows to docs/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,16 @@ https://github.com/roboflow/supervision/assets/26109316/c9436828-9fbf-4c25-ae8c-
 
 https://github.com/roboflow/supervision/assets/26109316/3ac6982f-4943-4108-9b7f-51787ef1a69f
 
+## ▶︎ playground
+
+Play with supervision annotators in your browser using [**Workflows**](https://roboflow.com/workflows/build)
+
+- [Detect common objects](https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoibTJ5Ync5bUxzRGl4czI4cGI2OEkiLCJ3b3Jrc3BhY2VJZCI6ImtyT1RBYm5jRmhvUU1DZExPbGU0IiwidXNlcklkIjoiRVJNUFBZY3FQMmZWWjB1NkRpNXZaYXJDdlZPMiIsImlhdCI6MTcyNjc1MDM1NH0.YQIDaeLS1CEaqwecawhgspLqjjzAcn8WaSli6GtUgJs)
+- [Small object detection (SAHI)](https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoiMWU4bkNOb2Jtdm0wOGtIb2Q1OWQiLCJ3b3Jrc3BhY2VJZCI6ImtyT1RBYm5jRmhvUU1DZExPbGU0IiwidXNlcklkIjoiRVJNUFBZY3FQMmZWWjB1NkRpNXZaYXJDdlZPMiIsImlhdCI6MTcyNjc1MzcwMX0.xfnBA38QDURJka1_WGItrKMbDg1T0IHdloSNGtgcj_I)
+- [Facial emotions](https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoibWpuM1VjcWFqeEllSUtSb2RNWUEiLCJ3b3Jrc3BhY2VJZCI6ImtyT1RBYm5jRmhvUU1DZExPbGU0IiwidXNlcklkIjoiRVJNUFBZY3FQMmZWWjB1NkRpNXZaYXJDdlZPMiIsImlhdCI6MTcyNjc1Mzc2NH0.uoO5idABijO2Gcg7_HQe1E5agCKAuxyYj9qxj-34ETA)
+- [People in target zone](https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoiSG9RRk9pWmkyNmFvYnRDVVZJYjgiLCJ3b3Jrc3BhY2VJZCI6ImtyT1RBYm5jRmhvUU1DZExPbGU0IiwidXNlcklkIjoiRVJNUFBZY3FQMmZWWjB1NkRpNXZaYXJDdlZPMiIsImlhdCI6MTcyNjc1MzgyMn0.gvlQmc41YyzwhkbCzkHOhmyXFhcFVABI-ZW91mi3Rvg)
+- [YOLO World](https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoiOTF1bm43NmNpcHlTcllSQWxXSlYiLCJ3b3Jrc3BhY2VJZCI6IjFsY25TMDdFSVJTb08xUHo5RkFmIiwidXNlcklkIjoiRVJNUFBZY3FQMmZWWjB1NkRpNXZaYXJDdlZPMiIsImlhdCI6MTcyNjc1Mzg1N30.7-Rg_zKxVPU2kgskyjefFVf_0BWOS7J_vhS_lqP98OY)
+
 ## 📚 documentation
 
 Visit our [documentation](https://roboflow.github.io/supervision) page to learn how supervision can help you build computer vision applications faster and more reliably.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,12 @@ We write your reusable computer vision tools. Whether you need to load your data
     >
 </video>
 
+## ▶︎ Try it out
+
+Play with our annotators using [**Workflows**](https://roboflow.com/workflows/build), powered by `supervision`.
+
+<div style="height: 600px; width: 850px;"><iframe src="https://app.roboflow.com/workflows/embed/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ3b3JrZmxvd0lkIjoibTJ5Ync5bUxzRGl4czI4cGI2OEkiLCJ3b3Jrc3BhY2VJZCI6ImtyT1RBYm5jRmhvUU1DZExPbGU0IiwidXNlcklkIjoiRVJNUFBZY3FQMmZWWjB1NkRpNXZaYXJDdlZPMiIsImlhdCI6MTcyNjc1MDM1NH0.YQIDaeLS1CEaqwecawhgspLqjjzAcn8WaSli6GtUgJs" loading="lazy" title="Roboflow Workflow for Detect Common Objects" style="width: 100%; height: 100%; min-height: 400px; border: none;"></iframe></div>
+
 ## 💻 Install
 
 You can install `supervision` in a


### PR DESCRIPTION
# Description

- Adds playground workflows to base README, below "built with supervision" section
- Adds embedded playground workflow to docs, right below the demo video

![image](https://github.com/user-attachments/assets/de81182b-4732-41cb-a5fe-3b2ec71ff675)

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Previewing the `.md` documents to assure things are working.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
