### PR TITLE
correct docstring to match parameter order as per documentation.

### DIFF
--- a/supervision/keypoint/core.py
+++ b/supervision/keypoint/core.py
@@ -91,10 +91,10 @@ class KeyPoints:
         xy (np.ndarray): An array of shape `(n, m, 2)` containing
             `n` detected objects, each composed of `m` equally-sized
             sets of keypoints, where each point is `[x, y]`.
-        confidence (Optional[np.ndarray]): An array of shape
-            `(n, m)` containing the confidence scores of each keypoint.
         class_id (Optional[np.ndarray]): An array of shape
             `(n,)` containing the class ids of the detected objects.
+        confidence (Optional[np.ndarray]): An array of shape
+            `(n, m)` containing the confidence scores of each keypoint.
         data (Dict[str, Union[np.ndarray, List]]): A dictionary containing additional
             data where each key is a string representing the data type, and the value
             is either a NumPy array or a list of corresponding data of length `n`


### PR DESCRIPTION
# Description
Updated the docstring to accurately reflect the correct order of parameters defined in the documentation, ensuring clarity and consistency.

## Type of change
Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
No tests seem to be required
