### PR TITLE
feat: add __len__ to ColorPalette

### DIFF
--- a/supervision/draw/color.py
+++ b/supervision/draw/color.py
@@ -397,6 +397,15 @@ class ColorPalette:
         idx = idx % len(self.colors)
         return self.colors[idx]
 
+    def __len__(self) -> int:
+        """
+        Returns the number of colors in the palette.
+
+        Returns:
+            int: The number of colors.
+        """
+        return len(self.colors)
+
 
 def unify_to_bgr(color: Union[Tuple[int, int, int], Color]) -> Tuple[int, int, int]:
     """


### PR DESCRIPTION
# Description

For downstream use being able to determine how many colors are in a ColorPalette object can be useful. E.g., checking if a user has provided a color palette that matches the number of labels. ColorPalette doesn't currenly have a __len__ attribute meaning that `mypalette.colors` has to be used for calculating lengths. This change adds `__len__` to make this more intutitive by allowing `len(mypalette)`.

We found the lack of this functionality confusing: https://github.com/weecology/DeepForest/issues/790

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

I built the package with the change and confirmed that `len(mypalette)` returns the appropriate result

## Docs

No associate docs changes
