### PR TITLE
Add skiing video asset

### DIFF
--- a/supervision/assets/list.py
+++ b/supervision/assets/list.py
@@ -20,6 +20,7 @@ class VideoAssets(Enum):
     | `PEOPLE_WALKING`       | `people-walking.mp4`       | [Link](https://media.roboflow.com/supervision/video-examples/people-walking.mp4)      |
     | `BEACH`                | `beach-1.mp4`              | [Link](https://media.roboflow.com/supervision/video-examples/beach-1.mp4)             |
     | `BASKETBALL`           | `basketball-1.mp4`         | [Link](https://media.roboflow.com/supervision/video-examples/basketball-1.mp4)        |
+    | `SKIING`               | `skiing.mp4`               | [Link](https://media.roboflow.com/supervision/video-examples/skiing.mp4)              |
     """  # noqa: E501 // docs
 
     VEHICLES = "vehicles.mp4"
@@ -31,6 +32,7 @@ class VideoAssets(Enum):
     PEOPLE_WALKING = "people-walking.mp4"
     BEACH = "beach-1.mp4"
     BASKETBALL = "basketball-1.mp4"
+    SKIING = "skiing.mp4"
 
     @classmethod
     def list(cls):
@@ -73,5 +75,9 @@ VIDEO_ASSETS: Dict[str, Tuple[str, str]] = {
     VideoAssets.BASKETBALL.value: (
         f"{BASE_VIDEO_URL}{VideoAssets.BASKETBALL.value}",
         "60d94a3c7c47d16f09d342b088012ecc",
+    ),
+    VideoAssets.SKIING.value: (
+        f"{BASE_VIDEO_URL}{VideoAssets.SKIING.value}",
+        "d30987cbab1bbc5934199cdd1b293119",
     ),
 }


### PR DESCRIPTION
# Description

Add a video asset of a skier, with the camera following him.

Video by Adrien JACTA: https://www.pexels.com/video/ski-montagne-skier-piste-de-ski-4274798/
from [Pexels](https://www.pexels.com/)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

```python
from supervision.assets import download_assets, VideoAssets
from supervision.assets.list import VIDEO_ASSETS
from supervision.assets.downloader import is_md5_hash_matching


download_assets(VideoAssets.SKIING)

assert is_md5_hash_matching("skiing.mp4", VIDEO_ASSETS[VideoAssets.SKIING.value][1])
```


## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes:
