### PR TITLE
Revert "fix: 🔥 downgrade mkdocs-git-committers-plugin-2 to version 2.3.0"

### DIFF
--- a/.github/workflows/publish-dev-docs.yml
+++ b/.github/workflows/publish-dev-docs.yml
@@ -43,7 +43,7 @@ jobs:
       - name: 📦 Install mkdocs-jupyter
         run: pip install mkdocs-jupyter
       - name: 📦 Install mkdocs-git-committers-plugin-2
-        run: pip install mkdocs-git-committers-plugin-2==2.3.0
+        run: pip install mkdocs-git-committers-plugin-2
       - name: ⚙️ Configure git for github-actions
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/publish-release-docs.yml
+++ b/.github/workflows/publish-release-docs.yml
@@ -44,7 +44,7 @@ jobs:
       - name: 📦 Install mkdocs-jupyter
         run: pip install mkdocs-jupyter
       - name: 📦 Install mkdocs-git-committers-plugin-2
-        run: pip install mkdocs-git-committers-plugin-2==2.3.0
+        run: pip install mkdocs-git-committers-plugin-2
       - name: ⚙️ Configure git for github-actions 👷
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/test-doc.yml
+++ b/.github/workflows/test-doc.yml
@@ -17,5 +17,5 @@ jobs:
       - name:  🏗️ Install dependencies and Test Docs Build
         run: |
           python -m pip install --upgrade pip
-          pip install "mkdocs-material" "mkdocstrings[python]" "mkdocs-material[imaging]" mike "mkdocs-git-revision-date-localized-plugin" jupyterlab mkdocs-jupyter mkdocs-git-committers-plugin-2==2.3.0
+          pip install "mkdocs-material" "mkdocstrings[python]" "mkdocs-material[imaging]" mike "mkdocs-git-revision-date-localized-plugin" jupyterlab mkdocs-jupyter mkdocs-git-committers-plugin-2
           mkdocs build --verbose

--- a/poetry.lock
+++ b/poetry.lock
@@ -2195,13 +2195,13 @@ pyyaml = ">=5.1"
 
 [[package]]
 name = "mkdocs-git-committers-plugin-2"
-version = "2.3.0"
+version = "2.4.1"
 description = "An MkDocs plugin to create a list of contributors on the page. The git-committers plugin will seed the template context with a list of GitHub or GitLab committers and other useful GIT info such as last modified date"
 optional = false
-python-versions = ">=3.8,<4"
+python-versions = "<4,>=3.8"
 files = [
-    {file = "mkdocs-git-committers-plugin-2-2.3.0.tar.gz", hash = "sha256:d6baca1ae04db8120640038eda8142f2d081c27b53f3b566c83c75717e4ed81a"},
-    {file = "mkdocs_git_committers_plugin_2-2.3.0-py3-none-any.whl", hash = "sha256:7b3434af3be525c12858eb3b44b4c6b695b7c7b7760482ea8de1c6e292e84f0f"},
+    {file = "mkdocs_git_committers_plugin_2-2.4.1-py3-none-any.whl", hash = "sha256:ec9c1d81445606c471337d1c4a1782c643b7377077b545279dc18b86b7362c6d"},
+    {file = "mkdocs_git_committers_plugin_2-2.4.1.tar.gz", hash = "sha256:ea1f80a79cedc42289e0b8e973276df04fb94f56e0ae3efc5385fb28547cf5cb"},
 ]
 
 [package.dependencies]
@@ -4545,4 +4545,4 @@ metrics = ["pandas", "pandas-stubs"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "6619a49f1450ccc15a01215d156afbcf248619374ad2ba0576f48434d9b8720f"
+content-hash = "ab2e2c455fa1a7d74271da71f8c1b6f096bbebd92a79b4ec646523ef7d8530b0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4545,4 +4545,4 @@ metrics = ["pandas", "pandas-stubs"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f7f497da73c8c467b621555f622bf0f10b21d0c4e97f68521e3f079e2ffb7789"
+content-hash = "6619a49f1450ccc15a01215d156afbcf248619374ad2ba0576f48434d9b8720f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ mike = "^2.0.0"
 # For Documentation Development use Python 3.10 or above
 # Use Latest mkdocs-jupyter min 0.24.6 for Jupyter Notebook Theme support
 mkdocs-jupyter = "^0.24.3"
-mkdocs-git-committers-plugin-2 = "^2.2.3"
+mkdocs-git-committers-plugin-2 = "^2.4.1"
 mkdocs-git-revision-date-localized-plugin = "^1.2.4"
 
 [tool.poetry.group.typecheck]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ mike = "^2.0.0"
 # For Documentation Development use Python 3.10 or above
 # Use Latest mkdocs-jupyter min 0.24.6 for Jupyter Notebook Theme support
 mkdocs-jupyter = "^0.24.3"
-mkdocs-git-committers-plugin-2 = "2.3.0"
+mkdocs-git-committers-plugin-2 = "^2.2.3"
 mkdocs-git-revision-date-localized-plugin = "^1.2.4"
 
 [tool.poetry.group.typecheck]


### PR DESCRIPTION
Based on new release of mkdocs-git-committers-plugin-2 I am reverting to original state of package version

https://github.com/ojacques/mkdocs-git-committers-plugin-2/pull/73
https://github.com/ojacques/mkdocs-git-committers-plugin-2/releases/tag/2.4.1