### PR TITLE
Minor fix: mAP can be 1.01

### DIFF
--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -230,7 +230,7 @@ class MeanAveragePrecision(Metric):
         for r, p in zip(recall[::-1], precision[::-1]):
             precision_levels[recall_levels <= r] = p
 
-        average_precision = (1 / 100 * precision_levels).sum()
+        average_precision = (1 / 101 * precision_levels).sum()
         return average_precision
 
     @staticmethod


### PR DESCRIPTION
# Description
Fix division to avoid cases where mAP value of `1.01` is possible.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Discovered here: https://colab.research.google.com/drive/10EaQ4lJNXzcmub7doO2vGn2t1LgDdkcC?usp=sharing

## Any specific deployment considerations

This effects mAP scores computed previously, such as those on the leaderboard.
This is effectively a `* 0.99` multiplier and will have a very minimal effect. I don't think we should recompute right now, and instead do it when we have more metrics.

## Docs

-   [ ] Docs updated? What were the changes:
