### PR TITLE
fix: ID=0 bug in Mean Average Precision calculation

### DIFF
--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -1237,7 +1237,7 @@ class MeanAveragePrecision(Metric):
                     "image_id": image_id,
                     "bbox": xywh,
                     "category_id": category_id,
-                    "id": len(annotations),  # incrementally increase the id
+                    "id": len(annotations) + 1,  # incrementally increase the id
                 }
                 annotations.append(dict_annotation)
         # Category list

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -1237,7 +1237,7 @@ class MeanAveragePrecision(Metric):
                     "image_id": image_id,
                     "bbox": xywh,
                     "category_id": category_id,
-                    "id": len(annotations) + 1,  # incrementally increase the id
+                    "id": len(annotations) + 1,  # Start IDs from 1 (0 means no match)
                 }
                 annotations.append(dict_annotation)
         # Category list

--- a/test/metrics/test_mean_average_precision.py
+++ b/test/metrics/test_mean_average_precision.py
@@ -1,0 +1,66 @@
+"""
+Tests for Mean Average Precision ID=0 bug fix
+"""
+import numpy as np
+import pytest
+
+from supervision.detection.core import Detections
+from supervision.metrics.mean_average_precision import MeanAveragePrecision
+
+
+def test_single_perfect_detection():
+    """Test that single perfect detection gets 1.0 mAP (not 0.0 due to ID=0 bug)"""
+    # Perfect detection (identical prediction and target)
+    detection = Detections(
+        xyxy=np.array([[10, 10, 50, 50]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.9])
+    )
+    
+    metric = MeanAveragePrecision()
+    metric.update([detection], [detection])
+    result = metric.compute()
+    
+    # Should be perfect 1.0 mAP, not 0.0 due to ID=0 bug
+    assert abs(result.map50_95 - 1.0) < 1e-6
+
+
+def test_multiple_perfect_detections():
+    """Test that multiple perfect detections get 1.0 mAP"""
+    # Multiple perfect detections in one image
+    detections = Detections(
+        xyxy=np.array([
+            [10, 10, 50, 50],
+            [100, 100, 140, 140],
+            [200, 200, 240, 240]
+        ], dtype=np.float64),
+        class_id=np.array([0, 0, 0]),
+        confidence=np.array([0.9, 0.9, 0.9])
+    )
+    
+    metric = MeanAveragePrecision()
+    metric.update([detections], [detections])
+    result = metric.compute()
+    
+    # Should be perfect 1.0 mAP
+    assert abs(result.map50_95 - 1.0) < 1e-6
+
+
+def test_batch_updates_perfect_detections():
+    """Test that batch updates with perfect detections get 1.0 mAP"""
+    # Single perfect detection for multiple batch updates
+    detection = Detections(
+        xyxy=np.array([[10, 10, 50, 50]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.9])
+    )
+    
+    metric = MeanAveragePrecision()
+    # Add 3 batch updates
+    metric.update([detection], [detection])
+    metric.update([detection], [detection])
+    metric.update([detection], [detection])
+    result = metric.compute()
+    
+    # Should be perfect 1.0 mAP across all batches
+    assert abs(result.map50_95 - 1.0) < 1e-6 

--- a/test/metrics/test_mean_average_precision.py
+++ b/test/metrics/test_mean_average_precision.py
@@ -1,8 +1,8 @@
 """
 Tests for Mean Average Precision ID=0 bug fix
 """
+
 import numpy as np
-import pytest
 
 from supervision.detection.core import Detections
 from supervision.metrics.mean_average_precision import MeanAveragePrecision
@@ -14,13 +14,13 @@ def test_single_perfect_detection():
     detection = Detections(
         xyxy=np.array([[10, 10, 50, 50]], dtype=np.float64),
         class_id=np.array([0]),
-        confidence=np.array([0.9])
+        confidence=np.array([0.9]),
     )
-    
+
     metric = MeanAveragePrecision()
     metric.update([detection], [detection])
     result = metric.compute()
-    
+
     # Should be perfect 1.0 mAP, not 0.0 due to ID=0 bug
     assert abs(result.map50_95 - 1.0) < 1e-6
 
@@ -29,19 +29,18 @@ def test_multiple_perfect_detections():
     """Test that multiple perfect detections get 1.0 mAP"""
     # Multiple perfect detections in one image
     detections = Detections(
-        xyxy=np.array([
-            [10, 10, 50, 50],
-            [100, 100, 140, 140],
-            [200, 200, 240, 240]
-        ], dtype=np.float64),
+        xyxy=np.array(
+            [[10, 10, 50, 50], [100, 100, 140, 140], [200, 200, 240, 240]],
+            dtype=np.float64,
+        ),
         class_id=np.array([0, 0, 0]),
-        confidence=np.array([0.9, 0.9, 0.9])
+        confidence=np.array([0.9, 0.9, 0.9]),
     )
-    
+
     metric = MeanAveragePrecision()
     metric.update([detections], [detections])
     result = metric.compute()
-    
+
     # Should be perfect 1.0 mAP
     assert abs(result.map50_95 - 1.0) < 1e-6
 
@@ -52,15 +51,15 @@ def test_batch_updates_perfect_detections():
     detection = Detections(
         xyxy=np.array([[10, 10, 50, 50]], dtype=np.float64),
         class_id=np.array([0]),
-        confidence=np.array([0.9])
+        confidence=np.array([0.9]),
     )
-    
+
     metric = MeanAveragePrecision()
     # Add 3 batch updates
     metric.update([detection], [detection])
     metric.update([detection], [detection])
     metric.update([detection], [detection])
     result = metric.compute()
-    
+
     # Should be perfect 1.0 mAP across all batches
-    assert abs(result.map50_95 - 1.0) < 1e-6 
+    assert abs(result.map50_95 - 1.0) < 1e-6


### PR DESCRIPTION
# Description

Objects were getting 0.0 mAP despite perfect IoU matches due to a bug in annotation ID assignment. The COCO evaluator treats ID=0 as "no match", but supervision was assigning the first annotation ID=0, causing it to be incorrectly classified as a false positive.

### Root Cause
```python
# BUGGY: Started IDs from 0
"id": len(annotations),  # First object gets ID=0 → treated as "no match"
```

### Solution
```python  
# FIXED: Start IDs from 1
"id": len(annotations) + 1,  # Start IDs from 1 (0 means no match)
```

### Impact
- **Before**: Single objects → 0.000 mAP, Multi-objects → partial failure
- **After**: All perfect predictions → 1.000 mAP

### Testing
Added 3 regression tests covering single objects, multiple objects, and batch updates to prevent future regressions.

### Reproduction Notebooks:

supervision 0.26.0 showing the bug:
https://colab.research.google.com/drive/1naVTb7qo7rbgT_AYaD8V9CvRdhK_wwPH?usp=sharing

With fix:
https://colab.research.google.com/drive/1Kz34ec1zuDbqE7lovvTWz1REKLNsyPuM?usp=sharing

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tests, and in a reproduction notebook

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
