### PR TITLE
Added smart positioning (non overlapping labels) to VertexLabelAnnotator

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1139,9 +1139,9 @@ class LabelAnnotator(BaseAnnotator):
 
         labels = self._get_labels_text(detections, labels)
         label_properties = self._get_label_properties(detections, labels)
-        xyxy = label_properties[:, :4]
 
         if self.smart_position:
+            xyxy = label_properties[:, :4]
             xyxy = spread_out_boxes(xyxy)
             label_properties[:, :4] = xyxy
 
@@ -1412,9 +1412,9 @@ class RichLabelAnnotator(BaseAnnotator):
         draw = ImageDraw.Draw(scene)
         labels = self._get_labels_text(detections, labels)
         label_properties = self._get_label_properties(draw, detections, labels)
-        xyxy = label_properties[:, :4]
 
         if self.smart_position:
+            xyxy = label_properties[:, :4]
             xyxy = spread_out_boxes(xyxy)
             label_properties[:, :4] = xyxy
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1056,7 +1056,7 @@ class LabelAnnotator(BaseAnnotator):
         text_position: Position = Position.TOP_LEFT,
         color_lookup: ColorLookup = ColorLookup.CLASS,
         border_radius: int = 0,
-        smart_positions: bool = False,
+        smart_position: bool = False,
     ):
         """
         Args:
@@ -1073,7 +1073,7 @@ class LabelAnnotator(BaseAnnotator):
                 Options are `INDEX`, `CLASS`, `TRACK`.
             border_radius (int): The radius to apply round edges. If the selected
                 value is higher than the lower dimension, width or height, is clipped.
-            smart_positions (bool): Spread out the labels to avoid overlapping.
+            smart_position (bool): Spread out the labels to avoid overlapping.
         """
         self.border_radius: int = border_radius
         self.color: Union[Color, ColorPalette] = color
@@ -1083,7 +1083,7 @@ class LabelAnnotator(BaseAnnotator):
         self.text_padding: int = text_padding
         self.text_anchor: Position = text_position
         self.color_lookup: ColorLookup = color_lookup
-        self.smart_positions = smart_positions
+        self.smart_position = smart_position
 
     @ensure_cv2_image_for_annotation
     def annotate(
@@ -1141,7 +1141,7 @@ class LabelAnnotator(BaseAnnotator):
         label_properties = self._get_label_properties(detections, labels)
         xyxy = label_properties[:, :4]
 
-        if self.smart_positions:
+        if self.smart_position:
             xyxy = spread_out_boxes(xyxy)
             label_properties[:, :4] = xyxy
 
@@ -1331,7 +1331,7 @@ class RichLabelAnnotator(BaseAnnotator):
         text_position: Position = Position.TOP_LEFT,
         color_lookup: ColorLookup = ColorLookup.CLASS,
         border_radius: int = 0,
-        smart_positions: bool = False,
+        smart_position: bool = False,
     ):
         """
         Args:
@@ -1348,7 +1348,7 @@ class RichLabelAnnotator(BaseAnnotator):
                 Options are `INDEX`, `CLASS`, `TRACK`.
             border_radius (int): The radius to apply round edges. If the selected
                 value is higher than the lower dimension, width or height, is clipped.
-            smart_positions (bool): Spread out the labels to avoid overlapping.
+            smart_position (bool): Spread out the labels to avoid overlapping.
         """
         self.color = color
         self.text_color = text_color
@@ -1356,7 +1356,7 @@ class RichLabelAnnotator(BaseAnnotator):
         self.text_anchor = text_position
         self.color_lookup = color_lookup
         self.border_radius = border_radius
-        self.smart_positions = smart_positions
+        self.smart_position = smart_position
         self.font = self._load_font(font_size, font_path)
 
     @ensure_pil_image_for_annotation
@@ -1414,7 +1414,7 @@ class RichLabelAnnotator(BaseAnnotator):
         label_properties = self._get_label_properties(draw, detections, labels)
         xyxy = label_properties[:, :4]
 
-        if self.smart_positions:
+        if self.smart_position:
             xyxy = spread_out_boxes(xyxy)
             label_properties[:, :4] = xyxy
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1065,7 +1065,7 @@ class LabelAnnotator(BaseAnnotator):
         text_position: Position = Position.TOP_LEFT,
         color_lookup: ColorLookup = ColorLookup.CLASS,
         border_radius: int = 0,
-        spread_out: bool = False,
+        smart_positions: bool = False,
     ):
         """
         Args:
@@ -1082,7 +1082,7 @@ class LabelAnnotator(BaseAnnotator):
                 Options are `INDEX`, `CLASS`, `TRACK`.
             border_radius (int): The radius to apply round edges. If the selected
                 value is higher than the lower dimension, width or height, is clipped.
-            spread_out (bool): Spread out the labels to avoid overlapping.
+            smart_positions (bool): Spread out the labels to avoid overlapping.
         """
         self.border_radius: int = border_radius
         self.color: Union[Color, ColorPalette] = color
@@ -1092,7 +1092,7 @@ class LabelAnnotator(BaseAnnotator):
         self.text_padding: int = text_padding
         self.text_anchor: Position = text_position
         self.color_lookup: ColorLookup = color_lookup
-        self.spread_out = spread_out
+        self.smart_positions = smart_positions
 
     @ensure_cv2_image_for_annotation
     def annotate(
@@ -1153,7 +1153,7 @@ class LabelAnnotator(BaseAnnotator):
             detections, text_properties, self.text_anchor
         )
 
-        if self.spread_out:
+        if self.smart_positions:
             xyxy = spread_out_boxes(xyxy, step=2, max_iterations=len(xyxy) * 20)
 
         self._draw_labels(
@@ -1362,7 +1362,7 @@ class RichLabelAnnotator(BaseAnnotator):
         text_position: Position = Position.TOP_LEFT,
         color_lookup: ColorLookup = ColorLookup.CLASS,
         border_radius: int = 0,
-        spread_out: bool = False,
+        smart_positions: bool = False,
     ):
         """
         Args:
@@ -1379,7 +1379,7 @@ class RichLabelAnnotator(BaseAnnotator):
                 Options are `INDEX`, `CLASS`, `TRACK`.
             border_radius (int): The radius to apply round edges. If the selected
                 value is higher than the lower dimension, width or height, is clipped.
-            spread_out (bool): Spread out the labels to avoid overlapping.
+            smart_positions (bool): Spread out the labels to avoid overlapping.
         """
         self.color = color
         self.text_color = text_color
@@ -1387,7 +1387,7 @@ class RichLabelAnnotator(BaseAnnotator):
         self.text_anchor = text_position
         self.color_lookup = color_lookup
         self.border_radius = border_radius
-        self.spread_out = spread_out
+        self.smart_positions = smart_positions
         self.font = self._load_font(font_size, font_path)
 
     @ensure_pil_image_for_annotation
@@ -1448,7 +1448,7 @@ class RichLabelAnnotator(BaseAnnotator):
             detections, text_properties, self.text_anchor
         )
 
-        if self.spread_out:
+        if self.smart_positions:
             xyxy = spread_out_boxes(xyxy, step=2, max_iterations=len(xyxy) * 20)
 
         self._draw_labels(

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1154,7 +1154,7 @@ class LabelAnnotator(BaseAnnotator):
         )
 
         if self.smart_positions:
-            xyxy = spread_out_boxes(xyxy, step=2, max_iterations=len(xyxy) * 20)
+            xyxy = spread_out_boxes(xyxy)
 
         self._draw_labels(
             scene=scene,
@@ -1449,7 +1449,7 @@ class RichLabelAnnotator(BaseAnnotator):
         )
 
         if self.smart_positions:
-            xyxy = spread_out_boxes(xyxy, step=2, max_iterations=len(xyxy) * 20)
+            xyxy = spread_out_boxes(xyxy)
 
         self._draw_labels(
             draw=draw,

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1247,9 +1247,11 @@ class LabelAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: Optional[np.ndarray],
     ) -> None:
