### PR TITLE
feat(annotators): enhance label annotators with frame boundary adjust…

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -139,10 +139,10 @@ class _BaseLabelAnnotator(BaseAnnotator):
             # Update the properties with the spread out boxes
             adjusted_properties[:, :4] = spread_boxes
 
-            # Additional check to ensure boxes are still within frame after spreading
-            adjusted_properties[:, :4] = snap_boxes(
-                adjusted_properties[:, :4], resolution_wh
-            )
+        # Additional check to ensure boxes are still within frame after spreading
+        adjusted_properties[:, :4] = snap_boxes(
+            adjusted_properties[:, :4], resolution_wh
+        )
 
         return adjusted_properties
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1397,7 +1397,7 @@ class RichLabelAnnotator(_BaseLabelAnnotator):
     @ensure_pil_image_for_annotation
     def annotate(
         self,
-        scene: Image.Image,
+        scene: ImageType
         detections: Detections,
         labels: Optional[List[str]] = None,
         custom_color_lookup: Optional[np.ndarray] = None,

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1110,9 +1110,7 @@ class LabelAnnotator(_BaseLabelAnnotator):
         validate_labels(labels, detections)
 
         labels = get_labels_text(detections, labels)
-        label_properties = self._get_label_properties(
-            detections, labels
-        )
+        label_properties = self._get_label_properties(detections, labels)
 
         if self.smart_position:
             xyxy = label_properties[:, :4]
@@ -1176,10 +1174,12 @@ class LabelAnnotator(_BaseLabelAnnotator):
                 position=self.text_anchor,
             )
 
-            label_properties.append([
-                *text_background_xyxy,
-                total_height,
-            ])
+            label_properties.append(
+                [
+                    *text_background_xyxy,
+                    total_height,
+                ]
+            )
         return np.array(label_properties).reshape(-1, 5)
 
     def _draw_labels(

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -326,9 +326,9 @@ class _BaseLabelAnnotator(BaseAnnotator):
             wrapped = textwrap.wrap(
                 paragraph,
                 width=self.max_line_length,
-                break_long_words=True,  # Break words longer than max_line_length
-                replace_whitespace=False,  # Preserve existing spaces
-                drop_whitespace=True,  # Drop leading/trailing whitespace on wrapped lines
+                break_long_words=True,
+                replace_whitespace=False,
+                drop_whitespace=True,
             )
 
             # Add the wrapped lines for this paragraph
@@ -1375,12 +1375,10 @@ class LabelAnnotator(_BaseLabelAnnotator):
                 position=self.text_anchor,
             )
 
-            label_properties.append(
-                [
-                    *text_background_xyxy,
-                    total_height,
-                ]
-            )
+            label_properties.append([
+                *text_background_xyxy,
+                total_height,
+            ])
         return np.array(label_properties).reshape(-1, 5)
 
     def _draw_labels(
@@ -1431,9 +1429,10 @@ class LabelAnnotator(_BaseLabelAnnotator):
             current_y = box_xyxy[1] + self.text_padding  # Start y position
 
             for line in wrapped_lines:
-                if not line:  # Skip empty lines
+                if not line:
+                    # Use a character with ascenders and descenders as height reference
                     (_, text_h) = cv2.getTextSize(
-                        text="Tg",  # Use a character with ascenders and descenders as height reference
+                        text="Tg",
                         fontFace=CV2_FONT,
                         fontScale=self.text_scale,
                         thickness=self.text_thickness,

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1375,10 +1375,12 @@ class LabelAnnotator(_BaseLabelAnnotator):
                 position=self.text_anchor,
             )
 
-            label_properties.append([
-                *text_background_xyxy,
-                total_height,
-            ])
+            label_properties.append(
+                [
+                    *text_background_xyxy,
+                    total_height,
+                ]
+            )
         return np.array(label_properties).reshape(-1, 5)
 
     def _draw_labels(
@@ -1702,7 +1704,6 @@ class RichLabelAnnotator(_BaseLabelAnnotator):
         except OSError:
             print(f"Font path '{font_path}' not found. Using PIL's default font.")
             return load_default_font(font_size)
-
 
 
 class IconAnnotator(BaseAnnotator):

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1375,10 +1375,12 @@ class LabelAnnotator(_BaseLabelAnnotator):
                 position=self.text_anchor,
             )
 
-            label_properties.append([
-                *text_background_xyxy,
-                total_height,
-            ])
+            label_properties.append(
+                [
+                    *text_background_xyxy,
+                    total_height,
+                ]
+            )
         return np.array(label_properties).reshape(-1, 5)
 
     def _draw_labels(

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1187,7 +1187,7 @@ class LabelAnnotator(_BaseLabelAnnotator):
     @ensure_cv2_image_for_annotation
     def annotate(
         self,
-        scene: np.ndarray,  # Ensure scene is initially a NumPy array here
+        scene: ImageType,  # Ensure scene is initially a NumPy array here
         detections: Detections,
         labels: Optional[List[str]] = None,
         custom_color_lookup: Optional[np.ndarray] = None,

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1254,10 +1254,12 @@ class LabelAnnotator(_BaseLabelAnnotator):
                 position=self.text_anchor,
             )
 
-            label_properties.append([
-                *text_background_xyxy,
-                text_h,
-            ])
+            label_properties.append(
+                [
+                    *text_background_xyxy,
+                    text_h,
+                ]
+            )
         return np.array(label_properties).reshape(-1, 5)
 
     def _draw_labels(

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1397,7 +1397,7 @@ class RichLabelAnnotator(_BaseLabelAnnotator):
     @ensure_pil_image_for_annotation
     def annotate(
         self,
-        scene: ImageType
+        scene: ImageType,
         detections: Detections,
         labels: Optional[List[str]] = None,
         custom_color_lookup: Optional[np.ndarray] = None,

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -139,10 +139,10 @@ class _BaseLabelAnnotator(BaseAnnotator):
             # Update the properties with the spread out boxes
             adjusted_properties[:, :4] = spread_boxes
 
-        # Additional check to ensure boxes are still within frame after spreading
-        adjusted_properties[:, :4] = snap_boxes(
-            adjusted_properties[:, :4], resolution_wh
-        )
+            # Additional check to ensure boxes are still within frame after spreading
+            adjusted_properties[:, :4] = snap_boxes(
+                adjusted_properties[:, :4], resolution_wh
+            )
 
         return adjusted_properties
 

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -1401,7 +1401,7 @@ class RichLabelAnnotator(_BaseLabelAnnotator):
         detections: Detections,
         labels: Optional[List[str]] = None,
         custom_color_lookup: Optional[np.ndarray] = None,
-    ) -> Image.Image:
+    ) -> ImageType:
         assert isinstance(scene, Image.Image)
         self._validate_labels(labels, detections)
 

--- a/supervision/annotators/utils.py
+++ b/supervision/annotators/utils.py
@@ -1,8 +1,10 @@
+import textwrap
 from enum import Enum
 from typing import Optional, Tuple, Union
 
 import numpy as np
 
+from supervision.config import CLASS_NAME_DATA_FIELD
 from supervision.detection.core import Detections
 from supervision.draw.color import Color, ColorPalette
 from supervision.geometry.core import Position
@@ -139,6 +141,178 @@ def resolve_color(
     return get_color_by_index(color=color, idx=idx)
 
 
+def wrap_text(text: str, max_line_length=None) -> list[str]:
+    """
+    Wraps text to the specified maximum line length, respecting existing newlines.
+    Uses the textwrap library for robust text wrapping.
+
+    Args:
+        text (str): The text to wrap.
+
+    Returns:
+        List[str]: A list of text lines after wrapping.
+    """
+
+    if not text:
+        return [""]
+
+    if max_line_length is None:
+        return text.splitlines() or [""]
+
+    paragraphs = text.split("\n")
+    all_lines = []
+
+    for paragraph in paragraphs:
+        if not paragraph:
+            # Keep empty lines
+            all_lines.append("")
+            continue
+
+        wrapped = textwrap.wrap(
+            paragraph,
+            width=max_line_length,
+            break_long_words=True,
+            replace_whitespace=False,
+            drop_whitespace=True,
+        )
+
+        if wrapped:
+            all_lines.extend(wrapped)
+        else:
+            all_lines.append("")
+
+    return all_lines if all_lines else [""]
+
+
+def validate_labels(labels: Optional[list[str]], detections: Detections):
+    """
+    Validates that the number of provided labels matches the number of detections.
+
+    Args:
+        labels (Optional[List[str]]): A list of labels, one for each detection. Can
+                                        be None.
+        detections (Detections): The detections to be labeled.
+
+    Raises:
+        ValueError: If `labels` is not None and its length does not match the number
+        of detections.
+    """
+    if labels is not None and len(labels) != len(detections):
+        raise ValueError(
+            f"The number of labels ({len(labels)}) does not match the "
+            f"number of detections ({len(detections)}). Each detection "
+            f"should have exactly 1 label."
+        )
+
+
+def get_labels_text(
+    detections: Detections, custom_labels: Optional[list[str]]
+) -> list[str]:
+    """
+    Retrieves the text labels for the detections.
+
+    If `custom_labels` are provided, they are used. Otherwise, the labels are
+    extracted from the `detections` object, prioritizing the 'class_name' field,
+    then the `class_id`, and finally using the detection index as a string.
+
+    Args:
+        detections (Detections): The detections to get labels for.
+        custom_labels (Optional[List[str]]): An optional list of custom labels.
+
+    Returns:
+        List[str]: A list of text labels for each detection.
+    """
+    if custom_labels is not None:
+        return custom_labels
+
+    labels = []
+    for idx in range(len(detections)):
+        if CLASS_NAME_DATA_FIELD in detections.data:
+            labels.append(detections.data[CLASS_NAME_DATA_FIELD][idx])
+        elif detections.class_id is not None:
+            labels.append(str(detections.class_id[idx]))
+        else:
+            labels.append(str(idx))
+    return labels
+
+
+def snap_boxes(xyxy: np.ndarray, resolution_wh: Tuple[int, int]) -> np.ndarray:
+    """
+    Shifts bounding boxes into the frame so that they are fully contained
+    within the given resolution, prioritizing the top/left edge.
+    Unlike `clip_boxes`, this function does not crop boxes.
+    It moves them entirely if they exceed the frame boundaries.
+
+    Args:
+        xyxy (np.ndarray): A numpy array of shape `(N, 4)` where each
+            row corresponds to a bounding box in the format
+            `(x_min, y_min, x_max, y_max)`.
+        resolution_wh (Tuple[int, int]): A tuple `(width, height)`
+            representing the resolution of the frame.
+
+    Returns:
+        np.ndarray: A numpy array of shape `(N, 4)` with boxes shifted into frame.
+
+    Examples:
+        ```python
+        import numpy as np
+        # Assuming this function is part of a library like supervision (sv)
+        # import supervision as sv # or just use the function directly
+
+        xyxy = np.array([
+            [-10, 10, 30, 50], # Off left
+            [310, 200, 350, 250], # Off right
+            [100, -20, 150, 30], # Off top
+            [200, 220, 250, 270], # Off bottom
+            [-20, 10, 350, 50], # Wider than frame, (width = 370 vs 320)
+            [10, -20, 30, 260]  # Taller than frame, (height = 280 vs 240)
+        ])
+
+        resolution_wh = (320, 240)
+
+        # Expected output for the new cases:
+        # [-20, 10, 350, 50] (wider) -> shifted right by -(-20) = 20 -> [0, 10, 370, 50]
+        # [10, -20, 30, 260] (taller) -> shifted down by -(-20) = 20 -> [10, 0, 30, 280]
+        # Note: Oversized boxes still won't be fully contained without cropping
+        # but this logic ensures the primary (top/left) boundary is corrected.
+
+        snapped_boxes = snap_boxes(xyxy=xyxy, resolution_wh=resolution_wh)
+        print(snapped_boxes)
+        # Expected output (including original examples and new ones):
+        # [[  0  10  40  50] # Original example 1 snapped
+        #  [280 200 320 250] # Original example 2 snapped
+        #  [100   0 150  50] # Original example 3 snapped
+        #  [200 190 250 240] # Original example 4 snapped
+        #  [  0  10 370  50] # New example (wider) snapped by left edge priority
+        #  [ 10   0  30 280]] # New example (taller) snapped by top edge priority
+        ```
+    """
+    result = np.copy(xyxy)
+    width, height = resolution_wh
+
+    shift_if_left_out = -result[:, 0]
+    shift_if_right_out = width - result[:, 2]
+
+    shift_x = np.where(result[:, 0] < 0, shift_if_left_out,
+                       np.where(result[:, 2] > width, shift_if_right_out, 0))
+
+    result[:, 0] += shift_x
+    result[:, 2] += shift_x
+
+
+    shift_if_top_out = -result[:, 1]
+    shift_if_bottom_out = height - result[:, 3]
+
+    shift_y = np.where(result[:, 1] < 0, shift_if_top_out,
+                       np.where(result[:, 3] > height, shift_if_bottom_out, 0))
+
+
+    result[:, 1] += shift_y
+    result[:, 3] += shift_y
+
+    return result
+
+
 class Trace:
     def __init__(
         self,
@@ -157,9 +331,10 @@ class Trace:
     def put(self, detections: Detections) -> None:
         frame_id = np.full(len(detections), self.current_frame_id, dtype=int)
         self.frame_id = np.concatenate([self.frame_id, frame_id])
-        self.xy = np.concatenate(
-            [self.xy, detections.get_anchors_coordinates(self.anchor)]
-        )
+        self.xy = np.concatenate([
+            self.xy,
+            detections.get_anchors_coordinates(self.anchor),
+        ])
         self.tracker_id = np.concatenate([self.tracker_id, detections.tracker_id])
 
         unique_frame_id = np.unique(self.frame_id)

--- a/supervision/annotators/utils.py
+++ b/supervision/annotators/utils.py
@@ -293,19 +293,23 @@ def snap_boxes(xyxy: np.ndarray, resolution_wh: Tuple[int, int]) -> np.ndarray:
     shift_if_left_out = -result[:, 0]
     shift_if_right_out = width - result[:, 2]
 
-    shift_x = np.where(result[:, 0] < 0, shift_if_left_out,
-                       np.where(result[:, 2] > width, shift_if_right_out, 0))
+    shift_x = np.where(
+        result[:, 0] < 0,
+        shift_if_left_out,
+        np.where(result[:, 2] > width, shift_if_right_out, 0),
+    )
 
     result[:, 0] += shift_x
     result[:, 2] += shift_x
 
-
     shift_if_top_out = -result[:, 1]
     shift_if_bottom_out = height - result[:, 3]
 
-    shift_y = np.where(result[:, 1] < 0, shift_if_top_out,
-                       np.where(result[:, 3] > height, shift_if_bottom_out, 0))
-
+    shift_y = np.where(
+        result[:, 1] < 0,
+        shift_if_top_out,
+        np.where(result[:, 3] > height, shift_if_bottom_out, 0),
+    )
 
     result[:, 1] += shift_y
     result[:, 3] += shift_y
@@ -331,10 +335,12 @@ class Trace:
     def put(self, detections: Detections) -> None:
         frame_id = np.full(len(detections), self.current_frame_id, dtype=int)
         self.frame_id = np.concatenate([self.frame_id, frame_id])
-        self.xy = np.concatenate([
-            self.xy,
-            detections.get_anchors_coordinates(self.anchor),
-        ])
+        self.xy = np.concatenate(
+            [
+                self.xy,
+                detections.get_anchors_coordinates(self.anchor),
+            ]
+        )
         self.tracker_id = np.concatenate([self.tracker_id, detections.tracker_id])
 
         unique_frame_id = np.unique(self.frame_id)

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -1214,10 +1214,12 @@ def cross_product(anchors: np.ndarray, vector: Vector) -> np.ndarray:
     Returns:
         Array of cross products of shape (number of anchors, detections)
     """
-    vector_at_zero = np.array([
-        vector.end.x - vector.start.x,
-        vector.end.y - vector.start.y,
-    ])
+    vector_at_zero = np.array(
+        [
+            vector.end.x - vector.start.x,
+            vector.end.y - vector.start.y,
+        ]
+    )
     vector_start = np.array([vector.start.x, vector.start.y])
     return np.cross(vector_at_zero, anchors - vector_start)
 

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -1214,9 +1214,10 @@ def cross_product(anchors: np.ndarray, vector: Vector) -> np.ndarray:
     Returns:
         Array of cross products of shape (number of anchors, detections)
     """
-    vector_at_zero = np.array(
-        [vector.end.x - vector.start.x, vector.end.y - vector.start.y]
-    )
+    vector_at_zero = np.array([
+        vector.end.x - vector.start.x,
+        vector.end.y - vector.start.y,
+    ])
     vector_start = np.array([vector.start.x, vector.start.y])
     return np.cross(vector_at_zero, anchors - vector_start)
 
@@ -1224,6 +1225,8 @@ def cross_product(anchors: np.ndarray, vector: Vector) -> np.ndarray:
 def spread_out_boxes(
     xyxy: np.ndarray,
     max_iterations: int = 100,
+    force_scale: float = 10.0,
+    consider_size: bool = True,
 ) -> np.ndarray:
     """
     Spread out boxes that overlap with each other.
@@ -1231,29 +1234,50 @@ def spread_out_boxes(
     Args:
         xyxy: Numpy array of shape (N, 4) where N is the number of boxes.
         max_iterations: Maximum number of iterations to run the algorithm for.
+        force_scale: Scale factor for the repulsion forces.
+        consider_size: Whether to consider box size when calculating forces.
     """
     if len(xyxy) == 0:
         return xyxy
 
     xyxy_padded = pad_boxes(xyxy, px=1)
+
+    # Calculate box areas if we're considering size
+    if consider_size:
+        box_areas = (xyxy_padded[:, 2] - xyxy_padded[:, 0]) * (
+            xyxy_padded[:, 3] - xyxy_padded[:, 1]
+        )
+        # Calculate the size factors (normalize by mean size)
+        size_factors = (
+            np.sqrt(box_areas) / np.mean(np.sqrt(box_areas))
+            if len(box_areas) > 0
+            else np.ones(len(xyxy_padded))
+        )
+        size_factors = np.clip(size_factors, 0.5, 2.0)  # Clip to avoid extreme values
+    else:
+        size_factors = np.ones(len(xyxy_padded))
+
     for _ in range(max_iterations):
-        # NxN
+        # NxN matrix of IoU values
         iou = box_iou_batch(xyxy_padded, xyxy_padded)
-        np.fill_diagonal(iou, 0)
+        np.fill_diagonal(iou, 0)  # Eliminate self-interactions
+
         if np.all(iou == 0):
-            break
+            break  # No more overlaps
 
         overlap_mask = iou > 0
 
-        # Nx2
+        # Nx2 array of box centers
         centers = (xyxy_padded[:, :2] + xyxy_padded[:, 2:]) / 2
 
-        # NxNx2
+        # NxNx2 array of differences between centers
         delta_centers = centers[:, np.newaxis, :] - centers[np.newaxis, :, :]
         delta_centers *= overlap_mask[:, :, np.newaxis]
 
-        # Nx2
+        # Nx2 array of total delta vectors
         delta_sum = np.sum(delta_centers, axis=1)
+
+        # Normalize to unit vectors
         delta_magnitude = np.linalg.norm(delta_sum, axis=1, keepdims=True)
         direction_vectors = np.divide(
             delta_sum,
@@ -1262,15 +1286,32 @@ def spread_out_boxes(
             where=delta_magnitude != 0,
         )
 
+        # Calculate force based on IoU values
         force_vectors = np.sum(iou, axis=1)
         force_vectors = force_vectors[:, np.newaxis] * direction_vectors
 
-        force_vectors *= 10
-        force_vectors[(force_vectors > 0) & (force_vectors < 2)] = 2
-        force_vectors[(force_vectors < 0) & (force_vectors > -2)] = -2
+        # Apply size-based scaling if enabled
+        if consider_size:
+            force_vectors *= size_factors[:, np.newaxis]
 
+        # Scale forces
+        force_vectors *= force_scale
+
+        # Ensure minimum force for small overlaps
+        force_magnitudes = np.linalg.norm(force_vectors, axis=1, keepdims=True)
+        small_force_mask = (force_magnitudes > 0) & (force_magnitudes < 2)
+        if np.any(small_force_mask):
+            force_directions = force_vectors / np.where(
+                force_magnitudes > 0, force_magnitudes, 1
+            )
+            force_vectors = np.where(
+                small_force_mask, force_directions * 2, force_vectors
+            )
+
+        # Convert to integer displacements
         force_vectors = force_vectors.astype(int)
 
+        # Apply forces to update box positions
         xyxy_padded[:, [0, 1]] += force_vectors
         xyxy_padded[:, [2, 3]] += force_vectors
 

--- a/supervision/detection/utils.py
+++ b/supervision/detection/utils.py
@@ -1264,10 +1264,12 @@ def cross_product(anchors: np.ndarray, vector: Vector) -> np.ndarray:
     Returns:
         Array of cross products of shape (number of anchors, detections)
     """
-    vector_at_zero = np.array([
-        vector.end.x - vector.start.x,
-        vector.end.y - vector.start.y,
-    ])
+    vector_at_zero = np.array(
+        [
+            vector.end.x - vector.start.x,
+            vector.end.y - vector.start.y,
+        ]
+    )
     vector_start = np.array([vector.start.x, vector.start.y])
     return np.cross(vector_at_zero, anchors - vector_start)
 


### PR DESCRIPTION
# 🚀 Enhance label annotators with frame boundary adjustments and new base class

## Description

This PR adds the ability to ensure labels stay within frame boundaries through a new `ensure_in_frame` parameter. When enabled, this functionality guarantees that text labels for bounding boxes near image edges remain visible by adjusting their position to fit within the frame.

The key improvements include:
- ✅ Text labels near edges now properly positioned within frame boundaries
- ✅ Implemented as an optional parameter (default: `False` to maintain backward compatibility)
- ✅ Works alongside existing `smart_position` functionality with complementary behavior

*While there may be occasional label overlaps in very busy frames when both `smart_position` and `ensure_in_frame` are enabled, running the smart positioning algorithm first typically yields better results overall.*

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How has this change been tested?

I tested this change with various image scenarios that have bounding boxes positioned near frame edges. The implementation was verified by:

1. Comparing output images with and without the `ensure_in_frame` parameter enabled
2. Testing cases with multiple objects near edges to ensure proper positioning
3. Validating behavior when used in combination with `smart_position`

Example test code:
```python
import cv2
import numpy as np
import supervision as sv
from supervision.annotators.core import LabelAnnotator, BoxAnnotator
from PIL import Image, ImageDraw
import os
from typing import Optional, Tuple, List


def generate_mock_yolo_output(image_shape: Tuple[int, int, int]) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
    """
    Generates mock bounding box detections, confidence scores, and class predictions
    for a given image shape.  The function creates a set of detections, including
    one that covers the whole image.

    Args:
        image_shape (Tuple[int, int, int]): The shape of the image (height, width, channels).
            This is used to determine the boundaries for the generated bounding boxes.

    Returns:
        Tuple[np.ndarray, np.ndarray, np.ndarray]: A tuple containing:
            - A NumPy array of bounding boxes (N, 4), where N is the number of detections.
              Each box is defined as [xmin, ymin, xmax, ymax].
            - A NumPy array of confidence scores (N,).
            - A NumPy array of class labels (N,).
    """
    image_height, image_width, _ = image_shape
    num_detections = 100
    
    # Generate random bounding boxes
    xmin = np.random.randint(0, image_width, num_detections)
    ymin = np.random.randint(0, image_height, num_detections)
    xmax = np.random.randint(xmin + 20, image_width + 50, num_detections)
    ymax = np.random.randint(ymin + 20, image_height + 50, num_detections)
    bounding_boxes = np.stack([xmin, ymin, xmax, ymax], axis=1).astype(np.float32)

    # Add a box that covers the whole image
    full_image_box = np.array([0, 0, image_width, image_height], dtype=np.float32).reshape(1, 4)
    bounding_boxes = np.concatenate([bounding_boxes, full_image_box], axis=0)
    num_detections += 1

    # Generate random confidence scores
    confidence_scores = np.random.uniform(0.5, 0.95, num_detections).astype(np.float32)
    confidence_scores[-1] = 0.99  # High confidence for the full image box

    # Generate random class labels
    class_labels = np.random.randint(0, 2, num_detections).astype(np.int32)
    class_labels[-1] = 0  # Assign a class to the full image box

    return bounding_boxes, confidence_scores, class_labels



def process_image_with_supervision(
    image: np.ndarray,
    display_image: bool = True,
    text_position: sv.Position = sv.Position.TOP_LEFT,
    smart_position: bool = False,
    detections: Optional[sv.Detections] = None,
) -> None:
    """
    Processes an image by simulating YOLO detection and using Supervision to annotate it.
    The function generates two annotated images (with and without `ensure_in_frame`)
    and stacks them vertically, adding headers and white boundaries for clarity.

    Args:
        image (np.ndarray): The input image as a NumPy array in BGR format.
        display_image (bool, optional): Flag to control whether to display the image.
            If True, it attempts to display the image. If False, it saves the
            image to a file. Defaults to True.
        text_position (sv.Position, optional): The position of the text label
            relative to the bounding box.  Defaults to sv.Position.TOP_LEFT.
        smart_position (bool, optional): Flag to enable smart position adjustment of labels
            to keep them within the image frame. Defaults to False.
        detections (sv.Detections, optional): Pre-calculated detections.
            If provided, the function uses these detections instead of generating new ones.
            Defaults to None.

    Returns:
        None (displays or saves the stacked annotated image).
    """
    # 1. Simulate YOLO model output or use provided
    if detections is None:
        bounding_boxes, confidence_scores, class_labels = generate_mock_yolo_output(image.shape)
        detections = sv.Detections(
            xyxy=bounding_boxes,
            confidence=confidence_scores,
            class_id=class_labels,
        )

    # 2. Create annotators
    box_annotator = BoxAnnotator(thickness=2)
    class_names = ["car", "person"]

    label_annotator_in_frame = LabelAnnotator(
        text_scale=0.5,
        text_thickness=1,
        text_padding=5,
        ensure_in_frame=True,
        text_position=text_position,
        smart_position=smart_position,
    )
    label_annotator_out_of_frame = LabelAnnotator(
        text_scale=0.5,
        text_thickness=1,
        text_padding=5,
        ensure_in_frame=False,
        text_position=text_position,
        smart_position=smart_position,
    )

    # 4. Annotate the image with the detections using both annotators.
    annotated_image_in_frame = box_annotator.annotate(image.copy(), detections=detections)
    labels_in_frame = [
        f"{class_names[int(class_id)]} {confidence:.2f}"  # Corrected f-string
        for _, _, confidence, class_id, *_ in detections
    ]
    annotated_image_in_frame = label_annotator_in_frame.annotate(
        annotated_image_in_frame, detections=detections, labels=labels_in_frame
    )

    annotated_image_out_of_frame = box_annotator.annotate(image.copy(), detections=detections)
    labels_out_of_frame = [
        f"{class_names[int(class_id)]} {confidence:.2f}"  # Corrected f-string
        for _, _, confidence, class_id, *_ in detections
    ]
    annotated_image_out_of_frame = label_annotator_out_of_frame.annotate(
        annotated_image_out_of_frame, detections=detections, labels=labels_out_of_frame
    )

    # 5. Add white boundaries around the images
    border_width = 3
    annotated_image_in_frame = cv2.copyMakeBorder(
        annotated_image_in_frame,
        border_width,
        border_width,
        border_width,
        border_width,
        cv2.BORDER_CONSTANT,
        value=(255, 255, 255),
    )
    annotated_image_out_of_frame = cv2.copyMakeBorder(
        annotated_image_out_of_frame,
        border_width,
        border_width,
        border_width,
        border_width,
        cv2.BORDER_CONSTANT,
        value=(255, 255, 255),
    )

    # 6. Add headers to each image
    header_height = 30
    header_color = (255, 255, 255)
    text_color = (0, 0, 0)
    font = cv2.FONT_HERSHEY_SIMPLEX
    font_scale = 0.7
    font_thickness = 2

    # Create header images for each annotated image
    header_image_in_frame = np.zeros(
        (header_height, annotated_image_in_frame.shape[1], 3), dtype=np.uint8
    )
    header_image_in_frame[:] = header_color
    text_size_in_frame = cv2.getTextSize("Enabled", font, font_scale, font_thickness)[0]
    text_x_in_frame = annotated_image_in_frame.shape[1] - text_size_in_frame[0] - 10
    text_y_in_frame = (header_height + text_size_in_frame[1]) // 2
    cv2.putText(
        header_image_in_frame,
        "Enabled",
        (text_x_in_frame, text_y_in_frame),
        font,
        font_scale,
        text_color,
        font_thickness,
        cv2.LINE_AA,
    )

    header_image_out_of_frame = np.zeros(
        (header_height, annotated_image_out_of_frame.shape[1], 3), dtype=np.uint8
    )
    header_image_out_of_frame[:] = header_color
    text_size_out_of_frame = cv2.getTextSize("Not Enabled", font, font_scale, font_thickness)[0]
    text_x_out_of_frame = (header_image_out_of_frame.shape[1] - text_size_out_of_frame[0]) // 2
    text_y_out_of_frame = (header_height + text_size_out_of_frame[1]) // 2
    cv2.putText(
        header_image_out_of_frame,
        "Not Enabled",
        (text_x_out_of_frame, text_y_out_of_frame),
        font,
        font_scale,
        text_color,
        font_thickness,
        cv2.LINE_AA,
    )

    # Stack the headers and the images
    annotated_image_in_frame_with_header = np.vstack(
        (header_image_in_frame, annotated_image_in_frame)
    )
    annotated_image_out_of_frame_with_header = np.vstack(
        (header_image_out_of_frame, annotated_image_out_of_frame)
    )

    # 7. Stack the two images vertically
    stacked_image = np.vstack(
        (annotated_image_in_frame_with_header, annotated_image_out_of_frame_with_header)
    )

    # Add position text to the top-left corner
    cv2.putText(
        stacked_image,
        str(text_position) + f", smart_pos={smart_position}",
        (10, 20),
        cv2.FONT_HERSHEY_SIMPLEX,
        0.7,
        (0, 0, 0),
        2,
        cv2.LINE_AA,
    )

    # 8. Display the annotated image.
    if display_image:
        try:
            pil_image = Image.fromarray(cv2.cvtColor(stacked_image, cv2.COLOR_BGR2RGB))
            pil_image.show()
            pil_image.close()
        except OSError as e:
            print(f"Error displaying image: {e}. Saving image instead.")
            cv2.imwrite(f"annotated_image_{text_position}_smart_{smart_position}.jpg", stacked_image)
    else:
        cv2.imwrite(f"annotated_image_{text_position}_smart_{smart_position}.jpg", stacked_image)
        print(f"Annotated image saved to annotated_image_{text_position}_smart_{smart_position}.jpg")



def main(image_path: str = "example.jpg") -> None:
    """
    Main function to run the image processing and annotation with different label positions
    and smart position settings.

    Args:
        image_path (str, optional): Path to the image file. Defaults to "example.jpg".
    """
    # Create a dummy image
    image = np.zeros((600, 800, 3), dtype=np.uint8)
    cv2.imwrite(image_path, image)

    # 1. Generate Detections once - Moved inside process_image_with_supervision
    # mock_bounding_boxes, mock_confidence_scores, mock_class_labels = generate_mock_yolo_output(image.shape)
    # detections = sv.Detections(
    #      xyxy=mock_bounding_boxes,
    #      confidence=confidence_scores,
    #      class_id=mock_class_labels,
    # )

    # 2. Loop through positions with smart_position=False
    positions = [
        sv.Position.TOP_LEFT,
        sv.Position.CENTER_LEFT,
        sv.Position.BOTTOM_RIGHT,
        sv.Position.CENTER_RIGHT,
    ]
    for position in positions:
        print(f"Processing image with text position: {position}, smart_position=False")
        process_image_with_supervision(image, display_image=False, text_position=position, smart_position=False)  # Removed detections

    # 3. Loop through positions with smart_position=True, using the same detections
    for position in positions:
        print(f"Processing image with text position: {position}, smart_position=True")
        process_image_with_supervision(image, display_image=False, text_position=position, smart_position=True)  # Removed detections

    os.remove(image_path)



if __name__ == "__main__":
    main()

```
![image](https://github.com/user-attachments/assets/f2f11be1-bd09-4021-ab57-4b5d70309b0a)
    
![image](https://github.com/user-attachments/assets/3bab49ca-beee-46de-8fb6-0ea7db01a153)
    
![image](https://github.com/user-attachments/assets/9b5f7bc9-5ca3-4cf8-8e95-658175b0cb6b)
    
![image](https://github.com/user-attachments/assets/15b2ce19-2a60-4511-8a31-b79ab51a0811)

    

## Any specific deployment considerations

No special deployment considerations are needed. This feature is implemented as an optional parameter that defaults to `False`, ensuring backward compatibility with existing code.

## Docs

- [ ] Docs updated? What were the changes:
No changes to docs as functionality is similar to `smart_position` and the only entry for this in the docs was in the changelog. I can update the documentation to include this new parameter in the appropriate class references if desired, just let me know where and the format.