### PR TITLE
Remove import check for `assets`

### DIFF
--- a/supervision/assets/downloader.py
+++ b/supervision/assets/downloader.py
@@ -4,19 +4,10 @@ from pathlib import Path
 from shutil import copyfileobj
 from typing import Union
 
-from supervision.assets.list import VIDEO_ASSETS, VideoAssets
+from requests import get
+from tqdm.auto import tqdm
 
-try:
-    from requests import get
-    from tqdm.auto import tqdm
-except ImportError:
-    raise ValueError(
-        "\n"
-        "Please install requests and tqdm to download assets \n"
-        "or install supervision with assets \n"
-        "pip install supervision[assets] \n"
-        "\n"
-    )
+from supervision.assets.list import VIDEO_ASSETS, VideoAssets
 
 
 def is_md5_hash_matching(filename: str, original_md5_hash: str) -> bool:


### PR DESCRIPTION
# Description

The dependencies are part of the main supervision package already, as of #1672 

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update