### PR TITLE
fix: typo in __all__ (xyxy_to_xcycarh)

### DIFF
--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -226,6 +226,6 @@ __all__ = [
     "xcycwh_to_xyxy",
     "xywh_to_xyxy",
     "xyxy_to_polygons",
-    "xyxy_to_xyah",
+    "xyxy_to_xcycarh",
     "xyxy_to_xywh",
 ]


### PR DESCRIPTION
### Fix typo in `__all__`

Commit **5d6ad66** introduced the helper `xyxy_to_xcycarh`, but `__all__` still exported
`xyxy_to_xyah`. As a result, `from supervision import *` raises an `ImportError`.

---

#### What’s changed
* `supervision/__init__.py`  
  * Replace the wrong entry **`xyxy_to_xyah`** with **`xyxy_to_xcycarh`**.

---

#### How I tested it
* **pytest** – full test suite passes.
* Quick sanity-check:

  ```python
  import supervision as sv
  assert all(hasattr(sv, n) for n in sv.__all__)
  ```

  → no missing symbols.

---

#### Checklist
- [x] Code compiles / tests pass
- [x] `pre-commit run --all-files` is clean
- [x] PR title uses Conventional Commits (`fix:`)

