### PR TITLE
feat: 🚀 Add default color to PolygonZoneAnnotator, drawing functions

### DIFF
--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -88,7 +88,7 @@ class PolygonZoneAnnotator:
 
     Attributes:
         zone (PolygonZone): The polygon zone to be annotated
-        color (Color): The color to draw the polygon lines
+        color (Color): The color to draw the polygon lines, default is white
         thickness (int): The thickness of the polygon lines, default is 2
         text_color (Color): The color of the text on the polygon, default is black
         text_scale (float): The scale of the text on the polygon, default is 0.5
@@ -104,7 +104,7 @@ class PolygonZoneAnnotator:
     def __init__(
         self,
         zone: PolygonZone,
-        color: Color,
+        color: Color = Color.WHITE,
         thickness: int = 2,
         text_color: Color = Color.BLACK,
         text_scale: float = 0.5,

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -9,7 +9,7 @@ from supervision.geometry.core import Point, Rect
 
 
 def draw_line(
-    scene: np.ndarray, start: Point, end: Point, color: Color=Color(163, 81, 251), thickness: int = 2
+    scene: np.ndarray, start: Point, end: Point, color: Color=Color.ROBOFLOW, thickness: int = 2
 ) -> np.ndarray:
     """
     Draws a line on a given scene.
@@ -35,7 +35,7 @@ def draw_line(
 
 
 def draw_rectangle(
-    scene: np.ndarray, rect: Rect, color: Color=Color(163, 81, 251), thickness: int = 2
+    scene: np.ndarray, rect: Rect, color: Color=Color.ROBOFLOW, thickness: int = 2
 ) -> np.ndarray:
     """
     Draws a rectangle on an image.
@@ -60,7 +60,7 @@ def draw_rectangle(
 
 
 def draw_filled_rectangle(
-    scene: np.ndarray, rect: Rect, color: Color=Color(163, 81, 251), opacity: float = 1
+    scene: np.ndarray, rect: Rect, color: Color=Color.ROBOFLOW, opacity: float = 1
 ) -> np.ndarray:
     """
     Draws a filled rectangle on an image.
@@ -151,7 +151,7 @@ def draw_rounded_rectangle(
 
 
 def draw_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color=Color(163, 81, 251), thickness: int = 2
+    scene: np.ndarray, polygon: np.ndarray, color: Color=Color.ROBOFLOW, thickness: int = 2
 ) -> np.ndarray:
     """Draw a polygon on a scene.
 
@@ -171,7 +171,7 @@ def draw_polygon(
 
 
 def draw_filled_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color=Color(163, 81, 251), opacity: float = 1
+    scene: np.ndarray, polygon: np.ndarray, color: Color=Color.ROBOFLOW, opacity: float = 1
 ) -> np.ndarray:
     """Draw a filled polygon on a scene.
 

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -22,7 +22,7 @@ def draw_line(
         scene (np.ndarray): The scene on which the line will be drawn
         start (Point): The starting point of the line
         end (Point): The end point of the line
-        color (Color): The color of the line
+        color (Color): The color of the line, defaults to Color.ROBOFLOW
         thickness (int): The thickness of the line
 
     Returns:
@@ -165,7 +165,7 @@ def draw_polygon(
     Parameters:
         scene (np.ndarray): The scene to draw the polygon on.
         polygon (np.ndarray): The polygon to be drawn, given as a list of vertices.
-        color (Color): The color of the polygon.
+        color (Color): The color of the polygon. Defaults to Color.ROBOFLOW.
         thickness (int): The thickness of the polygon lines, by default 2.
 
     Returns:
@@ -188,7 +188,7 @@ def draw_filled_polygon(
     Parameters:
         scene (np.ndarray): The scene to draw the polygon on.
         polygon (np.ndarray): The polygon to be drawn, given as a list of vertices.
-        color (Color): The color of the polygon.
+        color (Color): The color of the polygon. Defaults to Color.ROBOFLOW.
         opacity (float): The opacity of polygon when drawn on the scene.
 
     Returns:

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -9,7 +9,7 @@ from supervision.geometry.core import Point, Rect
 
 
 def draw_line(
-    scene: np.ndarray, start: Point, end: Point, color: Color, thickness: int = 2
+    scene: np.ndarray, start: Point, end: Point, color: Color=Color(163, 81, 251), thickness: int = 2
 ) -> np.ndarray:
     """
     Draws a line on a given scene.
@@ -35,7 +35,7 @@ def draw_line(
 
 
 def draw_rectangle(
-    scene: np.ndarray, rect: Rect, color: Color, thickness: int = 2
+    scene: np.ndarray, rect: Rect, color: Color=Color(163, 81, 251), thickness: int = 2
 ) -> np.ndarray:
     """
     Draws a rectangle on an image.
@@ -60,7 +60,7 @@ def draw_rectangle(
 
 
 def draw_filled_rectangle(
-    scene: np.ndarray, rect: Rect, color: Color, opacity: float = 1
+    scene: np.ndarray, rect: Rect, color: Color=Color(163, 81, 251), opacity: float = 1
 ) -> np.ndarray:
     """
     Draws a filled rectangle on an image.
@@ -151,7 +151,7 @@ def draw_rounded_rectangle(
 
 
 def draw_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color, thickness: int = 2
+    scene: np.ndarray, polygon: np.ndarray, color: Color=Color(163, 81, 251), thickness: int = 2
 ) -> np.ndarray:
     """Draw a polygon on a scene.
 
@@ -171,7 +171,7 @@ def draw_polygon(
 
 
 def draw_filled_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color, opacity: float = 1
+    scene: np.ndarray, polygon: np.ndarray, color: Color=Color(163, 81, 251), opacity: float = 1
 ) -> np.ndarray:
     """Draw a filled polygon on a scene.
 

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -9,7 +9,11 @@ from supervision.geometry.core import Point, Rect
 
 
 def draw_line(
-    scene: np.ndarray, start: Point, end: Point, color: Color=Color.ROBOFLOW, thickness: int = 2
+    scene: np.ndarray,
+    start: Point,
+    end: Point,
+    color: Color = Color.ROBOFLOW,
+    thickness: int = 2,
 ) -> np.ndarray:
     """
     Draws a line on a given scene.
@@ -35,7 +39,7 @@ def draw_line(
 
 
 def draw_rectangle(
-    scene: np.ndarray, rect: Rect, color: Color=Color.ROBOFLOW, thickness: int = 2
+    scene: np.ndarray, rect: Rect, color: Color = Color.ROBOFLOW, thickness: int = 2
 ) -> np.ndarray:
     """
     Draws a rectangle on an image.
@@ -60,7 +64,7 @@ def draw_rectangle(
 
 
 def draw_filled_rectangle(
-    scene: np.ndarray, rect: Rect, color: Color=Color.ROBOFLOW, opacity: float = 1
+    scene: np.ndarray, rect: Rect, color: Color = Color.ROBOFLOW, opacity: float = 1
 ) -> np.ndarray:
     """
     Draws a filled rectangle on an image.
@@ -151,7 +155,10 @@ def draw_rounded_rectangle(
 
 
 def draw_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color=Color.ROBOFLOW, thickness: int = 2
+    scene: np.ndarray,
+    polygon: np.ndarray,
+    color: Color = Color.ROBOFLOW,
+    thickness: int = 2,
 ) -> np.ndarray:
     """Draw a polygon on a scene.
 
@@ -171,7 +178,10 @@ def draw_polygon(
 
 
 def draw_filled_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color=Color.ROBOFLOW, opacity: float = 1
+    scene: np.ndarray,
+    polygon: np.ndarray,
+    color: Color = Color.ROBOFLOW,
+    opacity: float = 1,
 ) -> np.ndarray:
     """Draw a filled polygon on a scene.
 


### PR DESCRIPTION
# Description

Default Colors Added: Default colors were added to utility functions such as drawLine, drawRectangle, drawPolygon, and PolygonZoneAnnotator.
Documentation: Documentation was added to explain the changes and usage of the new default colors.

Fix: #1587

## Type of change

- New feature (non-breaking change which adds functionality)




