### PR TITLE
feat(color): add support for RGBA color representation and methods

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -220,7 +220,6 @@ class OrientedBoxAnnotator(BaseAnnotator):
 
             cv2.drawContours(scene, [obb], 0, color.as_bgra(), self.thickness)
 
-        
         # Blend the overlay with the original scene using opacity
         cv2.addWeighted(overlay, self.opacity, scene, 1 - self.opacity, 0, dst=scene)
         return scene
@@ -1120,7 +1119,7 @@ class LabelAnnotator(BaseAnnotator):
             detections=detections,
             custom_color_lookup=custom_color_lookup,
         )
-        
+
         cv2.addWeighted(scene, self.opacity, scene, 1 - self.opacity, 0, dst=scene)
 
         return scene

--- a/supervision/draw/color.py
+++ b/supervision/draw/color.py
@@ -68,7 +68,7 @@ class Color:
     Represents a color in RGBA format.
 
     This class provides methods to work with colors, including creating colors from hex
-    codes, converting colors to hex strings, RGB tuples, and BGR tuples, and RGBA tuples.
+    codes, converting colors to hex strings, RGB tuples, BGR tuples, and RGBA tuples.
 
     Attributes:
         r (int): Red channel value (0-255).
@@ -110,9 +110,9 @@ class Color:
             color_hex (str): The hex string representing the color. This string can
                 start with '#' followed by either 3 or 6 hexadecimal characters. In
                 case of 3 characters, each character is repeated to form the full
-                6-character hex code. If the string has 6 characters, it is assumed to be in
-                the format '#RRGGBB' or '#RRGGBBAA'. If the string has 8 characters, the last two
-                characters are treated as the alpha channel.
+                6-character hex code. If the string has 6 characters, it is assumed
+                to be in the format '#RRGGBB' or '#RRGGBBAA'. If the string has
+                8 characters, the last two characters are treated as the alpha channel.
 
         Returns:
             Color: An instance representing the color.

--- a/supervision/draw/color.py
+++ b/supervision/draw/color.py
@@ -131,7 +131,9 @@ class Color:
         _validate_color_hex(color_hex)
         color_hex = color_hex.lstrip("#")
         if len(color_hex) == 3:
-            color_hex = "".join(c * 2 for c in color_hex) + "ff"  # Default alpha value of 255
+            color_hex = (
+                "".join(c * 2 for c in color_hex) + "ff"
+            )  # Default alpha value of 255
         elif len(color_hex) == 6:
             color_hex += "ff "  # Default alpha value of 255 if not provided
         r, g, b, a = (int(color_hex[i : i + 2], 16) for i in range(0, 8, 2))
@@ -219,7 +221,7 @@ class Color:
             ```
         """
         return self.r, self.g, self.b
-    
+
     def as_rgba(self) -> Tuple[int, int, int, float]:
         """
         Returns the color as an RGBA tuple.


### PR DESCRIPTION
# Description

This pull request introduces an `opacity` parameter to various annotators in the `supervision/annotators/core.py` file, enabling control over the transparency of overlay masks. It also refines the color handling by switching from `as_bgr()` to `as_bgra()` to support alpha channels. Additionally, input validation has been added to ensure the `scene` parameter is not `None`.

### Enhancements to Annotators:

* **Opacity Parameter Added**: Introduced an `opacity` parameter (default `0.5`) to all annotators, allowing users to control the transparency of overlay masks. This parameter is validated to ensure values are between `0` and `1`.

* **Overlay Blending**: Updated the `annotate` methods to blend overlays with the original scene using `cv2.addWeighted`, incorporating the new `opacity` parameter for smooth transparency effects.

### Improvements to Color Handling:

* **Alpha Channel Support**: Replaced `color.as_bgr()` with `color.as_bgra()` across all annotators to support alpha channels, which is essential for blending transparency. 

### Input Validation:

* **Scene Parameter Check**: Added validation to ensure the `scene` parameter is not `None` before proceeding with annotation. A `ValueError` is raised if this condition is not met.

## Type of change

Please delete options that are not relevant.
-   [x] New feature (non-breaking change which adds functionality)
-   [x] This change requires a documentation update

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
