### PR TITLE
Fix regression where all uninitialized tracks are connected

### DIFF
--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -10,19 +10,23 @@ from supervision.tracker.byte_tracker.kalman_filter import KalmanFilter
 
 
 class IdCounter:
-    def __init__(self):
+    def __init__(self, start_id: int = 0):
+        self.start_id = start_id
+        if self.start_id <= self.NO_ID:
+            raise ValueError("start_id must be greater than -1")
         self.reset()
 
     def reset(self) -> None:
-        self._id = self.NO_ID
+        self._id = self.start_id
 
     def new_id(self) -> int:
+        returned_id = self._id
         self._id += 1
-        return self._id
+        return returned_id
 
     @property
     def NO_ID(self) -> int:
-        return 0
+        return -1
 
 
 class STrack(BaseTrack):
@@ -231,8 +235,10 @@ class ByteTrack:
         self.lost_tracks: List[STrack] = []
         self.removed_tracks: List[STrack] = []
 
+        # Warning, possible bug: If you also set internal_id to start at 1,
+        # all traces will be connected across objects.
         self.internal_id_counter = IdCounter()
-        self.external_id_counter = IdCounter()
+        self.external_id_counter = IdCounter(start_id=1)
 
     def update_with_detections(self, detections: Detections) -> Detections:
         """


### PR DESCRIPTION
# Description

Apparently, external track ID must start with `1` and not `0`.
I introduced the regression when refactoring how IDs are stored and generated inside ByteTrack, somewhere around  Commit `#4a7d9cea`.

If this is not true, when `minimum_consecutive_frames > 1`, all objects where no traces are established get assigned an ID of 0, and are connected with a single trace. A bit odd. Not sure where this coupling comes from.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

[Colab](https://colab.research.google.com/drive/1YL-NQPRDvJZHh-YQF-Ir8g0LiCoR5u5f?usp=sharing)

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes:
