### PR TITLE
Include `scipy-stubs` as optional dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ dev = [
     "ipywidgets>=8.1.1",
     "jupytext>=1.16.1",
     "nbconvert>=7.14.2",
-    "docutils!=0.21"
+    "docutils!=0.21",
+    "scipy-stubs>=1.14.1.6",
 ]
 docs = [
     "mkdocs-material[imaging]>=9.5.5",


### PR DESCRIPTION
This adds [`scipy-stubs`](https://github.com/scipy/scipy-stubs) as an optional development dependency. It can help quite a bit with IDE supports, such as autocompletion and introspection. It requires no configuration, mypy plugins, and there's no runtime impact.  So even if you don't care about typing annotations, you'll basically improve DX for free :)