### PR TITLE
feat(supervision): Add frame limitations + progressbar for `sv.process_video`

### DIFF
--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -242,15 +242,15 @@ def process_video(
                 else source_video_info.total_frames
             )
         for index, frame in enumerate(
-                tqdm(
-                    video_frames_generator,
-                    total=total_frames,
-                    disable=not show_progress,
-                    desc=progress_message,
-                )
-            ):
-                result_frame = callback(frame, index)
-                sink.write_frame(frame=result_frame)
+            tqdm(
+                video_frames_generator,
+                total=total_frames,
+                disable=not show_progress,
+                desc=progress_message,
+            )
+        ):
+            result_frame = callback(frame, index)
+            sink.write_frame(frame=result_frame)
         else:
             for index, frame in enumerate(video_frames_generator):
                 result_frame = callback(frame, index)

--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -197,7 +197,7 @@ def process_video(
     target_path: str,
     callback: Callable[[np.ndarray, int], np.ndarray],
     max_frames: Optional[int] = None,
-    show_progress: bool = True,
+    show_progress: bool = False,
     progress_message: str = "Processing video",
 ) -> None:
     """

--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -234,14 +234,13 @@ def process_video(
         source_path=source_path, end=max_frames
     )
     with VideoSink(target_path=target_path, video_info=source_video_info) as sink:
-        video_frames_generator = get_video_frames_generator(
-            source_path=source_path, end=max_frames
-        )
-        total_frames = (
-            min(source_video_info.total_frames, max_frames)
-            if max_frames is not None
-            else source_video_info.total_frames
-        )
+        if show_progress:
+            # Calculate total_frames only when needed for tqdm
+            total_frames = (
+                min(source_video_info.total_frames, max_frames)
+                if max_frames is not None
+                else source_video_info.total_frames
+            )
         for index, frame in enumerate(
             tqdm(
                 video_frames_generator,

--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -242,15 +242,19 @@ def process_video(
                 else source_video_info.total_frames
             )
         for index, frame in enumerate(
-            tqdm(
-                video_frames_generator,
-                total=total_frames,
-                disable=not show_progress,
-                desc=progress_message,
-            )
-        ):
-            result_frame = callback(frame, index)
-            sink.write_frame(frame=result_frame)
+                tqdm(
+                    video_frames_generator,
+                    total=total_frames,
+                    disable=not show_progress,
+                    desc=progress_message,
+                )
+            ):
+                result_frame = callback(frame, index)
+                sink.write_frame(frame=result_frame)
+        else:
+            for index, frame in enumerate(video_frames_generator):
+                result_frame = callback(frame, index)
+                sink.write_frame(frame=result_frame)
 
 
 class FPSMonitor:

--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -7,6 +7,7 @@ from typing import Callable, Generator, Optional, Tuple
 
 import cv2
 import numpy as np
+from tqdm.auto import tqdm
 
 
 @dataclass
@@ -195,6 +196,9 @@ def process_video(
     source_path: str,
     target_path: str,
     callback: Callable[[np.ndarray, int], np.ndarray],
+    max_frames: Optional[int] = None,
+    show_progress: bool = True,
+    progress_message: str = "Processing video",
 ) -> None:
     """
     Process a video file by applying a callback function on each frame
@@ -207,6 +211,9 @@ def process_video(
             a numpy ndarray representation of a video frame and an
             int index of the frame and returns a processed numpy ndarray
             representation of the frame.
+        max_frames (Optional[int]): The maximum number of frames to process.
+        show_progress (bool): Whether to show a progress bar.
+        progress_message (str): The message to display in the progress bar.
 
     Examples:
         ```python
@@ -224,8 +231,21 @@ def process_video(
     """
     source_video_info = VideoInfo.from_video_path(video_path=source_path)
     with VideoSink(target_path=target_path, video_info=source_video_info) as sink:
+        video_frames_generator = get_video_frames_generator(
+            source_path=source_path, end=max_frames
+        )
+        total_frames = (
+            min(source_video_info.total_frames, max_frames)
+            if max_frames is not None
+            else source_video_info.total_frames
+        )
         for index, frame in enumerate(
-            get_video_frames_generator(source_path=source_path)
+            tqdm(
+                video_frames_generator,
+                total=total_frames,
+                disable=not show_progress,
+                desc=progress_message,
+            )
         ):
             result_frame = callback(frame, index)
             sink.write_frame(frame=result_frame)

--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -230,7 +230,7 @@ def process_video(
         ```
     """
     source_video_info = VideoInfo.from_video_path(video_path=source_path)
-    frame_generator = get_video_frames_generator(
+    video_frames_generator = get_video_frames_generator(
         source_path=source_path, end=max_frames
     )
     with VideoSink(target_path=target_path, video_info=source_video_info) as sink:

--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -230,6 +230,9 @@ def process_video(
         ```
     """
     source_video_info = VideoInfo.from_video_path(video_path=source_path)
+    frame_generator = get_video_frames_generator(
+        source_path=source_path, end=max_frames
+    )
     with VideoSink(target_path=target_path, video_info=source_video_info) as sink:
         video_frames_generator = get_video_frames_generator(
             source_path=source_path, end=max_frames


### PR DESCRIPTION
# Description

This PR adds 2 quality-of-life updates for `sv.process_video`:

1. A parameter called `max_frames` that can be used to limit the maximum number of frames to process in a video.
2. A parameter called `show_progress` that when `True`, shows a progress bar during the video processing loop. Another parameter called `progress_message` can be used to set the message displayed on the progress bar.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

The PR can be tested with the following code snippet:

```python
import numpy as np
import supervision as sv
from ultralytics import YOLO
from supervision.assets import download_assets, VideoAssets

download_assets(VideoAssets.PEOPLE_WALKING)
model = YOLO("yolov8n.pt")
box_annotator = sv.BoxAnnotator()

def callback(frame: np.ndarray, _: int) -> np.ndarray:
    results = model(frame,verbose=False)[0]
    detections = sv.Detections.from_ultralytics(results)
    return box_annotator.annotate(frame.copy(), detections=detections)

sv.process_video(
    source_path="people-walking.mp4",
    target_path="result.mp4",
    callback=callback,
    max_frames=100,
    show_progress=True,
)
```

## Docs

-   [x] Docs updated? What were the changes: Docstring of the function `sv.process_video` was updated with the descriptions of the new parameters.
