### PR TITLE
feat: add default color (color.ROBOFLOW)

### DIFF
--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -104,7 +104,7 @@ class PolygonZoneAnnotator:
     def __init__(
         self,
         zone: PolygonZone,
-        color: Color,
+        color: Color = Color.ROBOFLOW,
         thickness: int = 2,
         text_color: Color = Color.BLACK,
         text_scale: float = 0.5,

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -9,7 +9,7 @@ from supervision.geometry.core import Point, Rect
 
 
 def draw_line(
-    scene: np.ndarray, start: Point, end: Point, color: Color, thickness: int = 2
+    scene: np.ndarray, start: Point, end: Point, color: Color = Color.ROBOFLOW, thickness: int = 2
 ) -> np.ndarray:
     """
     Draws a line on a given scene.
@@ -35,7 +35,7 @@ def draw_line(
 
 
 def draw_rectangle(
-    scene: np.ndarray, rect: Rect, color: Color, thickness: int = 2
+    scene: np.ndarray, rect: Rect, color: Color = Color.ROBOFLOW, thickness: int = 2
 ) -> np.ndarray:
     """
     Draws a rectangle on an image.
@@ -60,7 +60,7 @@ def draw_rectangle(
 
 
 def draw_filled_rectangle(
-    scene: np.ndarray, rect: Rect, color: Color, opacity: float = 1
+    scene: np.ndarray, rect: Rect, color: Color = Color.ROBOFLOW, opacity: float = 1
 ) -> np.ndarray:
     """
     Draws a filled rectangle on an image.
@@ -151,7 +151,7 @@ def draw_rounded_rectangle(
 
 
 def draw_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color, thickness: int = 2
+    scene: np.ndarray, polygon: np.ndarray, color: Color = Color.ROBOFLOW, thickness: int = 2
 ) -> np.ndarray:
     """Draw a polygon on a scene.
 
@@ -171,7 +171,7 @@ def draw_polygon(
 
 
 def draw_filled_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color, opacity: float = 1
+    scene: np.ndarray, polygon: np.ndarray, color: Color = Color.ROBOFLOW, opacity: float = 1
 ) -> np.ndarray:
     """Draw a filled polygon on a scene.
 

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -9,7 +9,11 @@ from supervision.geometry.core import Point, Rect
 
 
 def draw_line(
-    scene: np.ndarray, start: Point, end: Point, color: Color = Color.ROBOFLOW, thickness: int = 2
+    scene: np.ndarray,
+    start: Point,
+    end: Point,
+    color: Color = Color.ROBOFLOW,
+    thickness: int = 2,
 ) -> np.ndarray:
     """
     Draws a line on a given scene.
@@ -151,7 +155,10 @@ def draw_rounded_rectangle(
 
 
 def draw_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color = Color.ROBOFLOW, thickness: int = 2
+    scene: np.ndarray,
+    polygon: np.ndarray,
+    color: Color = Color.ROBOFLOW,
+    thickness: int = 2,
 ) -> np.ndarray:
     """Draw a polygon on a scene.
 
@@ -171,7 +178,10 @@ def draw_polygon(
 
 
 def draw_filled_polygon(
-    scene: np.ndarray, polygon: np.ndarray, color: Color = Color.ROBOFLOW, opacity: float = 1
+    scene: np.ndarray,
+    polygon: np.ndarray,
+    color: Color = Color.ROBOFLOW,
+    opacity: float = 1,
 ) -> np.ndarray:
     """Draw a filled polygon on a scene.
 


### PR DESCRIPTION
# Description

Fixes #1587 - adds default color `sv.Color.ROBOFLOW` to draw functions and polygon annotator.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Functions can now be called without specifying a color, as default ROBOFLOW color is used