-        assert (
-            len(xyxy) == len(text_properties) == len(detections)
-        ), f"Number of text properties ({len(text_properties)}), xyxy ({len(xyxy)}) and detections ({len(detections)}) do not match."
+        assert len(xyxy) == len(text_properties) == len(detections), (
+            f"Number of text properties ({len(text_properties)}), "
+            f"xyxy ({len(xyxy)}) and detections ({len(detections)}) "
+            "do not match."
+        )
 
         color_lookup = (
             custom_color_lookup
@@ -1442,7 +1444,6 @@ class RichLabelAnnotator(BaseAnnotator):
         labels = self._get_labels_text(detections, labels)
         text_properties = self._get_text_properties(draw, labels)
 
-        labels_text = self._get_labels_text(detections, labels)
         xyxy = self._calculate_label_positions(
             detections, text_properties, self.text_anchor
         )
@@ -1453,7 +1454,6 @@ class RichLabelAnnotator(BaseAnnotator):
         self._draw_labels(
             draw=draw,
             xyxy=xyxy,
-            labels=labels_text,
             text_properties=text_properties,
             detections=detections,
             custom_color_lookup=custom_color_lookup,
@@ -1520,25 +1520,6 @@ class RichLabelAnnotator(BaseAnnotator):
 
         return np.array(xyxy)
 
-    def _calculate_text_dimensions(
-        self, draw, label_text: str
-    ) -> Tuple[Tuple[int, int], Tuple[int, int]]:
-        """
-        Calculate text dimensions and offsets for the given label text.
-        Args:
-            label_text: The text to measure
-        Returns:
-            (Tuple[int, int]): ((left_offset, top_offset), (padded_width, padded_height))
-        """
-        text_left, text_top, text_right, text_bottom = draw.textbbox(
-            (0, 0), label_text, font=self.font
-        )
-        text_width = text_right - text_left
-        text_height = text_bottom - text_top
-        padded_width = text_width + 2 * self.text_padding
-        padded_height = text_height + 2 * self.text_padding
-        return (text_left, text_top), (padded_width, padded_height)
-
     @staticmethod
     def _get_labels_text(
         detections: Detections, custom_labels: Optional[List[str]]
@@ -1560,7 +1541,6 @@ class RichLabelAnnotator(BaseAnnotator):
         self,
         draw,
         xyxy: np.ndarray,
-        labels: List[str],
         text_properties: List[_TextProperties],
         detections: Detections,
         custom_color_lookup: Optional[np.ndarray],
@@ -1600,7 +1580,7 @@ class RichLabelAnnotator(BaseAnnotator):
             )
             draw.text(
                 xy=(label_x_position, label_y_position),
-                text=labels[idx],
+                text=text_properties[idx].text,
                 font=self.font,
                 fill=text_color.as_rgb(),
             )

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -33,6 +33,8 @@ from supervision.utils.image import (
 )
 from supervision.utils.internal import deprecated
 
+CV2_FONT = cv2.FONT_HERSHEY_SIMPLEX
+
 
 class BoxAnnotator(BaseAnnotator):
     """
@@ -1053,8 +1055,6 @@ class LabelAnnotator(BaseAnnotator):
         width_padded: int
         height_padded: int
 
-    _FONT = cv2.FONT_HERSHEY_SIMPLEX
-
     def __init__(
         self,
         color: Union[Color, ColorPalette] = ColorPalette.DEFAULT,
@@ -1181,7 +1181,7 @@ class LabelAnnotator(BaseAnnotator):
         for label in labels:
             (text_w, text_h) = cv2.getTextSize(
                 text=label,
-                fontFace=self._FONT,
+                fontFace=CV2_FONT,
                 fontScale=self.text_scale,
                 thickness=self.text_thickness,
             )[0]
@@ -1286,7 +1286,7 @@ class LabelAnnotator(BaseAnnotator):
                 img=scene,
                 text=text_properties[idx].text,
                 org=(text_x, text_y),
-                fontFace=self._FONT,
+                fontFace=CV2_FONT,
                 fontScale=self.text_scale,
                 color=text_color.as_bgr(),
                 thickness=self.text_thickness,

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from functools import lru_cache
 from math import sqrt
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
@@ -1154,10 +1154,7 @@ class LabelAnnotator(BaseAnnotator):
         )
 
         if self.spread_out:
-            xyxy = spread_out_boxes(
-                xyxy,
-                step=2,
-                max_iterations=len(xyxy) * 20)
+            xyxy = spread_out_boxes(xyxy, step=2, max_iterations=len(xyxy) * 20)
 
         self._draw_labels(
             scene=scene,
@@ -1189,23 +1186,25 @@ class LabelAnnotator(BaseAnnotator):
                 thickness=self.text_thickness,
             )[0]
 
-            text_properties.append(self._TextProperties(
-                text=label,
-                width=text_w,
-                height=text_h,
-                width_padded=text_w + 2 * self.text_padding,
-                height_padded=text_h + 2 * self.text_padding,
-            ))
+            text_properties.append(
+                self._TextProperties(
+                    text=label,
+                    width=text_w,
+                    height=text_h,
+                    width_padded=text_w + 2 * self.text_padding,
+                    height_padded=text_h + 2 * self.text_padding,
+                )
+            )
 
         return text_properties
 
     @staticmethod
     def _get_labels_text(
-        detections: Detections, custom_labels: Optional[List[str]]) -> List[str]:
-        
+        detections: Detections, custom_labels: Optional[List[str]]
+    ) -> List[str]:
         if custom_labels is not None:
             return custom_labels
-        
+
         labels = []
         for idx in range(len(detections)):
             if CLASS_NAME_DATA_FIELD in detections.data:
@@ -1248,9 +1247,9 @@ class LabelAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: Optional[np.ndarray],
     ) -> None:
-        assert len(xyxy) == len(text_properties) == len(detections), (
-            f"Number of text properties ({len(text_properties)}), xyxy ({len(xyxy)}) and detections ({len(detections)}) do not match."
-        )
+        assert (
+            len(xyxy) == len(text_properties) == len(detections)
+        ), f"Number of text properties ({len(text_properties)}), xyxy ({len(xyxy)}) and detections ({len(detections)}) do not match."
 
         color_lookup = (
             custom_color_lookup
@@ -1449,9 +1448,7 @@ class RichLabelAnnotator(BaseAnnotator):
         )
 
         if self.spread_out:
-            xyxy = spread_out_boxes(
-                xyxy, step=2, max_iterations=len(xyxy) * 20
-            )
+            xyxy = spread_out_boxes(xyxy, step=2, max_iterations=len(xyxy) * 20)
 
         self._draw_labels(
             draw=draw,
@@ -1459,7 +1456,7 @@ class RichLabelAnnotator(BaseAnnotator):
             labels=labels_text,
             text_properties=text_properties,
             detections=detections,
-            custom_color_lookup=custom_color_lookup
+            custom_color_lookup=custom_color_lookup,
         )
 
         return scene
@@ -1485,19 +1482,26 @@ class RichLabelAnnotator(BaseAnnotator):
             width_padded = text_width + 2 * self.text_padding
             height_padded = text_height + 2 * self.text_padding
 
-            text_properties.append(self._TextProperties(
-                text=label,
-                width=text_width,
-                height=text_height,
-                width_padded=width_padded,
-                height_padded=height_padded,
-                text_left=text_left,
-                text_top=text_top,
-            ))
+            text_properties.append(
+                self._TextProperties(
+                    text=label,
+                    width=text_width,
+                    height=text_height,
+                    width_padded=width_padded,
+                    height_padded=height_padded,
+                    text_left=text_left,
+                    text_top=text_top,
+                )
+            )
 
         return text_properties
-        
-    def _calculate_label_positions(self, detections: Detections, text_properties: List[_TextProperties], text_anchor: Position) -> np.ndarray:
+
+    def _calculate_label_positions(
+        self,
+        detections: Detections,
+        text_properties: List[_TextProperties],
+        text_anchor: Position,
+    ) -> np.ndarray:
         anchor_coordinates = detections.get_anchors_coordinates(
             anchor=self.text_anchor
         ).astype(int)
@@ -1516,7 +1520,9 @@ class RichLabelAnnotator(BaseAnnotator):
 
         return np.array(xyxy)
 
-    def _calculate_text_dimensions(self, draw, label_text: str) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+    def _calculate_text_dimensions(
+        self, draw, label_text: str
+    ) -> Tuple[Tuple[int, int], Tuple[int, int]]:
         """
         Calculate text dimensions and offsets for the given label text.
         Args:
@@ -1535,11 +1541,11 @@ class RichLabelAnnotator(BaseAnnotator):
 
     @staticmethod
     def _get_labels_text(
-        detections: Detections, custom_labels: Optional[List[str]]) -> List[str]:
-        
+        detections: Detections, custom_labels: Optional[List[str]]
+    ) -> List[str]:
         if custom_labels is not None:
             return custom_labels
-        
+
         labels = []
         for idx in range(len(detections)):
             if CLASS_NAME_DATA_FIELD in detections.data:
@@ -1599,7 +1605,6 @@ class RichLabelAnnotator(BaseAnnotator):
                 fill=text_color.as_rgb(),
             )
 
-
     @staticmethod
     def _load_font(font_size: int, font_path: Optional[str]):
         def load_default_font(size):
@@ -1607,15 +1612,16 @@ class RichLabelAnnotator(BaseAnnotator):
                 return ImageFont.load_default(size)
             except TypeError:
                 return ImageFont.load_default()
-        
+
         if font_path is None:
             return load_default_font(font_size)
-    
+
         try:
             return ImageFont.truetype(font_path, font_size)
         except OSError:
             print(f"Font path '{font_path}' not found. Using PIL's default font.")
             return load_default_font(font_size)
+
 
 class IconAnnotator(BaseAnnotator):
     """

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1168,6 +1168,13 @@ class LabelAnnotator(BaseAnnotator):
         detections: Detections,
         labels: List[str],
     ) -> np.ndarray:
+        """
+        Calculate the numerical properties required to draw the labels on the image.
+
+        Returns:
+            (np.ndarray): An array of label properties, containing columns:
+                `min_x`, `min_y`, `max_x`, `max_y`, `padded_text_height`.
+        """
         label_properties = []
         anchors_coordinates = detections.get_anchors_coordinates(
             anchor=self.text_anchor
@@ -1439,6 +1446,15 @@ class RichLabelAnnotator(BaseAnnotator):
     def _get_label_properties(
         self, draw, detections: Detections, labels: List[str]
     ) -> np.ndarray:
+        """
+        Calculate the numerical properties required to draw the labels on the image.
+
+        Returns:
+            (np.ndarray): An array of label properties, containing columns:
+                `min_x`, `min_y`, `max_x`, `max_y`, `text_left_coordinate`,
+                `text_top_coordinate`. The first 4 values are already padded
+                with `text_padding`.
+        """
         label_properties = []
 
         anchor_coordinates = detections.get_anchors_coordinates(

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -1042,83 +1042,53 @@ def cross_product(anchors: np.ndarray, vector: Vector) -> np.ndarray:
     return np.cross(vector_at_zero, anchors - vector_start)
 
 
-# Intelligent padding functions
-def get_intersection_center(
+def get_box_intersection(
     xyxy_1: np.ndarray, xyxy_2: np.ndarray
-) -> Optional[Tuple[float, float]]:
+) -> Optional[np.ndarray]:
     overlap_xmin = max(xyxy_1[0], xyxy_2[0])
     overlap_ymin = max(xyxy_1[1], xyxy_2[1])
     overlap_xmax = min(xyxy_1[2], xyxy_2[2])
     overlap_ymax = min(xyxy_1[3], xyxy_2[3])
 
     if overlap_xmin < overlap_xmax and overlap_ymin < overlap_ymax:
-        x_center = (overlap_xmin + overlap_xmax) / 2
-        y_center = (overlap_ymin + overlap_ymax) / 2
-        return (x_center, y_center)
+        return np.array([overlap_xmin, overlap_ymin, overlap_xmax, overlap_ymax])
     else:
         return None
 
+def get_unit_vector(xy_1: np.ndarray, xy_2: np.ndarray) -> np.ndarray:
+    direction = xy_2 - xy_1
+    magnitude = np.linalg.norm(direction)
+    return direction / magnitude if magnitude > 0 else np.zeros(2)
 
-def get_box_center(xyxy: np.ndarray) -> Tuple[float, float]:
-    x_center = (xyxy[0] + xyxy[2]) / 2
-    y_center = (xyxy[1] + xyxy[3]) / 2
-    return (x_center, y_center)
+def spread_out_boxes(xyxy: np.ndarray, step: int, max_iterations: int = 100) -> np.ndarray:
+    if len(xyxy) == 0:
+        return xyxy
 
-
-def vector_with_length(
-    xy_1: Tuple[float, float], xy_2: Tuple[float, float], n: float
-) -> Tuple[float, float]:
-    x1, y1 = xy_1
-    x2, y2 = xy_2
-
-    dx = x2 - x1
-    dy = y2 - y1
-
-    if dx == 0 and dy == 0:
-        return 0, 0
-
-    magnitude = math.sqrt(dx**2 + dy**2)
-
-    unit_dx = dx / magnitude
-    unit_dy = dy / magnitude
-
-    v1 = unit_dx * n
-    v2 = unit_dy * n
-
-    return (v1, v2)
-
-
-def pad(xyxy: np.ndarray, px: int, py: Optional[int] = None):
-    if py is None:
-        py = px
-
-    result = xyxy.copy()
-    result[:, [0, 1]] -= [px, py]
-    result[:, [2, 3]] += [px, py]
-
-    return result
-
-
-def spread_out(xyxy: np.ndarray, step) -> np.ndarray:
-    xyxy_padded = pad(xyxy, px=step)
-    while True:
+    xyxy_padded = pad_boxes(xyxy, px=step)
+    for _ in range(max_iterations):
         iou = box_iou_batch(xyxy_padded, xyxy_padded)
         np.fill_diagonal(iou, 0)
 
         if np.all(iou == 0):
-            return pad(xyxy_padded, px=-step)
+            break
 
         i, j = np.unravel_index(np.argmax(iou), iou.shape)
 
         xyxy_i, xyxy_j = xyxy_padded[i], xyxy_padded[j]
-        intersection_center = get_intersection_center(xyxy_i, xyxy_j)
-        xyxy_i_center = get_box_center(xyxy_i)
-        xyxy_j_center = get_box_center(xyxy_j)
+        box_intersection = get_box_intersection(xyxy_i, xyxy_j)
+        assert box_intersection is not None, \
+            "Since we checked IoU already, boxes should always intersect"
 
-        vector_i = vector_with_length(intersection_center, xyxy_i_center, step)
-        vector_j = vector_with_length(intersection_center, xyxy_j_center, step)
+        intersection_center = (box_intersection[:2] + box_intersection[2:]) / 2
+        xyxy_i_center = (xyxy_i[:2] + xyxy_i[2:]) / 2
+        xyxy_j_center = (xyxy_j[:2] + xyxy_j[2:]) / 2
 
-        xyxy_padded[i, [0, 2]] += int(vector_i[0])
-        xyxy_padded[i, [1, 3]] += int(vector_i[1])
-        xyxy_padded[j, [0, 2]] += int(vector_j[0])
-        xyxy_padded[j, [1, 3]] += int(vector_j[1])
+        unit_vector_i = get_unit_vector(intersection_center, xyxy_i_center)
+        unit_vector_j = get_unit_vector(intersection_center, xyxy_j_center)
+
+        xyxy_padded[i, [0, 2]] += int(unit_vector_i[0] * step)
+        xyxy_padded[i, [1, 3]] += int(unit_vector_i[1] * step)
+        xyxy_padded[j, [0, 2]] += int(unit_vector_j[0] * step)
+        xyxy_padded[j, [1, 3]] += int(unit_vector_j[1] * step)
+
+    return pad_boxes(xyxy_padded, px=-step)

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -1041,26 +1041,6 @@ def cross_product(anchors: np.ndarray, vector: Vector) -> np.ndarray:
     return np.cross(vector_at_zero, anchors - vector_start)
 
 
-def get_box_intersection(
-    xyxy_1: np.ndarray, xyxy_2: np.ndarray
-) -> Optional[np.ndarray]:
-    overlap_xmin = max(xyxy_1[0], xyxy_2[0])
-    overlap_ymin = max(xyxy_1[1], xyxy_2[1])
-    overlap_xmax = min(xyxy_1[2], xyxy_2[2])
-    overlap_ymax = min(xyxy_1[3], xyxy_2[3])
-
-    if overlap_xmin < overlap_xmax and overlap_ymin < overlap_ymax:
-        return np.array([overlap_xmin, overlap_ymin, overlap_xmax, overlap_ymax])
-    else:
-        return None
-
-
-def get_unit_vector(xy_1: np.ndarray, xy_2: np.ndarray) -> np.ndarray:
-    direction = xy_2 - xy_1
-    magnitude = np.linalg.norm(direction)
-    return direction / magnitude if magnitude > 0 else np.zeros(2)
-
-
 def spread_out_boxes(
     xyxy: np.ndarray,
     max_iterations: int = 100,

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -1,4 +1,3 @@
-import math
 from itertools import chain
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -1055,12 +1054,16 @@ def get_box_intersection(
     else:
         return None
 
+
 def get_unit_vector(xy_1: np.ndarray, xy_2: np.ndarray) -> np.ndarray:
     direction = xy_2 - xy_1
     magnitude = np.linalg.norm(direction)
     return direction / magnitude if magnitude > 0 else np.zeros(2)
 
-def spread_out_boxes(xyxy: np.ndarray, step: int, max_iterations: int = 100) -> np.ndarray:
+
+def spread_out_boxes(
+    xyxy: np.ndarray, step: int, max_iterations: int = 100
+) -> np.ndarray:
     if len(xyxy) == 0:
         return xyxy
 
@@ -1076,8 +1079,9 @@ def spread_out_boxes(xyxy: np.ndarray, step: int, max_iterations: int = 100) -> 
 
         xyxy_i, xyxy_j = xyxy_padded[i], xyxy_padded[j]
         box_intersection = get_box_intersection(xyxy_i, xyxy_j)
-        assert box_intersection is not None, \
-            "Since we checked IoU already, boxes should always intersect"
+        assert (
+            box_intersection is not None
+        ), "Since we checked IoU already, boxes should always intersect"
 
         intersection_center = (box_intersection[:2] + box_intersection[2:]) / 2
         xyxy_i_center = (xyxy_i[:2] + xyxy_i[2:]) / 2

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -1086,13 +1086,8 @@ def spread_out_boxes(
         force_vectors = force_vectors[:, np.newaxis] * direction_vectors
 
         force_vectors *= 10
-        force_vectors[(force_vectors > 0) & (force_vectors < 1)] = 1
-        force_vectors[(force_vectors < 0) & (force_vectors > -1)] = -1
-
-        # Move along main axis only.
-        force_vectors[
-            np.arange(len(force_vectors)), np.argmin(force_vectors, axis=1)
-        ] = 0
+        force_vectors[(force_vectors > 0) & (force_vectors < 2)] = 2
+        force_vectors[(force_vectors < 0) & (force_vectors > -2)] = -2
 
         force_vectors = force_vectors.astype(int)
 

--- a/supervision/keypoint/annotators.py
+++ b/supervision/keypoint/annotators.py
@@ -5,11 +5,11 @@ from typing import List, Optional, Tuple, Union
 import cv2
 import numpy as np
 
-from supervision.geometry.core import Rect
 from supervision.annotators.base import ImageType
 from supervision.detection.utils import pad_boxes, spread_out_boxes
 from supervision.draw.color import Color
 from supervision.draw.utils import draw_rounded_rectangle
+from supervision.geometry.core import Rect
 from supervision.keypoint.core import KeyPoints
 from supervision.keypoint.skeletons import SKELETONS_BY_VERTEX_COUNT
 from supervision.utils.conversion import ensure_cv2_image_for_annotation
@@ -348,23 +348,23 @@ class VertexLabelAnnotator:
         text_colors = text_colors[mask]
         labels = labels[mask]
 
-        xyxy = np.array([
-            self.get_text_bounding_box(
-                text=label,
-                font=font,
-                text_scale=self.text_scale,
-                text_thickness=self.text_thickness,
-                center_coordinates=tuple(anchor),
-            )
-            for anchor, label in zip(anchors, labels)
-        ])
+        xyxy = np.array(
+            [
+                self.get_text_bounding_box(
+                    text=label,
+                    font=font,
+                    text_scale=self.text_scale,
+                    text_thickness=self.text_thickness,
+                    center_coordinates=tuple(anchor),
+                )
+                for anchor, label in zip(anchors, labels)
+            ]
+        )
         xyxy_padded = pad_boxes(xyxy=xyxy, px=self.text_padding)
 
         if self.spread_out:
             xyxy_padded = spread_out_boxes(
-                xyxy_padded,
-                step=2,
-                max_iterations=len(xyxy_padded) * 20
+                xyxy_padded, step=2, max_iterations=len(xyxy_padded) * 20
             )
             xyxy = pad_boxes(xyxy=xyxy_padded, px=-self.text_padding)
 

--- a/supervision/keypoint/annotators.py
+++ b/supervision/keypoint/annotators.py
@@ -202,7 +202,7 @@ class VertexLabelAnnotator:
         text_thickness: int = 1,
         text_padding: int = 10,
         border_radius: int = 0,
-        spread_out: bool = False,
+        smart_positions: bool = False,
     ):
         """
         Args:
