### PR TITLE
Bugfix: Class-agnostic mAP

### DIFF
--- a/supervision/metrics/__init__.py
+++ b/supervision/metrics/__init__.py
@@ -1,5 +1,4 @@
 from supervision.metrics.core import (
-    CLASS_ID_NONE,
     AveragingMethod,
     Metric,
     MetricTarget,

--- a/supervision/metrics/core.py
+++ b/supervision/metrics/core.py
@@ -4,9 +4,6 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any
 
-CLASS_ID_NONE = -1
-"""Used by metrics module as class ID, when none is present"""
-
 
 class Metric(ABC):
     """

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -186,7 +186,9 @@ class MeanAveragePrecision(Metric):
 
                     # Match detections: if class_agnostic is set, skip class matching
                     if self._class_agnostic:
-                        matches = self._match_detection_batch_class_agnostic(iou, iou_thresholds)
+                        matches = self._match_detection_batch_class_agnostic(
+                            iou, iou_thresholds
+                        )
                     else:
                         matches = self._match_detection_batch(
                             predictions.class_id, targets.class_id, iou, iou_thresholds
@@ -258,7 +260,6 @@ class MeanAveragePrecision(Metric):
         )
         correct = np.zeros((num_predictions, num_iou_levels), dtype=bool)
 
-        
         correct_class = target_classes[:, None] == predictions_classes
 
         for i, iou_level in enumerate(iou_thresholds):
@@ -277,6 +278,7 @@ class MeanAveragePrecision(Metric):
                 correct[matches[:, 1].astype(int), i] = True
 
         return correct
+
     @staticmethod
     def _match_detection_batch_class_agnostic(
         iou: np.ndarray,
@@ -303,6 +305,7 @@ class MeanAveragePrecision(Metric):
                 correct[matches[:, 1].astype(int), i] = True
 
         return correct
+
     @staticmethod
     def _average_precisions_per_class(
         matches: np.ndarray,

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -78,9 +78,9 @@ class MeanAveragePrecision(Metric):
         
         if self._class_agnostic:
             for prediction in predictions:
-                prediction.class_id[:] = 0
+                prediction.class_id[:] = -1
             for target in targets:
-                target.class_id[:] = 0
+                target.class_id[:] = -1
 
         self._predictions_list.extend(predictions)
         self._targets_list.extend(targets)

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -444,7 +444,7 @@ class MeanAveragePrecisionResult:
     """
 
     metric_target: MetricTarget
-    is_class_agnostic: 
+    is_class_agnostic: bool
 
     @property
     def map50_95(self) -> float:

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -75,9 +75,8 @@ class MeanAveragePrecision(Metric):
                 f"The number of predictions ({len(predictions)}) and"
                 f" targets ({len(targets)}) during the update must be the same."
             )
-        # class-agnostic
+        
         if self._class_agnostic:
-            # Set all class_ids to 0 to ignore class distinction
             for prediction in predictions:
                 prediction.class_id[:] = 0
             for target in targets:
@@ -184,7 +183,7 @@ class MeanAveragePrecision(Metric):
                             "Unsupported metric target for IoU calculation"
                         )
 
-                    # Match detections: if class_agnostic is set, skip class matching
+
                     if self._class_agnostic:
                         matches = self._match_detection_batch_class_agnostic(
                             iou, iou_thresholds

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -277,33 +277,6 @@ class MeanAveragePrecision(Metric):
         return correct
 
     @staticmethod
-    def _match_detection_batch_class_agnostic(
-        iou: np.ndarray,
-        iou_thresholds: np.ndarray,
-    ) -> np.ndarray:
-        """
-        Match detections for class-agnostic case, ignoring the class labels.
-        """
-        num_predictions, num_iou_levels = iou.shape[0], iou_thresholds.shape[0]
-        correct = np.zeros((num_predictions, num_iou_levels), dtype=bool)
-
-        for i, iou_level in enumerate(iou_thresholds):
-            matched_indices = np.where(iou >= iou_level)
-            if matched_indices[0].shape[0]:
-                combined_indices = np.stack(matched_indices, axis=1)
-                iou_values = iou[matched_indices][:, None]
-                matches = np.hstack([combined_indices, iou_values])
-
-                if matched_indices[0].shape[0] > 1:
-                    matches = matches[matches[:, 2].argsort()[::-1]]
-                    matches = matches[np.unique(matches[:, 1], return_index=True)[1]]
-                    matches = matches[np.unique(matches[:, 0], return_index=True)[1]]
-
-                correct[matches[:, 1].astype(int), i] = True
-
-        return correct
-
-    @staticmethod
     def _average_precisions_per_class(
         matches: np.ndarray,
         prediction_confidence: np.ndarray,

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -186,8 +186,6 @@ class MeanAveragePrecision(Metric):
                             "Unsupported metric target for IoU calculation"
                         )
 
-                    
-                    
                     matches = self._match_detection_batch(
                         predictions.class_id, targets.class_id, iou, iou_thresholds
                     )

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -215,7 +215,7 @@ class MeanAveragePrecision(Metric):
 
         return MeanAveragePrecisionResult(
             metric_target=self._metric_target,
-            is_class_agnostic= self._class_agnostic,
+            is_class_agnostic=self._class_agnostic,
             mAP_scores=mAP_scores,
             iou_thresholds=iou_thresholds,
             matched_classes=unique_classes,
@@ -442,7 +442,6 @@ class MeanAveragePrecisionResult:
         large_objects (Optional[MeanAveragePrecisionResult]): the mAP results
             for large objects.
     """
-
 
     metric_target: MetricTarget
     is_class_agnostic: bool

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -395,7 +395,8 @@ class MeanAveragePrecisionResult:
     Attributes:
         metric_target (MetricTarget): the type of data used for the metric -
             boxes, masks or oriented bounding boxes.
-        class_agnostic: When computing class-agnostic results, class ID is set to `-1`.
+        class_agnostic (bool): When computing class-agnostic results, class ID
+            is set to `-1`.
         mAP_map50_95 (float): the mAP score at IoU thresholds from `0.5` to `0.95`.
         mAP_map50 (float): the mAP score at IoU threshold of `0.5`.
         mAP_map75 (float): the mAP score at IoU threshold of `0.75`.

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -215,6 +215,7 @@ class MeanAveragePrecision(Metric):
 
         return MeanAveragePrecisionResult(
             metric_target=self._metric_target,
+            is_class_agnostic= self._class_agnostic,
             mAP_scores=mAP_scores,
             iou_thresholds=iou_thresholds,
             matched_classes=unique_classes,
@@ -443,7 +444,7 @@ class MeanAveragePrecisionResult:
     """
 
     metric_target: MetricTarget
-    is_class_agnostic: bool
+    is_class_agnostic: 
 
     @property
     def map50_95(self) -> float:

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -77,6 +77,9 @@ class MeanAveragePrecision(Metric):
             )
 
         if self._class_agnostic:
+            predictions = deepcopy(predictions)
+            targets = deepcopy(targets)
+
             for prediction in predictions:
                 prediction.class_id[:] = -1
             for target in targets:

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -186,14 +186,11 @@ class MeanAveragePrecision(Metric):
                             "Unsupported metric target for IoU calculation"
                         )
 
