### PR TITLE
fix: is_empty check for filtering

### DIFF
--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1203,6 +1203,8 @@ class Detections:
             return self.data.get(index)
         if isinstance(index, int):
             index = [index]
+        if self.is_empty():
+            return Detections.empty()
         return Detections(
             xyxy=self.xyxy[index],
             mask=self.mask[index] if self.mask is not None else None,

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1201,10 +1201,10 @@ class Detections:
         """
         if isinstance(index, str):
             return self.data.get(index)
-        if isinstance(index, int):
-            index = [index]
         if self.is_empty():
             return Detections.empty()
+        if isinstance(index, int):
+            index = [index]
         return Detections(
             xyxy=self.xyxy[index],
             mask=self.mask[index] if self.mask is not None else None,

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -223,6 +223,12 @@ TEST_DET_DIFFERENT_METADATA = Detections(
             None,
             pytest.raises(IndexError),
         ),
+        (
+            Detections.empty(),
+            np.isin(Detections.empty()["class_name"], [0, 1, 2]),
+            Detections.empty(),
+            DoesNotRaise(),
+        ),
     ],
 )
 def test_getitem(

--- a/test/detection/test_core.py
+++ b/test/detection/test_core.py
@@ -225,10 +225,10 @@ TEST_DET_DIFFERENT_METADATA = Detections(
         ),
         (
             Detections.empty(),
-            np.isin(Detections.empty()["class_name"], [0, 1, 2]),
+            np.isin(Detections.empty()["class_name"], ["cat", "dog"]),
             Detections.empty(),
             DoesNotRaise(),
-        ),
+        ),  # Filter an empty detections by specific class names
     ],
 )
 def test_getitem(


### PR DESCRIPTION
Hopefully fixes #1694.

Test code:
```python
import supervision as sv
import numpy as np

CLASSES = [0, 1, 2]

prediction = sv.Detections.empty()
prediction = prediction[np.isin(prediction["class_name"], CLASSES)]

print(prediction)
```
New output:
```
Detections(xyxy=array([], shape=(0, 4), dtype=float32), mask=None, confidence=array([], dtype=float32), class_id=array([], dtype=int64), tracker_id=None, data={}, metadata={})
```