@@ -217,7 +217,7 @@ class VertexLabelAnnotator:
             text_padding (int): The padding around the text.
             border_radius (int): The radius of the rounded corners of the
                 boxes. Set to a high value to produce circles.
-            spread_out (bool): Spread out the labels to avoid overlap.
+            smart_positions (bool): Spread out the labels to avoid overlap.
         """
         self.border_radius: int = border_radius
         self.color: Union[Color, List[Color]] = color
@@ -225,7 +225,7 @@ class VertexLabelAnnotator:
         self.text_scale: float = text_scale
         self.text_thickness: int = text_thickness
         self.text_padding: int = text_padding
-        self.spread_out = spread_out
+        self.smart_positions = smart_positions
 
     def annotate(
         self,
@@ -362,7 +362,7 @@ class VertexLabelAnnotator:
         )
         xyxy_padded = pad_boxes(xyxy=xyxy, px=self.text_padding)
 
-        if self.spread_out:
+        if self.smart_positions:
             xyxy_padded = spread_out_boxes(
                 xyxy_padded, step=2, max_iterations=len(xyxy_padded) * 20
             )

--- a/supervision/keypoint/annotators.py
+++ b/supervision/keypoint/annotators.py
@@ -202,7 +202,7 @@ class VertexLabelAnnotator:
         text_thickness: int = 1,
         text_padding: int = 10,
         border_radius: int = 0,
-        smart_positions: bool = False,
+        smart_position: bool = False,
     ):
         """
         Args:
@@ -217,7 +217,7 @@ class VertexLabelAnnotator:
             text_padding (int): The padding around the text.
             border_radius (int): The radius of the rounded corners of the
                 boxes. Set to a high value to produce circles.
-            smart_positions (bool): Spread out the labels to avoid overlap.
+            smart_position (bool): Spread out the labels to avoid overlap.
         """
         self.border_radius: int = border_radius
         self.color: Union[Color, List[Color]] = color
@@ -225,7 +225,7 @@ class VertexLabelAnnotator:
         self.text_scale: float = text_scale
         self.text_thickness: int = text_thickness
         self.text_padding: int = text_padding
-        self.smart_positions = smart_positions
+        self.smart_position = smart_position
 
     def annotate(
         self,
@@ -362,7 +362,7 @@ class VertexLabelAnnotator:
         )
         xyxy_padded = pad_boxes(xyxy=xyxy, px=self.text_padding)
 
-        if self.smart_positions:
+        if self.smart_position:
             xyxy_padded = spread_out_boxes(xyxy_padded)
             xyxy = pad_boxes(xyxy=xyxy_padded, px=-self.text_padding)
 

--- a/supervision/keypoint/annotators.py
+++ b/supervision/keypoint/annotators.py
@@ -363,9 +363,7 @@ class VertexLabelAnnotator:
         xyxy_padded = pad_boxes(xyxy=xyxy, px=self.text_padding)
 
         if self.smart_positions:
-            xyxy_padded = spread_out_boxes(
-                xyxy_padded, step=2, max_iterations=len(xyxy_padded) * 20
-            )
+            xyxy_padded = spread_out_boxes(xyxy_padded)
             xyxy = pad_boxes(xyxy=xyxy_padded, px=-self.text_padding)
 
         for text, color, text_color, box, box_padded in zip(


### PR DESCRIPTION
# Description

Resolved issue #1383 regarding overlapping labels in output.
Changes Done in VertexLabelAnnotator, LabelAnnotator and RichLabelAnnotator
No Extra dependencies used

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Have added an optional argument to the VertexLabelAnnotator called `use_smart_positioning` which defaults to `False`.
Enabling this prevents overlapping.

Before:

https://github.com/user-attachments/assets/2906efd5-2a88-4ee0-ba86-cfb250d3fc8f

After:

VertexLabelAnnotator:

https://github.com/user-attachments/assets/5c4bf897-a695-4b88-962e-217f881248fe

Label Annotator:

https://github.com/user-attachments/assets/8ded0d84-cca0-4c05-8504-f1478ac20771

Rich Label Annotator (font: [Vampire Wars](https://www.dafont.com/vampire-wars.font?back=theme)):

https://github.com/user-attachments/assets/4065dd38-0151-4f89-b5b7-b0b613431608

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:
-  Changes to docstrings in:
1. VertexLabelAnnotator
2. LabelAnnotator
3. RichLabelAnnotator

Collab Link: https://colab.research.google.com/drive/1GPHr7PpZ_eNs8Gkxx_A4w6PL5p4pJAn1?usp=sharing#scrollTo=ZHptw0Fk4lk4
