### PR TITLE
bump version from 0.25.0 to 0.26.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "supervision"
-version = "0.25.0"
+version = "0.26.0rc1"
 description = "A set of easy-to-use utils that will come in handy in any Computer Vision project"
 authors = ["Piotr Skalski <piotr.skalski92@gmail.com>"]
 maintainers = [


### PR DESCRIPTION
# Release Candidate 0.26.0rc1

* Adjustments to numpy version requirements, making supervision easier to integrate with [inference](https://github.com/roboflow/inference) and workflows.
* removed `supervision[assets]` extra - assets are now part of the main `supervision` package.