### PR TITLE
Feature/gemini object detection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,14 +25,14 @@ repos:
       - id: mixed-line-ending
 
   -   repo: https://github.com/PyCQA/bandit
-      rev: '1.8.0'
+      rev: '1.8.3'
       hooks:
       -   id: bandit
           args: ["-c", "pyproject.toml"]
           additional_dependencies: ["bandit[toml]"]
 
   -   repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.8.6
+      rev: v0.9.6
       hooks:
       -   id: ruff
           args: [--fix, --exit-non-zero-on-fix]
@@ -48,7 +48,7 @@ repos:
   #       args: ["--number"]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:

--- a/supervision/detection/core.py
+++ b/supervision/detection/core.py
@@ -852,8 +852,8 @@ class Detections:
             import supervision as sv
             from PIL import Image
 
-            image = Image.open(<SOURCE_IMAGE_PATH>)
-            client = genai.Client(api_key=<API_KEY>)
+            IMAGE = Image.open(<SOURCE_IMAGE_PATH>)
+            GENAI_CLIENT = genai.Client(api_key=<API_KEY>)
 
             system_instructions = '''
                 Return bounding boxes as a JSON array with labels and ids. Never return masks or code fencing. Limit to 25 objects.
@@ -867,9 +867,9 @@ class Detections:
                 ),
             ]
 
-            response = client.models.generate_content(
+            response = GENAI_CLIENT.models.generate_content(
                 model="gemini-2.0-flash-exp",
-                contents=[prompt, im],
+                contents=[prompt, IMAGE],
                 config = types.GenerateContentConfig(
                     system_instruction=system_instructions,
                     temperature=0.5,
@@ -879,9 +879,8 @@ class Detections:
 
             detections = sv.Detections.from_lmm(
                 sv.LMM.GOOGLE_GEMINI_2_0,
-                response,
-                resolution_wh=(1000, 1000),
-                classes=['cat', 'dog'],
+                response.text,
+                resolution_wh=(IMAGE.size[0], IMAGE.size[1]),
             )
 
             detections.xyxy
@@ -890,7 +889,6 @@ class Detections:
             # array([0])
             detections.data
             # {'class_name': ['cat', 'dog']}
-
             ```
 
         """  # noqa: E501 // docs

--- a/supervision/detection/overlap_filter.py
+++ b/supervision/detection/overlap_filter.py
@@ -226,8 +226,7 @@ def box_non_max_merge(
     for merge_group in merge_groups:
         if len(merge_group) == 0:
             raise ValueError(
-                f"Empty group detected when non-max-merging "
-                f"detections: {merge_groups}"
+                f"Empty group detected when non-max-merging detections: {merge_groups}"
             )
     return merge_groups
 

--- a/supervision/metrics/mean_average_recall.py
+++ b/supervision/metrics/mean_average_recall.py
@@ -670,8 +670,7 @@ class MeanAverageRecallResult:
         ax.set_ylim(0, 1)
         ax.set_ylabel("Value", fontweight="bold")
         title = (
-            f"Mean Average Recall, by Object Size"
-            f"\n(target: {self.metric_target.value})"
+            f"Mean Average Recall, by Object Size\n(target: {self.metric_target.value})"
         )
         ax.set_title(title, fontweight="bold")
 

--- a/supervision/validators/__init__.py
+++ b/supervision/validators/__init__.py
@@ -54,7 +54,7 @@ def validate_confidence(confidence: Any, n: int) -> None:
 
 
 def validate_keypoint_confidence(confidence: Any, n: int, m: int) -> None:
-    expected_shape = f"({n,m})"
+    expected_shape = f"({n, m})"
     actual_shape = str(getattr(confidence, "shape", None))
 
     if confidence is not None:

--- a/test/detection/test_csv.py
+++ b/test/detection/test_csv.py
@@ -408,8 +408,8 @@ def assert_csv_equal(file_name, expected_rows):
     with open(file_name, mode="r", newline="") as file:
         reader = csv.reader(file)
         for i, row in enumerate(reader):
-            assert (
-                [str(item) for item in expected_rows[i]] == row
-            ), f"Row in CSV didn't match expected output: {row} != {expected_rows[i]}"
+            assert [str(item) for item in expected_rows[i]] == row, (
+                f"Row in CSV didn't match expected output: {row} != {expected_rows[i]}"
+            )
 
     os.remove(file_name)

--- a/test/detection/test_json.py
+++ b/test/detection/test_json.py
@@ -242,8 +242,8 @@ def test_json_sink(
 def assert_json_equal(file_name, expected_rows):
     with open(file_name, "r") as file:
         data = json.load(file)
-        assert (
-            data == expected_rows
-        ), f"Data in JSON file didn't match expected output: {data} != {expected_rows}"
+        assert data == expected_rows, (
+            f"Data in JSON file didn't match expected output: {data} != {expected_rows}"
+        )
 
     os.remove(file_name)

--- a/test/detection/test_line_counter.py
+++ b/test/detection/test_line_counter.py
@@ -250,12 +250,12 @@ def test_line_zone_one_detection_default_anchors(
         crossed_in_list.append(crossed_in[0])
         crossed_out_list.append(crossed_out[0])
 
-    assert (
-        crossed_in_list == expected_crossed_in
-    ), f"expected {expected_crossed_in}, got {crossed_in_list}"
-    assert (
-        crossed_out_list == expected_crossed_out
-    ), f"expected {expected_crossed_out}, got {crossed_out_list}"
+    assert crossed_in_list == expected_crossed_in, (
+        f"expected {expected_crossed_in}, got {crossed_in_list}"
+    )
+    assert crossed_out_list == expected_crossed_out, (
+        f"expected {expected_crossed_out}, got {crossed_out_list}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -415,12 +415,12 @@ def test_line_zone_one_detection(
         crossed_in_list.append(crossed_in[0])
         crossed_out_list.append(crossed_out[0])
 
-    assert (
-        crossed_in_list == expected_crossed_in
-    ), f"expected {expected_crossed_in}, got {crossed_in_list}"
-    assert (
-        crossed_out_list == expected_crossed_out
-    ), f"expected {expected_crossed_out}, got {crossed_out_list}"
+    assert crossed_in_list == expected_crossed_in, (
+        f"expected {expected_crossed_in}, got {crossed_in_list}"
+    )
+    assert crossed_out_list == expected_crossed_out, (
+        f"expected {expected_crossed_out}, got {crossed_out_list}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -600,12 +600,12 @@ def test_line_zone_one_detection_long_horizon(
         crossed_in_list.append(crossed_in[0])
         crossed_out_list.append(crossed_out[0])
 
-    assert (
-        crossed_in_list == expected_crossed_in
-    ), f"expected {expected_crossed_in}, got {crossed_in_list}"
-    assert (
-        crossed_out_list == expected_crossed_out
-    ), f"expected {expected_crossed_out}, got {crossed_out_list}"
+    assert crossed_in_list == expected_crossed_in, (
+        f"expected {expected_crossed_in}, got {crossed_in_list}"
+    )
+    assert crossed_out_list == expected_crossed_out, (
+        f"expected {expected_crossed_out}, got {crossed_out_list}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/detection/test_utils.py
+++ b/test/detection/test_utils.py
@@ -389,13 +389,13 @@ def test_process_roboflow_result(
         )
         for key in result[5]:
             if isinstance(result[5][key], np.ndarray):
-                assert np.array_equal(
-                    result[5][key], expected_result[5][key]
-                ), f"Mismatch in arrays for key {key}"
+                assert np.array_equal(result[5][key], expected_result[5][key]), (
+                    f"Mismatch in arrays for key {key}"
+                )
             else:
-                assert (
-                    result[5][key] == expected_result[5][key]
-                ), f"Mismatch in non-array data for key {key}"
+                assert result[5][key] == expected_result[5][key], (
+                    f"Mismatch in non-array data for key {key}"
+                )
 
 
 @pytest.mark.parametrize(
@@ -1042,13 +1042,13 @@ def test_merge_data(
 
         for key in result:
             if isinstance(result[key], np.ndarray):
-                assert np.array_equal(
-                    result[key], expected_result[key]
-                ), f"Mismatch in arrays for key {key}"
+                assert np.array_equal(result[key], expected_result[key]), (
+                    f"Mismatch in arrays for key {key}"
+                )
             else:
-                assert (
-                    result[key] == expected_result[key]
-                ), f"Mismatch in non-array data for key {key}"
+                assert result[key] == expected_result[key], (
+                    f"Mismatch in non-array data for key {key}"
+                )
 
 
 @pytest.mark.parametrize(
@@ -1215,13 +1215,13 @@ def test_get_data_item(
         result = get_data_item(data=data, index=index)
         for key in result:
             if isinstance(result[key], np.ndarray):
-                assert np.array_equal(
-                    result[key], expected_result[key]
-                ), f"Mismatch in arrays for key {key}"
+                assert np.array_equal(result[key], expected_result[key]), (
+                    f"Mismatch in arrays for key {key}"
+                )
             else:
-                assert (
-                    result[key] == expected_result[key]
-                ), f"Mismatch in non-array data for key {key}"
+                assert result[key] == expected_result[key], (
+                    f"Mismatch in non-array data for key {key}"
+                )
 
 
 @pytest.mark.parametrize(

--- a/test/detection/test_vlm.py
+++ b/test/detection/test_vlm.py
@@ -4,7 +4,11 @@ from typing import List, Optional, Tuple
 import numpy as np
 import pytest
 
-from supervision.detection.vlm import from_paligemma, from_qwen_2_5_vl
+from supervision.detection.vlm import (
+    from_google_gemini,
+    from_paligemma,
+    from_qwen_2_5_vl,
+)
 
 
 @pytest.mark.parametrize(
@@ -353,3 +357,22 @@ def test_from_qwen_2_5_vl(
             np.testing.assert_array_equal(xyxy, expected_results[0])
             np.testing.assert_array_equal(class_id, expected_results[1])
             np.testing.assert_array_equal(class_name, expected_results[2])
+
+
+def test_from_google_gemini() -> None:
+    result = """```json
+    [
+        {"box_2d": [10, 20, 110, 120], "label": "cat"},
+        {"box_2d": [50, 100, 150, 200], "label": "dog"}
+    ]
+    ```"""
+    resolution_wh = (640, 480)
+    xyxy, class_name = from_google_gemini(
+        result=result,
+        resolution_wh=resolution_wh,
+    )
+    np.testing.assert_array_equal(
+        xyxy,
+        np.array([[12.0, 4.0, 76.0, 52.0], [64.0, 24.0, 128.0, 72.0]]),
+    )
+    np.testing.assert_array_equal(class_name, np.array(["cat", "dog"]))

--- a/test/detection/tools/test_inference_slicer.py
+++ b/test/detection/tools/test_inference_slicer.py
@@ -180,6 +180,6 @@ def test_generate_offset(
     )
 
     # Verify that the generated offsets match the expected offsets
-    assert np.array_equal(
-        offsets, expected_offsets
-    ), f"Expected {expected_offsets}, got {offsets}"
+    assert np.array_equal(offsets, expected_offsets), (
+        f"Expected {expected_offsets}, got {offsets}"
+    )

--- a/test/utils/test_conversion.py
+++ b/test/utils/test_conversion.py
@@ -22,15 +22,15 @@ def test_ensure_cv2_image_for_processing_when_pillow_image_submitted(
         param_a: int,
         param_b: str,
     ) -> np.ndarray:
-        assert np.allclose(
-            image, empty_cv2_image
-        ), "Expected conversion to OpenCV image to happen"
-        assert (
-            param_a == param_a_value
-        ), f"Parameter a expected to be {param_a_value} in target function"
-        assert (
-            param_b == param_b_value
-        ), f"Parameter b expected to be {param_b_value} in target function"
+        assert np.allclose(image, empty_cv2_image), (
+            "Expected conversion to OpenCV image to happen"
+        )
+        assert param_a == param_a_value, (
+            f"Parameter a expected to be {param_a_value} in target function"
+        )
+        assert param_b == param_b_value, (
+            f"Parameter b expected to be {param_b_value} in target function"
+        )
         return image
 
     # when
@@ -61,15 +61,15 @@ def test_ensure_cv2_image_for_processing_when_cv2_image_submitted(
         param_a: int,
         param_b: str,
     ) -> np.ndarray:
-        assert np.allclose(
-            image, empty_cv2_image
-        ), "Expected conversion to OpenCV image to happen"
-        assert (
-            param_a == param_a_value
-        ), f"Parameter a expected to be {param_a_value} in target function"
-        assert (
-            param_b == param_b_value
-        ), f"Parameter b expected to be {param_b_value} in target function"
+        assert np.allclose(image, empty_cv2_image), (
+            "Expected conversion to OpenCV image to happen"
+        )
+        assert param_a == param_a_value, (
+            f"Parameter a expected to be {param_a_value} in target function"
+        )
+        assert param_b == param_b_value, (
+            f"Parameter b expected to be {param_b_value} in target function"
+        )
         return image
 
     # when
@@ -91,9 +91,9 @@ def test_cv2_to_pillow(
 
     # then
     difference = ImageChops.difference(result, empty_pillow_image)
-    assert (
-        difference.getbbox() is None
-    ), "Conversion to PIL.Image expected not to change the content of image"
+    assert difference.getbbox() is None, (
+        "Conversion to PIL.Image expected not to change the content of image"
+    )
 
 
 def test_pillow_to_cv2(
@@ -103,9 +103,9 @@ def test_pillow_to_cv2(
     result = pillow_to_cv2(image=empty_pillow_image)
 
     # then
-    assert np.allclose(
-        result, empty_cv2_image
-    ), "Conversion to OpenCV image expected not to change the content of image"
+    assert np.allclose(result, empty_cv2_image), (
+        "Conversion to OpenCV image expected not to change the content of image"
+    )
 
 
 def test_images_to_cv2_when_empty_input_provided() -> None:
@@ -128,9 +128,9 @@ def test_images_to_cv2_when_only_cv2_images_provided(
     # then
     assert len(result) == 5, "Expected the same number of output element as input ones"
     for result_element in result:
-        assert (
-            result_element is empty_cv2_image
-        ), "Expected CV images not to be touched by conversion"
+        assert result_element is empty_cv2_image, (
+            "Expected CV images not to be touched by conversion"
+        )
 
 
 def test_images_to_cv2_when_only_pillow_images_provided(
@@ -146,9 +146,9 @@ def test_images_to_cv2_when_only_pillow_images_provided(
     # then
     assert len(result) == 5, "Expected the same number of output element as input ones"
     for result_element in result:
-        assert np.allclose(
-            result_element, empty_cv2_image
-        ), "Output images expected to be equal to empty OpenCV image"
+        assert np.allclose(result_element, empty_cv2_image), (
+            "Output images expected to be equal to empty OpenCV image"
+        )
 
 
 def test_images_to_cv2_when_mixed_input_provided(
@@ -163,9 +163,9 @@ def test_images_to_cv2_when_mixed_input_provided(
 
     # then
     assert len(result) == 2, "Expected the same number of output element as input ones"
-    assert np.allclose(
-        result[0], empty_cv2_image
-    ), "PIL image should be converted to OpenCV one, equal to example empty image"
-    assert (
-        result[1] is empty_cv2_image
-    ), "Expected CV images not to be touched by conversion"
+    assert np.allclose(result[0], empty_cv2_image), (
+        "PIL image should be converted to OpenCV one, equal to example empty image"
+    )
+    assert result[1] is empty_cv2_image, (
+        "Expected CV images not to be touched by conversion"
+    )

--- a/test/utils/test_image.py
+++ b/test/utils/test_image.py
@@ -21,9 +21,9 @@ def test_resize_image_for_opencv_image() -> None:
     )
 
     # then
-    assert np.allclose(
-        result, expected_result
-    ), "Expected output shape to be (w, h): (1024, 768)"
+    assert np.allclose(result, expected_result), (
+        "Expected output shape to be (w, h): (1024, 768)"
+    )
 
 
 def test_resize_image_for_pillow_image() -> None:
@@ -41,9 +41,9 @@ def test_resize_image_for_pillow_image() -> None:
     # then
     assert result.size == (1024, 768), "Expected output shape to be (w, h): (1024, 768)"
     difference = ImageChops.difference(result, expected_result)
-    assert (
-        difference.getbbox() is None
-    ), "Expected no difference in resized image content as the image is all zeros"
+    assert difference.getbbox() is None, (
+        "Expected no difference in resized image content as the image is all zeros"
+    )
 
 
 def test_letterbox_image_for_opencv_image() -> None:
@@ -95,9 +95,9 @@ def test_letterbox_image_for_pillow_image() -> None:
         1024,
     ), "Expected output shape to be (w, h): (1024, 1024)"
     difference = ImageChops.difference(result, expected_result)
-    assert (
-        difference.getbbox() is None
-    ), "Expected padding to be added top and bottom with padding added top and bottom"
+    assert difference.getbbox() is None, (
+        "Expected padding to be added top and bottom with padding added top and bottom"
+    )
 
 
 def test_create_tiles_with_one_image(


### PR DESCRIPTION
## 🚀 from_vlm now has Google gemini 2D  spatial understanding support  for Detection class 🎯


[![Open in Colab](https://img.shields.io/badge/Open%20in-Colab-blue?logo=googlecolab)](https://colab.research.google.com/drive/1DVNI1T5i4JzzNokSTjj9RBKqWOUNvim5?usp=sharing)

## ✨ New Functionality:

* [`supervision/detection/core.py`](diffhunk://#diff-d620bf6569b39b0318ed01ac9fbd645b801ee1e237c188e3c50a7e3480f2ee25R40): Added support for `from_google_gemini` and included an example in the `from_lmm` method documentation. [[1]](diffhunk://#diff-d620bf6569b39b0318ed01ac9fbd645b801ee1e237c188e3c50a7e3480f2ee25R40) [[2]](diffhunk://#diff-d620bf6569b39b0318ed01ac9fbd645b801ee1e237c188e3c50a7e3480f2ee25L718-R719) [[3]](diffhunk://#diff-d620bf6569b39b0318ed01ac9fbd645b801ee1e237c188e3c50a7e3480f2ee25L846-R901) [[4]](diffhunk://#diff-d620bf6569b39b0318ed01ac9fbd645b801ee1e237c188e3c50a7e3480f2ee25R954-R958)
* [`supervision/detection/vlm.py`](diffhunk://#diff-c4a61ae6e74887622a7248a14d9bc5dcb301ec23e8920b70578e7105fa82df5dR20-R48): Added `GOOGLE_GEMINI_2_0` to `LMM` and `VLM` enums, and implemented the `from_google_gemini` function. [[1]](diffhunk://#diff-c4a61ae6e74887622a7248a14d9bc5dcb301ec23e8920b70578e7105fa82df5dR20-R48) [[2]](diffhunk://#diff-c4a61ae6e74887622a7248a14d9bc5dcb301ec23e8920b70578e7105fa82df5dL235-R242) [[3]](diffhunk://#diff-c4a61ae6e74887622a7248a14d9bc5dcb301ec23e8920b70578e7105fa82df5dL297-R314) [[4]](diffhunk://#diff-c4a61ae6e74887622a7248a14d9bc5dcb301ec23e8920b70578e7105fa82df5dR324-R387)

## 🔧 Pre-commit update


* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L28-R35): Updated `bandit` to `1.8.3`, `ruff-pre-commit` to `v0.9.6`, and `codespell` to `v2.4.1`. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L28-R35) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L51-R51)

Assertion formatting improvements:
* Various test files: Reformatted assertions for better readability and consistency. [[1]](diffhunk://#diff-2185113c87138ca76c082af73589d45a6d3be64a4967cebeb1d07516ba07281aL411-R413) [[2]](diffhunk://#diff-a50b39fd7f1df19264075af2e2d41dfcb520566b1ef01f5b664be9ee4bae743dL245-R247) [[3]](diffhunk://#diff-106334deba835d12e663ee7c0961c5eb4f4215a364e3a847af123ed95aa430faL253-R258) [[4]](diffhunk://#diff-0379a32ca37a7f402d04f932db914ea57a505705c31a01ea57d483524bc374e3L392-R398) [[5]](diffhunk://#diff-0379a32ca37a7f402d04f932db914ea57a505705c31a01ea57d483524bc374e3L1045-R1051) [[6]](diffhunk://#diff-0379a32ca37a7f402d04f932db914ea57a505705c31a01ea57d483524bc374e3L1218-R1224) [[7]](diffhunk://#diff-788347cdcfb7a14d2fcfbe29847050abab7f285bac72be83471f18e2515c12d4L183-R185)
