### PR TITLE
Mask datatype specify in docs

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -117,7 +117,7 @@ class Detections:
         xyxy (np.ndarray): An array of shape `(n, 4)` containing
             the bounding boxes coordinates in format `[x1, y1, x2, y2]`
         mask: (Optional[np.ndarray]): An array of shape
-            `(n, H, W)` containing the segmentation masks.
+            `(n, H, W)` containing the segmentation masks (`bool` data type).
         confidence (Optional[np.ndarray]): An array of shape
             `(n,)` containing the confidence scores of the detections.
         class_id (Optional[np.ndarray]): An array of shape


### PR DESCRIPTION
Specified that mask is in bool datatype. Used int8 (gpt generated code) and was debugging this issue for 3 hours until I looked into source code of mask annotator.

When using int8 mask (instead of bool dtype), mask annotator will take crazy long to process (like 10sec on MacBook M2), and result won't be correct.

## Type of change

Please delete options that are not relevant.

-   [x] Documentation update
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
Docs update

## Docs

-   [x] Docs updated? What were the changes:
