### PR TITLE
Disable kapa until we test its functionality

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,7 +178,8 @@ markdown_extensions:
       anchor_linenums: true
 
 extra_javascript:
-  - "javascripts/init_kapa_widget.js"
+  # disabled until 0.27.0, so we can test its functionality
+  # - "javascripts/init_kapa_widget.js"
   - "javascripts/cookbooks-card.js"
   - "https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.8/purify.min.js"
 


### PR DESCRIPTION
# Description

We've recently created a supervision config in Kapa, which made the widget appear on the site, prior to any testing we could do. Let's disable it until `0.27.0`.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

`mkdocs serve`

## Any specific deployment considerations

## Docs

-   [x] Docs updated? What were the changes:

`Ask AI` widget is no longer available.
