### PR TITLE
feat(ByteTrack): Allow ByteTrack to track detection without class ids

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1609,7 +1609,7 @@ class TraceAnnotator(BaseAnnotator):
         position: Position = Position.CENTER,
         trace_length: int = 30,
         thickness: int = 2,
-        color_lookup: ColorLookup = ColorLookup.INDEX,
+        color_lookup: ColorLookup = ColorLookup.CLASS,
     ):
         """
         Args:

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1609,7 +1609,7 @@ class TraceAnnotator(BaseAnnotator):
         position: Position = Position.CENTER,
         trace_length: int = 30,
         thickness: int = 2,
-        color_lookup: ColorLookup = ColorLookup.CLASS,
+        color_lookup: ColorLookup = ColorLookup.INDEX,
     ):
         """
         Args:

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -32,7 +32,6 @@ class STrack(BaseTrack):
         self,
         tlwh,
         score,
-        class_ids,
         minimum_consecutive_frames,
         internal_id_counter: IdCounter,
         external_id_counter: IdCounter,
@@ -45,7 +44,6 @@ class STrack(BaseTrack):
         self.is_activated = False
 
         self.score = score
-        self.class_ids = class_ids
         self.tracklet_len = 0
 
         self.minimum_consecutive_frames = minimum_consecutive_frames
@@ -280,7 +278,6 @@ class ByteTrack:
             (
                 detections.xyxy,
                 detections.confidence[:, np.newaxis],
-                detections.class_id[:, np.newaxis],
             )
         )
         tracks = self.update_with_tensors(tensors=tensors)
@@ -340,7 +337,6 @@ class ByteTrack:
         lost_stracks = []
         removed_stracks = []
 
-        class_ids = tensors[:, 5]
         scores = tensors[:, 4]
         bboxes = tensors[:, :4]
 
@@ -354,21 +350,17 @@ class ByteTrack:
         scores_keep = scores[remain_inds]
         scores_second = scores[inds_second]
 
-        class_ids_keep = class_ids[remain_inds]
-        class_ids_second = class_ids[inds_second]
-
         if len(dets) > 0:
             """Detections"""
             detections = [
                 STrack(
                     STrack.tlbr_to_tlwh(tlbr),
                     s,
-                    c,
                     self.minimum_consecutive_frames,
                     self.internal_id_counter,
                     self.external_id_counter,
                 )
-                for (tlbr, s, c) in zip(dets, scores_keep, class_ids_keep)
+                for (tlbr, s) in zip(dets, scores_keep)
             ]
         else:
             detections = []
@@ -412,12 +404,11 @@ class ByteTrack:
                 STrack(
                     STrack.tlbr_to_tlwh(tlbr),
                     s,
-                    c,
                     self.minimum_consecutive_frames,
                     self.internal_id_counter,
                     self.external_id_counter,
                 )
-                for (tlbr, s, c) in zip(dets_second, scores_second, class_ids_second)
+                for (tlbr, s) in zip(dets_second, scores_second)
             ]
         else:
             detections_second = []


### PR DESCRIPTION
ByteTrack was tested and confirmed to work without needing class_ids. After reviewing the ByteTrack documentation, also noted that class_ids were not essential, so I removed class_ids. The system functions correctly without them.

You can test the functionality with the provided [Colab Notebook](https://colab.research.google.com/drive/1SXZndmumMotpHobM3kTefuv2pkggyy_R?usp=sharing) which demonstrates ByteTrack handling cases with and without class_id.

#1582 