### PR TITLE
Enable kapa for 0.27.0

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,8 +178,7 @@ markdown_extensions:
       anchor_linenums: true
 
 extra_javascript:
-  # disabled until 0.27.0, so we can test its functionality
-  # - "javascripts/init_kapa_widget.js"
+  - "javascripts/init_kapa_widget.js"
   - "javascripts/cookbooks-card.js"
   - "https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.8/purify.min.js"
 


### PR DESCRIPTION
# Description

⚠️ Only merge this after 0.26.0 release

Kapa AI abruptly appeared on supervision after setting up the project on Kapa's website, without sufficient testing. We've disabled it for `0.26.0`.

Let's re-enable it for `0.27.0`.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

`mkdocs serve`

## Any specific deployment considerations

Only merge this after 0.26.0 release.

## Docs

-   [x] Docs updated? What were the changes:

`Ask AI` button is available again.