### PR TITLE
Letterbox resolve to required resolution

### DIFF
--- a/docs/detection/utils.md
+++ b/docs/detection/utils.md
@@ -72,6 +72,12 @@ status: new
 :::supervision.detection.utils.scale_boxes
 
 <div class="md-typeset">
+  <h2><a href="#supervision.detection.utils.resolve_letterbox">resolve_letterbox</a></h2>
+</div>
+
+:::supervision.detection.utils.resolve_letterbox
+
+<div class="md-typeset">
   <h2><a href="#supervision.detection.utils.clip_boxes">clip_boxes</a></h2>
 </div>
 

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -76,6 +76,7 @@ from supervision.detection.utils import (
     scale_boxes,
     xcycwh_to_xyxy,
     xywh_to_xyxy,
+    resolve_letterbox,
 )
 from supervision.draw.color import Color, ColorPalette
 from supervision.draw.utils import (
@@ -219,6 +220,7 @@ __all__ = [
     "resize_image",
     "rle_to_mask",
     "scale_boxes",
+    "resolve_letterbox",
     "scale_image",
     "xcycwh_to_xyxy",
     "xywh_to_xyxy",

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -73,10 +73,10 @@ from supervision.detection.utils import (
     pad_boxes,
     polygon_to_mask,
     polygon_to_xyxy,
+    resolve_letterbox,
     scale_boxes,
     xcycwh_to_xyxy,
     xywh_to_xyxy,
-    resolve_letterbox,
 )
 from supervision.draw.color import Color, ColorPalette
 from supervision.draw.utils import (
@@ -218,9 +218,9 @@ __all__ = [
     "polygon_to_xyxy",
     "process_video",
     "resize_image",
+    "resolve_letterbox",
     "rle_to_mask",
     "scale_boxes",
-    "resolve_letterbox",
     "scale_image",
     "xcycwh_to_xyxy",
     "xywh_to_xyxy",

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -762,7 +762,11 @@ def scale_boxes(
     return np.concatenate((centers - new_sizes / 2, centers + new_sizes / 2), axis=1)
 
 
-def resolve_letterbox(xyxy: npt.NDArray[np.float64], letterbox_wh: Tuple[int, int], resolution_wh: Tuple[int, int]) -> npt.NDArray[np.float64]:
+def resolve_letterbox(
+    xyxy: npt.NDArray[np.float64],
+    letterbox_wh: Tuple[int, int],
+    resolution_wh: Tuple[int, int],
+) -> npt.NDArray[np.float64]:
     """
     Resolves the bounding box coordinates from letterbox format to the required resolution.
     Args:
@@ -790,7 +794,7 @@ def resolve_letterbox(xyxy: npt.NDArray[np.float64], letterbox_wh: Tuple[int, in
 
     scale = input_w / width_new
 
-    padding_top = (letterbox_h - height_new)  // 2
+    padding_top = (letterbox_h - height_new) // 2
     padding_left = (letterbox_w - width_new) // 2
 
     boxes = xyxy.copy()
@@ -801,7 +805,7 @@ def resolve_letterbox(xyxy: npt.NDArray[np.float64], letterbox_wh: Tuple[int, in
     boxes[:, [1, 3]] *= scale
 
     return boxes
-    
+
 
 def calculate_masks_centroids(masks: np.ndarray) -> np.ndarray:
     """

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -762,13 +762,13 @@ def scale_boxes(
     return np.concatenate((centers - new_sizes / 2, centers + new_sizes / 2), axis=1)
 
 
-def resolve_letterbox(
-    xyxy: npt.NDArray[np.float64],
-    letterbox_wh: Tuple[int, int],
-    resolution_wh: Tuple[int, int],
-) -> npt.NDArray[np.float64]:
+
+def resolve_letterbox(xyxy: npt.NDArray[np.float64],
+                      letterbox_wh: Tuple[int, int],
+                      resolution_wh: Tuple[int, int]) -> npt.NDArray[np.float64]:
     """
-    Resolves the bounding box coordinates from letterbox format to the required resolution.
+    Resolves the bounding box coordinates from letterbox format
+    to the required resolution.
     Args:
         xyxy (npt.NDArray[np.float64]): An array of shape `(n, 4)` containing the
             bounding boxes coordinates in format `[x1, y1, x2, y2]`
@@ -776,8 +776,8 @@ def resolve_letterbox(
         resolution_wh (Tuple[int, int]): The target resolution as `(width, height)`.
 
     Returns:
-        Detections: A new Detections object with the bounding box coordinates resolved to the
-            target resolution.
+        Detections: A new Detections object with the bounding box coordinates resolved
+        to the target resolution.
     """
 
     input_w, input_h = resolution_wh
@@ -794,7 +794,7 @@ def resolve_letterbox(
 
     scale = input_w / width_new
 
-    padding_top = (letterbox_h - height_new) // 2
+    padding_top = (letterbox_h - height_new)  // 2
     padding_left = (letterbox_w - width_new) // 2
 
     boxes = xyxy.copy()

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -762,10 +762,11 @@ def scale_boxes(
     return np.concatenate((centers - new_sizes / 2, centers + new_sizes / 2), axis=1)
 
 
-
-def resolve_letterbox(xyxy: npt.NDArray[np.float64],
-                      letterbox_wh: Tuple[int, int],
-                      resolution_wh: Tuple[int, int]) -> npt.NDArray[np.float64]:
+def resolve_letterbox(
+    xyxy: npt.NDArray[np.float64],
+    letterbox_wh: Tuple[int, int],
+    resolution_wh: Tuple[int, int],
+) -> npt.NDArray[np.float64]:
     """
     Resolves the bounding box coordinates from letterbox format
     to the required resolution.
@@ -794,7 +795,7 @@ def resolve_letterbox(xyxy: npt.NDArray[np.float64],
 
     scale = input_w / width_new
 
-    padding_top = (letterbox_h - height_new)  // 2
+    padding_top = (letterbox_h - height_new) // 2
     padding_left = (letterbox_w - width_new) // 2
 
     boxes = xyxy.copy()


### PR DESCRIPTION
# Description

Currently, supervision has `sv.letterbox_image()` which resize images to get padded and with same aspect ratio image. But once this image used for detection task, then boxes has to be resized to original image in order to get correct scale and location of the boxes.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [x] Docs updated? What were the changes:

## Script to reproduce results:

```
import numpy as np
from ultralytics import YOLO
from PIL import Image
import cv2
import supervision as sv


model = YOLO("yolo11n.pt")

image = Image.open("bus.jpg")

def detect_objects(image):
    results = model([image])[0]
    detections = sv.Detections.from_ultralytics(results)
    return detections


def annotate_img(image, dets):
    box_annotator = sv.BoxAnnotator()
    ann_img = box_annotator.annotate(image.copy(), dets)

    return ann_img


wo_letterbox_detections = detect_objects(image)
box_annotator = sv.BoxAnnotator()
wo_ann_img = box_annotator.annotate(image.copy(), wo_letterbox_detections)

## Process with letterbox
letterbox_resolution = (640, 640)
resolution_wh = (image.width, image.height)
letterboxed_image = sv.letterbox_image(image, letterbox_resolution)
letterbox_detections = detect_objects(letterboxed_image)
letterbox_detections.xyxy = sv.resolve_letterbox(letterbox_detections.xyxy, letterbox_resolution, resolution_wh)

box_annotator = sv.BoxAnnotator()
with_ann_img = box_annotator.annotate(image.copy(), letterbox_detections)
with_ann_img = sv.pillow_to_cv2(with_ann_img)


wo_ann_img = sv.pillow_to_cv2(wo_ann_img)
viz_img = np.hstack([wo_ann_img, with_ann_img])
cv2.imshow("Detection", viz_img)
cv2.waitKey(0)

```

