### PR TITLE
Kapa: remove duplicate initialization

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,7 +178,6 @@ markdown_extensions:
       anchor_linenums: true
 
 extra_javascript:
-  - "https://widget.kapa.ai/kapa-widget.bundle.js"
   - "javascripts/init_kapa_widget.js"
   - "javascripts/cookbooks-card.js"
   - "https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.8/purify.min.js"


### PR DESCRIPTION
# Description

This is a tiny change that removes duplicate initialization of the Kapa widget.

With duplicate initialization no Roboflow logo is displayed on the chat button, and attempts to chat with the agent result in a configuration error message.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested by checking out mkdocs and chatting with the agent.

<img width="859" alt="image" src="https://github.com/user-attachments/assets/531bc2b1-5ccf-42be-922e-f3002a26099d">

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
