### PR TITLE
Fix polygon trigger false positives when bounding boxes are clipped

### DIFF
--- a/supervision/detection/tools/polygon_zone.py
+++ b/supervision/detection/tools/polygon_zone.py
@@ -1,4 +1,3 @@
-from dataclasses import replace
 from typing import Iterable, Optional
 
 import cv2
@@ -6,7 +5,7 @@ import numpy as np
 import numpy.typing as npt
 
 from supervision import Detections
-from supervision.detection.utils import clip_boxes, polygon_to_mask
+from supervision.detection.utils import polygon_to_mask
 from supervision.draw.color import Color
 from supervision.draw.utils import draw_filled_polygon, draw_polygon, draw_text
 from supervision.geometry.core import Position
@@ -87,25 +86,30 @@ class PolygonZone:
                 if each detection is within the polygon zone
         """
 
-        original_anchors = np.array([
-            np.ceil(detections.get_anchors_coordinates(anchor)).astype(int)
-            for anchor in self.triggering_anchors
-        ])
-        
+        original_anchors = np.array(
+            [
+                np.ceil(detections.get_anchors_coordinates(anchor)).astype(int)
+                for anchor in self.triggering_anchors
+            ]
+        )
+
         original_anchors_clamped = np.clip(
             original_anchors,
             a_min=[0, 0],
-            a_max=[self.mask.shape[1] - 1, self.mask.shape[0] - 1]
+            a_max=[self.mask.shape[1] - 1, self.mask.shape[0] - 1],
         )
-        
-        is_in_zone_original = self.mask[
-            original_anchors_clamped[:, :, 1],
-            original_anchors_clamped[:, :, 0]
-        ].transpose().astype(bool)
-        
+
+        is_in_zone_original = (
+            self.mask[
+                original_anchors_clamped[:, :, 1], original_anchors_clamped[:, :, 0]
+            ]
+            .transpose()
+            .astype(bool)
+        )
+
         is_in_zone = np.all(is_in_zone_original, axis=1)
         self.current_count = int(np.sum(is_in_zone))
-        
+
         return is_in_zone.astype(bool)
 
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

**Fixed an issue where objects partially overlapping with polygons were incorrectly detected. Previously, when a polygon was positioned on the left side of the screen and a person on the right, with the person's bounding box slightly overlapping the polygon, the clip_boxes() function would forcefully clip the boxes to fit within the frame. This caused objects outside the frame to be incorrectly identified as being inside the polygon.**

### Changes

- Modified the trigger() function to use original bounding box coordinates (pre-clipping) for polygon intersection checks
- This reduces false positives and ensures more accurate counting while maintaining logical consistency

![image](https://github.com/user-attachments/assets/decbf119-3bd9-46e0-b110-106c6fc371a8)

The original bounding box is large, and its bottom center point does not overlap with the polygon. However, during the clipping process, since the bottom-left corner intersects with the polygon, the box is forcefully shrunk. This causes the center point to shift inside the polygon, resulting in false detections.

Thank you

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
