### PR TITLE
Revert "feat(ByteTrack): Allow ByteTrack to track detection without class ids"

### DIFF
--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -276,16 +276,11 @@ class ByteTrack:
             ```
         """
 
-        num_rows = detections.xyxy.shape[0]
-        class_ids = np.full(num_rows, -5)
-        if detections.class_id is not None:
-            class_ids = detections.class_id
-
         tensors = np.hstack(
             (
                 detections.xyxy,
                 detections.confidence[:, np.newaxis],
-                class_ids[:, np.newaxis],
+                detections.class_id[:, np.newaxis],
             )
         )
         tracks = self.update_with_tensors(tensors=tensors)


### PR DESCRIPTION
Reverts roboflow/supervision#1618, as class_id is not necessary for tracking.