### PR TITLE
fix: 🔥 downgrade mkdocs-git-committers-plugin-2 to version 2.3.0

### DIFF
--- a/.github/workflows/publish-dev-docs.yml
+++ b/.github/workflows/publish-dev-docs.yml
@@ -43,7 +43,7 @@ jobs:
       - name: 📦 Install mkdocs-jupyter
         run: pip install mkdocs-jupyter
       - name: 📦 Install mkdocs-git-committers-plugin-2
-        run: pip install mkdocs-git-committers-plugin-2
+        run: pip install mkdocs-git-committers-plugin-2==2.3.0
       - name: ⚙️ Configure git for github-actions
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/publish-release-docs.yml
+++ b/.github/workflows/publish-release-docs.yml
@@ -44,7 +44,7 @@ jobs:
       - name: 📦 Install mkdocs-jupyter
         run: pip install mkdocs-jupyter
       - name: 📦 Install mkdocs-git-committers-plugin-2
-        run: pip install mkdocs-git-committers-plugin-2
+        run: pip install mkdocs-git-committers-plugin-2==2.3.0
       - name: ⚙️ Configure git for github-actions 👷
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/test-doc.yml
+++ b/.github/workflows/test-doc.yml
@@ -17,5 +17,5 @@ jobs:
       - name:  🏗️ Install dependencies and Test Docs Build
         run: |
           python -m pip install --upgrade pip
-          pip install "mkdocs-material" "mkdocstrings[python]" "mkdocs-material[imaging]" mike "mkdocs-git-revision-date-localized-plugin" jupyterlab mkdocs-jupyter mkdocs-git-committers-plugin-2
+          pip install "mkdocs-material" "mkdocstrings[python]" "mkdocs-material[imaging]" mike "mkdocs-git-revision-date-localized-plugin" jupyterlab mkdocs-jupyter mkdocs-git-committers-plugin-2==2.3.0
           mkdocs build --verbose

--- a/poetry.lock
+++ b/poetry.lock
@@ -4545,4 +4545,4 @@ metrics = ["pandas", "pandas-stubs"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "6619a49f1450ccc15a01215d156afbcf248619374ad2ba0576f48434d9b8720f"
+content-hash = "f7f497da73c8c467b621555f622bf0f10b21d0c4e97f68521e3f079e2ffb7789"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ mike = "^2.0.0"
 # For Documentation Development use Python 3.10 or above
 # Use Latest mkdocs-jupyter min 0.24.6 for Jupyter Notebook Theme support
 mkdocs-jupyter = "^0.24.3"
-mkdocs-git-committers-plugin-2 = "^2.2.3"
+mkdocs-git-committers-plugin-2 = "2.3.0"
 mkdocs-git-revision-date-localized-plugin = "^1.2.4"
 
 [tool.poetry.group.typecheck]


### PR DESCRIPTION
Temporary fix for mkdocs-git-committers-plugin-2 bug for avoid documentation build failds 
