### PR TITLE
Add transform method to Detections class and documentation for the transform method

### DIFF
--- a/docs/detection/detection.md
+++ b/docs/detection/detection.md
@@ -1,0 +1,48 @@
+### `transform`
+
+Transform detections to match the dataset's class names and IDs.
+
+This method performs the following steps:
+
+1. **Remaps class names** using the provided `class_mapping` dictionary.
+2. **Filters out predictions** that are not present in the dataset's classes.
+3. **Remaps class IDs** to match the dataset's class IDs.
+
+#### Parameters
+
+- **dataset**: The dataset object containing class names and IDs.
+- **class_mapping** (`Optional[Dict[str, str]]`): A dictionary to map model class names to dataset class names. If `None`, no remapping is performed.
+
+#### Returns
+
+- **Detections**: A new `Detections` object with transformed class names and IDs.
+
+#### Raises
+
+- **ValueError**: If the dataset does not contain the required class names.
+
+#### Example
+
+```python
+# Example dataset with class names
+class DatasetMock:
+    def __init__(self):
+        self.classes = ["animal", "bird"]
+
+# Example detections
+detections = Detections(
+    xyxy=np.array([[10, 10, 50, 50], [60, 60, 100, 100]]),
+    confidence=np.array([0.9, 0.8]),
+    class_id=np.array([0, 1]),
+    data={"class_name": ["dog", "eagle"]}
+)
+
+# Class mapping
+class_mapping = {"dog": "animal", "eagle": "bird"}
+
+# Transform detections
+transformed_detections = detections.transform(DatasetMock(), class_mapping)
+
+print(transformed_detections.class_id)  # Output: [0, 1]
+print(transformed_detections.data["class_name"])  # Output: ["animal", "bird"]
+```

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -1532,7 +1532,9 @@ def validate_fields_both_defined_or_none(
             )
 
 
-def transform(self, dataset, class_mapping: Optional[Dict[str, str]] = None) -> Detections:
+def transform(
+    self, dataset, class_mapping: Optional[Dict[str, str]] = None
+) -> Detections:
     """
     Transform detections to match the dataset's class names and IDs.
 
@@ -1552,13 +1554,15 @@ def transform(self, dataset, class_mapping: Optional[Dict[str, str]] = None) -> 
 
     if class_mapping is not None:
         if self.class_id is None or self.data.get(CLASS_NAME_DATA_FIELD) is None:
-            raise ValueError("Class names must be available in the data field for remapping.")
+            raise ValueError(
+                "Class names must be available in the data field for remapping."
+            )
 
         current_class_names = self.data[CLASS_NAME_DATA_FIELD]
 
-        remapped_class_names = np.array([
-            class_mapping.get(name, name) for name in current_class_names
-        ])
+        remapped_class_names = np.array(
+            [class_mapping.get(name, name) for name in current_class_names]
+        )
 
         if not all(name in dataset.classes for name in np.unique(remapped_class_names)):
             raise ValueError("All mapped class names must be in the dataset's classes.")
@@ -1566,7 +1570,6 @@ def transform(self, dataset, class_mapping: Optional[Dict[str, str]] = None) -> 
         self.data[CLASS_NAME_DATA_FIELD] = remapped_class_names
 
     if self.class_id is not None and self.data.get(CLASS_NAME_DATA_FIELD) is not None:
-
         class_names = self.data[CLASS_NAME_DATA_FIELD]
 
         mask = np.isin(class_names, dataset.classes)

--- a/test/detection/test_detection.py
+++ b/test/detection/test_detection.py
@@ -1,6 +1,9 @@
 import unittest
+
 import numpy as np
+
 from supervision.detections.core import Detections
+
 
 class TestDetectionsTransform(unittest.TestCase):
     def test_transform(self):
@@ -14,7 +17,7 @@ class TestDetectionsTransform(unittest.TestCase):
             xyxy=np.array([[10, 10, 50, 50], [60, 60, 100, 100]]),
             confidence=np.array([0.9, 0.8]),
             class_id=np.array([0, 1]),
-            data={"class_name": ["dog", "eagle"]}
+            data={"class_name": ["dog", "eagle"]},
         )
 
         # Class mapping
@@ -25,7 +28,10 @@ class TestDetectionsTransform(unittest.TestCase):
 
         # Verify results
         self.assertEqual(transformed_detections.class_id.tolist(), [0, 1])
-        self.assertEqual(transformed_detections.data["class_name"].tolist(), ["animal", "bird"])
+        self.assertEqual(
+            transformed_detections.data["class_name"].tolist(), ["animal", "bird"]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/detection/test_detection.py
+++ b/test/detection/test_detection.py
@@ -1,0 +1,31 @@
+import unittest
+import numpy as np
+from supervision.detections.core import Detections
+
+class TestDetectionsTransform(unittest.TestCase):
+    def test_transform(self):
+        # Mock dataset
+        class DatasetMock:
+            def __init__(self):
+                self.classes = ["animal", "bird"]
+
+        # Example detections
+        detections = Detections(
+            xyxy=np.array([[10, 10, 50, 50], [60, 60, 100, 100]]),
+            confidence=np.array([0.9, 0.8]),
+            class_id=np.array([0, 1]),
+            data={"class_name": ["dog", "eagle"]}
+        )
+
+        # Class mapping
+        class_mapping = {"dog": "animal", "eagle": "bird"}
+
+        # Transform detections
+        transformed_detections = detections.transform(DatasetMock(), class_mapping)
+
+        # Verify results
+        self.assertEqual(transformed_detections.class_id.tolist(), [0, 1])
+        self.assertEqual(transformed_detections.data["class_name"].tolist(), ["animal", "bird"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add transform method to Detections class and documentation for the transform method

- Added the `transform` method to the `Detections` class to support remapping class names, filtering predictions, and remapping class IDs to match a dataset's classes.
- Added comprehensive documentation for the `transform` method in `docs/detections.md`, including a description, parameters, returns, raises, and an example usage.