### PR TITLE
feat(ByteTrack): Allow ByteTrack to track detection without class ids

### DIFF
--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -276,11 +276,16 @@ class ByteTrack:
             ```
         """
 
+        num_rows = detections.xyxy.shape[0]
+        class_ids = np.full(num_rows, -5)
+        if detections.class_id is not None:
+            class_ids = detections.class_id
+
         tensors = np.hstack(
             (
                 detections.xyxy,
                 detections.confidence[:, np.newaxis],
-                detections.class_id[:, np.newaxis],
+                class_ids[:, np.newaxis],
             )
         )
         tracks = self.update_with_tensors(tensors=tensors)


### PR DESCRIPTION
**_Description:_**
This PR modifies ByteTrack to handle detections that do not include a class_id, improving the flexibility of the tracking algorithm. In cases where models don’t return a class_id, ByteTrack will now assign a default internal ID to ensure continued tracking.

**_Key Changes:_**
Default class_id Assignment:

- If class_id is missing from the detection, a default value of -5 is assigned to all detections.
- If class_id is available, the algorithm uses it as normal.

This ensures that ByteTrack works seamlessly with models that do not provide class_id, without breaking existing functionality.

You can test the functionality with the provided [Colab Notebook](https://colab.research.google.com/drive/1SXZndmumMotpHobM3kTefuv2pkggyy_R?usp=sharing) which demonstrates ByteTrack handling cases with and without class_id.

#1582 