-                    if self._class_agnostic:
-                        matches = self._match_detection_batch_class_agnostic(
-                            iou, iou_thresholds
-                        )
-                    else:
-                        matches = self._match_detection_batch(
-                            predictions.class_id, targets.class_id, iou, iou_thresholds
-                        )
+                    
+                    
+                    matches = self._match_detection_batch(
+                        predictions.class_id, targets.class_id, iou, iou_thresholds
+                    )
 
                     stats.append(
                         (

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -424,6 +424,7 @@ class MeanAveragePrecisionResult:
     Attributes:
         metric_target (MetricTarget): the type of data used for the metric -
             boxes, masks or oriented bounding boxes.
+        class_agnostic: When computing class-agnostic results, class ID is set to `-1`.
         mAP_map50_95 (float): the mAP score at IoU thresholds from `0.5` to `0.95`.
         mAP_map50 (float): the mAP score at IoU threshold of `0.5`.
         mAP_map75 (float): the mAP score at IoU threshold of `0.75`.
@@ -443,6 +444,7 @@ class MeanAveragePrecisionResult:
     """
 
     metric_target: MetricTarget
+    is_class_agnostic: bool
 
     @property
     def map50_95(self) -> float:
@@ -477,6 +479,7 @@ class MeanAveragePrecisionResult:
         out_str = (
             f"{self.__class__.__name__}:\n"
             f"Metric target: {self.metric_target}\n"
+            f"Class-agnostic: {self.is_class_agnostic}\n"
             f"mAP @ 50:95: {self.map50_95:.4f}\n"
             f"mAP @ 50:    {self.map50:.4f}\n"
             f"mAP @ 75:    {self.map75:.4f}\n"

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -478,7 +478,7 @@ class MeanAveragePrecisionResult:
         out_str = (
             f"{self.__class__.__name__}:\n"
             f"Metric target: {self.metric_target}\n"
-            f"Class-agnostic: {self.is_class_agnostic}\n"
+            f"Class agnostic: {self.is_class_agnostic}\n"
             f"mAP @ 50:95: {self.map50_95:.4f}\n"
             f"mAP @ 50:    {self.map50:.4f}\n"
             f"mAP @ 75:    {self.map75:.4f}\n"


### PR DESCRIPTION
# Description

This pull request fixes the issue with the class_agnostic argument in the `MeanAveragePrecision` class, which was previously not functioning correctly. `The class_agnostic` flag now treats all predictions and ground truth as belonging to the same class when set to `True`. Added a `_match_detection_batch_class_agnostic` functionality.

[link for collab](https://colab.research.google.com/drive/10EaQ4lJNXzcmub7doO2vGn2t1LgDdkcC?usp=sharing)
## Type of change

Please delete options that are not relevant.

-  [X] Bug fix (non-breaking change which fixes an issue)


## How has this change been tested, please provide a testcase or example of how you tested the change?

This fix has been thoroughly tested using newly added unit tests, covering the following scenarios:

1. **Class-Specific mAP Calculation**:
   - Verified that mAP is computed correctly when `class_agnostic` is set to `False` (default).
   
2. **Class-Agnostic mAP Calculation**:
   - Confirmed that mAP is calculated without class distinction when `class_agnostic=True`.
  
3. **Edge Cases**:
   - Included test cases for no overlaps, perfect match scenarios, and partial overlaps.
## Any specific deployment considerations

No

## Docs

-   [x] Docs updated? What were the changes: No
