### PR TITLE
fix(tests): 🐞 update inference slicer tests to new overlap system for removing test warnings

### DIFF
--- a/test/detection/tools/test_inference_slicer.py
+++ b/test/detection/tools/test_inference_slicer.py
@@ -22,33 +22,26 @@ def mock_callback():
 @pytest.mark.parametrize(
     "slice_wh, overlap_ratio_wh, overlap_wh, expected_overlap, exception",
     [
-        # Valid case: overlap_ratio_wh provided, overlap calculated from the ratio
-        ((128, 128), (0.2, 0.2), None, None, DoesNotRaise()),
-        # Valid case: overlap_wh in pixels, no ratio provided
+        # Valid case: explicit overlap_wh in pixels
+        ((128, 128), None, (26, 26), (26, 26), DoesNotRaise()),
+        # Valid case: overlap_wh in pixels
         ((128, 128), None, (20, 20), (20, 20), DoesNotRaise()),
-        # Invalid case: overlap_ratio_wh greater than 1, should raise ValueError
-        ((128, 128), (1.1, 0.5), None, None, pytest.raises(ValueError)),
         # Invalid case: negative overlap_wh, should raise ValueError
         ((128, 128), None, (-10, 20), None, pytest.raises(ValueError)),
-        # Invalid case:
-        # overlap_ratio_wh and overlap_wh provided, should raise ValueError
-        ((128, 128), (0.5, 0.5), (20, 20), (20, 20), pytest.raises(ValueError)),
-        # Valid case: no overlap_ratio_wh, overlap_wh = 50 pixels
-        ((256, 256), None, (50, 50), (50, 50), DoesNotRaise()),
-        # Valid case: overlap_ratio_wh provided, overlap calculated from (0.3, 0.3)
-        ((200, 200), (0.3, 0.3), None, None, DoesNotRaise()),
-        # Valid case: small overlap_ratio_wh values
-        ((100, 100), (0.1, 0.1), None, None, DoesNotRaise()),
-        # Invalid case: negative overlap_ratio_wh value, should raise ValueError
-        ((128, 128), (-0.1, 0.2), None, None, pytest.raises(ValueError)),
-        # Invalid case: negative overlap_ratio_wh with overlap_wh provided
-        ((128, 128), (-0.1, 0.2), (30, 30), None, pytest.raises(ValueError)),
-        # Invalid case: overlap_wh greater than slice size, should raise ValueError
-        ((128, 128), None, (150, 150), (150, 150), DoesNotRaise()),
-        # Valid case: overlap_ratio_wh is 0, no overlap
-        ((128, 128), (0.0, 0.0), None, None, DoesNotRaise()),
-        # Invalid case: no overlaps defined, no overlap
+        # Invalid case: no overlaps defined
         ((128, 128), None, None, None, pytest.raises(ValueError)),
+        # Valid case: overlap_wh = 50 pixels
+        ((256, 256), None, (50, 50), (50, 50), DoesNotRaise()),
+        # Valid case: overlap_wh = 60 pixels
+        ((200, 200), None, (60, 60), (60, 60), DoesNotRaise()),
+        # Valid case: small overlap_wh values
+        ((100, 100), None, (0.1, 0.1), (0.1, 0.1), DoesNotRaise()),
+        # Invalid case: negative overlap_wh values
+        ((128, 128), None, (-10, -10), None, pytest.raises(ValueError)),
+        # Invalid case: overlap_wh greater than slice size
+        ((128, 128), None, (150, 150), (150, 150), DoesNotRaise()),
+        # Valid case: zero overlap
+        ((128, 128), None, (0, 0), (0, 0), DoesNotRaise()),
     ],
 )
 def test_inference_slicer_overlap(


### PR DESCRIPTION

# Description

Fixing warnings 

```console
========================================================================== warnings summary ===========================================================================
test/detection/tools/test_inference_slicer.py::test_inference_slicer_overlap[slice_wh0-overlap_ratio_wh0-None-None-exception0]
test/detection/tools/test_inference_slicer.py::test_inference_slicer_overlap[slice_wh2-overlap_ratio_wh2-None-None-exception2]
test/detection/tools/test_inference_slicer.py::test_inference_slicer_overlap[slice_wh4-overlap_ratio_wh4-overlap_wh4-expected_overlap4-exception4]
test/detection/tools/test_inference_slicer.py::test_inference_slicer_overlap[slice_wh6-overlap_ratio_wh6-None-None-exception6]
```

fix(tests): 🐞 update inference slicer tests to new overlap system for removing test warnings