### PR TITLE
fix: handle -1 sentinel values in mAP calculation to prevent negative results and mimic pycocotools behaviour

### DIFF
--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -57,7 +57,11 @@ class MeanAveragePrecisionResult:
 
     @property
     def map50_95(self) -> float:
-        return self.mAP_scores.mean()
+        valid_scores = self.mAP_scores[self.mAP_scores > -1]
+        if len(valid_scores) > 0:
+            return valid_scores.mean()
+        else:
+            return -1
 
     @property
     def map50(self) -> float:
@@ -917,35 +921,38 @@ class COCOEvaluator:
             :, :, :, area_range_idx, max_100_dets_idx
         ]
         # mAP over thresholds (dimension=num_thresholds)
-        mAP_scores_all_sizes = average_precision_all_sizes.mean(axis=(1, 2))
+        # Use masked array to exclude -1 values when computing mean
+        masked = np.ma.masked_equal(average_precision_all_sizes, -1)
+        mAP_scores_all_sizes = np.ma.filled(masked.mean(axis=(1, 2)), -1)
         # AP per class
-        ap_per_class_all_sizes = average_precision_all_sizes.mean(axis=1).transpose(
-            1, 0
-        )
+        ap_per_class_all_sizes = np.ma.filled(masked.mean(axis=1), -1).transpose(1, 0)
 
         # Average precision for SMALL objects and 100 max detections
         small_area_range_idx = list(ObjectSize).index(ObjectSize.SMALL)
         average_precision_small = precision[
             :, :, :, small_area_range_idx, max_100_dets_idx
         ]
-        mAP_scores_small = average_precision_small.mean(axis=(1, 2))
-        ap_per_class_small = average_precision_small.mean(axis=1).transpose(1, 0)
+        masked_small = np.ma.masked_equal(average_precision_small, -1)
+        mAP_scores_small = np.ma.filled(masked_small.mean(axis=(1, 2)), -1)
+        ap_per_class_small = np.ma.filled(masked_small.mean(axis=1), -1).transpose(1, 0)
 
         # Average precision for MEDIUM objects and 100 max detections
         medium_area_range_idx = list(ObjectSize).index(ObjectSize.MEDIUM)
         average_precision_medium = precision[
             :, :, :, medium_area_range_idx, max_100_dets_idx
         ]
-        mAP_scores_medium = average_precision_medium.mean(axis=(1, 2))
-        ap_per_class_medium = average_precision_medium.mean(axis=1).transpose(1, 0)
+        masked_medium = np.ma.masked_equal(average_precision_medium, -1)
+        mAP_scores_medium = np.ma.filled(masked_medium.mean(axis=(1, 2)), -1)
+        ap_per_class_medium = np.ma.filled(masked_medium.mean(axis=1), -1).transpose(1, 0)
 
         # Average precision for LARGE objects and 100 max detections
         large_area_range_idx = list(ObjectSize).index(ObjectSize.LARGE)
         average_precision_large = precision[
             :, :, :, large_area_range_idx, max_100_dets_idx
         ]
-        mAP_scores_large = average_precision_large.mean(axis=(1, 2))
-        ap_per_class_large = average_precision_large.mean(axis=1).transpose(1, 0)
+        masked_large = np.ma.masked_equal(average_precision_large, -1)
+        mAP_scores_large = np.ma.filled(masked_large.mean(axis=(1, 2)), -1)
+        ap_per_class_large = np.ma.filled(masked_large.mean(axis=1), -1).transpose(1, 0)
 
         self.results = {
             "params": self.params,

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -1237,7 +1237,7 @@ class MeanAveragePrecision(Metric):
                     "image_id": image_id,
                     "bbox": xywh,
                     "category_id": category_id,
-                    "id": len(annotations),  # incrementally increase the id
+                    "id": len(annotations) + 1,  # incrementally increase the id
                 }
                 annotations.append(dict_annotation)
         # Category list

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -425,6 +425,11 @@ class EvaluationDataset:
         if not isinstance(predictions, list):
             raise ValueError("results must be a list")
 
+        # Handle empty predictions
+        if len(predictions) == 0:
+            predictions_dataset.dataset["annotations"] = []
+            return predictions_dataset
+
         ids = [pred["image_id"] for pred in predictions]
 
         # Make sure the image ids from predictions exist in the current dataset
@@ -923,9 +928,14 @@ class COCOEvaluator:
         # mAP over thresholds (dimension=num_thresholds)
         # Use masked array to exclude -1 values when computing mean
         masked = np.ma.masked_equal(average_precision_all_sizes, -1)
-        mAP_scores_all_sizes = np.ma.filled(masked.mean(axis=(1, 2)), -1)
-        # AP per class
-        ap_per_class_all_sizes = np.ma.filled(masked.mean(axis=1), -1).transpose(1, 0)
+        # Check if all values are masked (empty array)
+        if masked.count() == 0:
+            mAP_scores_all_sizes = np.full(num_iou_thresholds, -1)
+            ap_per_class_all_sizes = np.full((num_categories, num_iou_thresholds), -1)
+        else:
+            mAP_scores_all_sizes = np.ma.filled(masked.mean(axis=(1, 2)), -1)
+            # AP per class
+            ap_per_class_all_sizes = np.ma.filled(masked.mean(axis=1), -1).transpose(1, 0)
 
         # Average precision for SMALL objects and 100 max detections
         small_area_range_idx = list(ObjectSize).index(ObjectSize.SMALL)
@@ -933,8 +943,12 @@ class COCOEvaluator:
             :, :, :, small_area_range_idx, max_100_dets_idx
         ]
         masked_small = np.ma.masked_equal(average_precision_small, -1)
-        mAP_scores_small = np.ma.filled(masked_small.mean(axis=(1, 2)), -1)
-        ap_per_class_small = np.ma.filled(masked_small.mean(axis=1), -1).transpose(1, 0)
+        if masked_small.count() == 0:
+            mAP_scores_small = np.full(num_iou_thresholds, -1)
+            ap_per_class_small = np.full((num_categories, num_iou_thresholds), -1)
+        else:
+            mAP_scores_small = np.ma.filled(masked_small.mean(axis=(1, 2)), -1)
+            ap_per_class_small = np.ma.filled(masked_small.mean(axis=1), -1).transpose(1, 0)
 
         # Average precision for MEDIUM objects and 100 max detections
         medium_area_range_idx = list(ObjectSize).index(ObjectSize.MEDIUM)
@@ -942,8 +956,12 @@ class COCOEvaluator:
             :, :, :, medium_area_range_idx, max_100_dets_idx
         ]
         masked_medium = np.ma.masked_equal(average_precision_medium, -1)
-        mAP_scores_medium = np.ma.filled(masked_medium.mean(axis=(1, 2)), -1)
-        ap_per_class_medium = np.ma.filled(masked_medium.mean(axis=1), -1).transpose(1, 0)
+        if masked_medium.count() == 0:
+            mAP_scores_medium = np.full(num_iou_thresholds, -1)
+            ap_per_class_medium = np.full((num_categories, num_iou_thresholds), -1)
+        else:
+            mAP_scores_medium = np.ma.filled(masked_medium.mean(axis=(1, 2)), -1)
+            ap_per_class_medium = np.ma.filled(masked_medium.mean(axis=1), -1).transpose(1, 0)
 
         # Average precision for LARGE objects and 100 max detections
         large_area_range_idx = list(ObjectSize).index(ObjectSize.LARGE)
@@ -951,8 +969,12 @@ class COCOEvaluator:
             :, :, :, large_area_range_idx, max_100_dets_idx
         ]
         masked_large = np.ma.masked_equal(average_precision_large, -1)
-        mAP_scores_large = np.ma.filled(masked_large.mean(axis=(1, 2)), -1)
-        ap_per_class_large = np.ma.filled(masked_large.mean(axis=1), -1).transpose(1, 0)
+        if masked_large.count() == 0:
+            mAP_scores_large = np.full(num_iou_thresholds, -1)
+            ap_per_class_large = np.full((num_categories, num_iou_thresholds), -1)
+        else:
+            mAP_scores_large = np.ma.filled(masked_large.mean(axis=(1, 2)), -1)
+            ap_per_class_large = np.ma.filled(masked_large.mean(axis=1), -1).transpose(1, 0)
 
         self.results = {
             "params": self.params,

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -920,7 +920,13 @@ class COCOEvaluator:
 
         self.results = {
             "params": self.params,
-            "counts": [num_iou_thresholds, num_recall_thresholds, num_categories, num_area_ranges, num_max_detections],
+            "counts": [
+                num_iou_thresholds,
+                num_recall_thresholds,
+                num_categories,
+                num_area_ranges,
+                num_max_detections,
+            ],
             "date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             "precision": precision,
             "recall": recall,
@@ -933,7 +939,9 @@ class COCOEvaluator:
             masked = np.ma.masked_equal(precision_slice, -1)
             if masked.count() == 0:
                 # All values are -1 (no data)
-                return np.full(num_iou_thresholds, -1), np.full((num_categories, num_iou_thresholds), -1)
+                return np.full(num_iou_thresholds, -1), np.full(
+                    (num_categories, num_iou_thresholds), -1
+                )
             else:
                 mAP_scores = np.ma.filled(masked.mean(axis=(1, 2)), -1)
                 ap_per_class = np.ma.filled(masked.mean(axis=1), -1).transpose(1, 0)
@@ -948,28 +956,36 @@ class COCOEvaluator:
         ]
         # mAP over thresholds (dimension=num_thresholds)
         # Use masked array to exclude -1 values when computing mean
-        mAP_scores_all_sizes, ap_per_class_all_sizes = compute_average_precision(average_precision_all_sizes)
+        mAP_scores_all_sizes, ap_per_class_all_sizes = compute_average_precision(
+            average_precision_all_sizes
+        )
 
         # Average precision for SMALL objects and 100 max detections
         small_area_range_idx = list(ObjectSize).index(ObjectSize.SMALL)
         average_precision_small = precision[
             :, :, :, small_area_range_idx, max_100_dets_idx
         ]
-        mAP_scores_small, ap_per_class_small = compute_average_precision(average_precision_small)
+        mAP_scores_small, ap_per_class_small = compute_average_precision(
+            average_precision_small
+        )
 
         # Average precision for MEDIUM objects and 100 max detections
         medium_area_range_idx = list(ObjectSize).index(ObjectSize.MEDIUM)
         average_precision_medium = precision[
             :, :, :, medium_area_range_idx, max_100_dets_idx
         ]
-        mAP_scores_medium, ap_per_class_medium = compute_average_precision(average_precision_medium)
+        mAP_scores_medium, ap_per_class_medium = compute_average_precision(
+            average_precision_medium
+        )
 
         # Average precision for LARGE objects and 100 max detections
         large_area_range_idx = list(ObjectSize).index(ObjectSize.LARGE)
         average_precision_large = precision[
             :, :, :, large_area_range_idx, max_100_dets_idx
         ]
-        mAP_scores_large, ap_per_class_large = compute_average_precision(average_precision_large)
+        mAP_scores_large, ap_per_class_large = compute_average_precision(
+            average_precision_large
+        )
 
         self.results = {
             "params": self.params,

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -935,7 +935,7 @@ class COCOEvaluator:
 
         # Helper function to compute average precision while handling -1 sentinel values
         def compute_average_precision(precision_slice):
-            """Helper function to compute average precision while handling -1 sentinel values."""
+            """Compute average precision while handling -1 sentinel values."""
             masked = np.ma.masked_equal(precision_slice, -1)
             if masked.count() == 0:
                 # All values are -1 (no data)

--- a/supervision/metrics/mean_average_precision.py
+++ b/supervision/metrics/mean_average_precision.py
@@ -1237,7 +1237,7 @@ class MeanAveragePrecision(Metric):
                     "image_id": image_id,
                     "bbox": xywh,
                     "category_id": category_id,
-                    "id": len(annotations) + 1,  # incrementally increase the id
+                    "id": len(annotations) + 1,  # Start IDs from 1 (0 means no match)
                 }
                 annotations.append(dict_annotation)
         # Category list

--- a/test/metrics/test_mean_average_precision.py
+++ b/test/metrics/test_mean_average_precision.py
@@ -72,49 +72,47 @@ def test_scenario_1_success_case_imperfect_match():
         xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
         class_id=np.array([0]),
         confidence=np.array([0.95]),
-        data={"area": np.array([900])}
+        data={"area": np.array([900])},
     )
-    
+
     # Medium object (class 1) - area = 50*50 = 2500 (between 1024 and 9216)
     medium_target = Detections(
         xyxy=np.array([[10, 10, 60, 60]], dtype=np.float64),
         class_id=np.array([1]),
-        data={"area": np.array([2500])}
+        data={"area": np.array([2500])},
     )
     medium_pred = Detections(
         xyxy=np.array([[12, 12, 60, 60]], dtype=np.float64),  # Slightly off
         class_id=np.array([1]),
         confidence=np.array([0.9]),
-        data={"area": np.array([2304])}  # 48*48
+        data={"area": np.array([2304])},  # 48*48
     )
-    
+
     # Large objects (classes 0, 1, 2) - area = 100*100 = 10000 > 9216
     large_targets = Detections(
-        xyxy=np.array([
-            [10, 10, 110, 110],
-            [120, 120, 220, 220],
-            [230, 230, 330, 330]
-        ], dtype=np.float64),
+        xyxy=np.array(
+            [[10, 10, 110, 110], [120, 120, 220, 220], [230, 230, 330, 330]],
+            dtype=np.float64,
+        ),
         class_id=np.array([2, 0, 1]),
-        data={"area": np.array([10000, 10000, 10000])}
+        data={"area": np.array([10000, 10000, 10000])},
     )
     large_preds = Detections(
-        xyxy=np.array([
-            [10, 10, 110, 110],
-            [120, 120, 220, 220],
-            [230, 230, 330, 330]
-        ], dtype=np.float64),
+        xyxy=np.array(
+            [[10, 10, 110, 110], [120, 120, 220, 220], [230, 230, 330, 330]],
+            dtype=np.float64,
+        ),
         class_id=np.array([2, 0, 1]),
         confidence=np.array([0.9, 0.9, 0.9]),
-        data={"area": np.array([10000, 10000, 10000])}
+        data={"area": np.array([10000, 10000, 10000])},
     )
-    
+
     metric = MeanAveragePrecision()
     metric.update([small_perfect], [small_perfect])
     metric.update([medium_pred], [medium_target])
     metric.update([large_preds], [large_targets])
     result = metric.compute()
-    
+
     # Should be close to 0.9 (slightly less than perfect due to medium object)
     assert 0.85 < result.map50_95 < 0.98  # Adjusted upper bound
     assert result.medium_objects.map50_95 < 1.0  # Medium should be less than perfect
@@ -127,35 +125,34 @@ def test_scenario_2_missed_detection():
         xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
         class_id=np.array([0]),
         confidence=np.array([0.95]),
-        data={"area": np.array([900])}
+        data={"area": np.array([900])},
     )
-    
+
     # Medium object - area = 50*50 = 2500 (between 1024 and 9216) - no prediction (missed)
     medium_target = Detections(
         xyxy=np.array([[10, 10, 60, 60]], dtype=np.float64),
         class_id=np.array([1]),
-        data={"area": np.array([2500])}
+        data={"area": np.array([2500])},
     )
     no_medium_pred = Detections.empty()
-    
+
     # Large objects - area = 100*100 = 10000 > 9216
     large_detections = Detections(
-        xyxy=np.array([
-            [10, 10, 110, 110],
-            [120, 120, 220, 220],
-            [230, 230, 330, 330]
-        ], dtype=np.float64),
+        xyxy=np.array(
+            [[10, 10, 110, 110], [120, 120, 220, 220], [230, 230, 330, 330]],
+            dtype=np.float64,
+        ),
         class_id=np.array([2, 0, 1]),
         confidence=np.array([0.9, 0.9, 0.9]),
-        data={"area": np.array([10000, 10000, 10000])}
+        data={"area": np.array([10000, 10000, 10000])},
     )
-    
+
     metric = MeanAveragePrecision()
     metric.update([small_detection], [small_detection])
     metric.update([no_medium_pred], [medium_target])
     metric.update([large_detections], [large_detections])
     result = metric.compute()
-    
+
     # Medium objects should have 0.0 mAP (missed detection)
     assert abs(result.medium_objects.map50_95 - 0.0) < 1e-6
 
@@ -167,36 +164,35 @@ def test_scenario_3_false_positive():
         xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
         class_id=np.array([0]),
         confidence=np.array([0.95]),
-        data={"area": np.array([900])}
+        data={"area": np.array([900])},
     )
-    
+
     # Medium object - area = 50*50 = 2500 - false positive (no GT)
     medium_pred = Detections(
         xyxy=np.array([[12, 12, 62, 62]], dtype=np.float64),
         class_id=np.array([1]),
         confidence=np.array([0.9]),
-        data={"area": np.array([2500])}
+        data={"area": np.array([2500])},
     )
     no_medium_target = Detections.empty()
-    
+
     # Large objects - area = 100*100 = 10000 > 9216
     large_detections = Detections(
-        xyxy=np.array([
-            [10, 10, 110, 110],
-            [120, 120, 220, 220],
-            [230, 230, 330, 330]
-        ], dtype=np.float64),
+        xyxy=np.array(
+            [[10, 10, 110, 110], [120, 120, 220, 220], [230, 230, 330, 330]],
+            dtype=np.float64,
+        ),
         class_id=np.array([2, 0, 1]),
         confidence=np.array([0.9, 0.9, 0.9]),
-        data={"area": np.array([10000, 10000, 10000])}
+        data={"area": np.array([10000, 10000, 10000])},
     )
-    
+
     metric = MeanAveragePrecision()
     metric.update([small_detection], [small_detection])
     metric.update([medium_pred], [no_medium_target])
     metric.update([large_detections], [large_detections])
     result = metric.compute()
-    
+
     # Medium objects should have -1 mAP (false positive, matching pycocotools)
     assert result.medium_objects.map50_95 == -1
 
@@ -208,37 +204,43 @@ def test_scenario_4_no_data():
         xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
         class_id=np.array([0]),
         confidence=np.array([0.95]),
-        data={"area": np.array([900])}
+        data={"area": np.array([900])},
     )
-    
+
     # Medium object - no data at all
     no_medium = Detections.empty()
-    
+
     # Large objects - area = 100*100 = 10000 > 9216 - only classes 0 and 2 (no class 1)
     large_targets = Detections(
-        xyxy=np.array([
-            [10, 10, 110, 110],
-            [120, 120, 220, 220],
-        ], dtype=np.float64),
+        xyxy=np.array(
+            [
+                [10, 10, 110, 110],
+                [120, 120, 220, 220],
+            ],
+            dtype=np.float64,
+        ),
         class_id=np.array([2, 0]),
-        data={"area": np.array([10000, 10000])}
+        data={"area": np.array([10000, 10000])},
     )
     large_preds = Detections(
-        xyxy=np.array([
-            [10, 10, 110, 110],
-            [120, 120, 220, 220],
-        ], dtype=np.float64),
+        xyxy=np.array(
+            [
+                [10, 10, 110, 110],
+                [120, 120, 220, 220],
+            ],
+            dtype=np.float64,
+        ),
         class_id=np.array([2, 0]),
         confidence=np.array([0.9, 0.9]),
-        data={"area": np.array([10000, 10000])}
+        data={"area": np.array([10000, 10000])},
     )
-    
+
     metric = MeanAveragePrecision()
     metric.update([small_detection], [small_detection])
     metric.update([no_medium], [no_medium])
     metric.update([large_preds], [large_targets])
     result = metric.compute()
-    
+
     # Should NOT have negative mAP values for overall
     assert result.map50_95 >= 0.0
     # Medium objects should have -1 mAP (no data, matching pycocotools)
@@ -260,13 +262,13 @@ def test_scenario_5_only_one_class_present():
             confidence=np.array([0.9]),
         ),
     ]
-    
+
     metric = MeanAveragePrecision()
     for det in detections_class_0:
         metric.update([det], [det])
-    
+
     result = metric.compute()
-    
+
     # Should be 1.0 mAP (perfect match for the only class present)
     assert abs(result.map50_95 - 1.0) < 1e-6
     assert abs(result.map50 - 1.0) < 1e-6
@@ -281,14 +283,14 @@ def test_mixed_classes_with_missing_detections():
         class_id=np.array([0]),
         confidence=np.array([0.9]),
     )
-    
+
     # Class 1: GT exists but no prediction
     class_1_target = Detections(
         xyxy=np.array([[60, 60, 100, 100]], dtype=np.float64),
         class_id=np.array([1]),
     )
     class_1_pred = Detections.empty()
-    
+
     # Class 2: Prediction exists but no GT (false positive)
     class_2_pred = Detections(
         xyxy=np.array([[110, 110, 150, 150]], dtype=np.float64),
@@ -296,13 +298,13 @@ def test_mixed_classes_with_missing_detections():
         confidence=np.array([0.8]),
     )
     class_2_target = Detections.empty()
-    
+
     metric = MeanAveragePrecision()
     metric.update([class_0_det], [class_0_det])
     metric.update([class_1_pred], [class_1_target])
     metric.update([class_2_pred], [class_2_target])
     result = metric.compute()
-    
+
     # Should not have negative mAP
     assert result.map50_95 >= 0.0
     # Should be less than 1.0 due to missed detection and false positive
@@ -314,12 +316,12 @@ def test_empty_predictions_and_targets():
     metric = MeanAveragePrecision()
     metric.update([Detections.empty()], [Detections.empty()])
     result = metric.compute()
-    
+
     # Should return -1 for no data (matching pycocotools behavior)
     assert result.map50_95 == -1
     assert result.map50 == -1
     assert result.map75 == -1
-    
+
     # All object size categories should also be -1
     assert result.small_objects.map50_95 == -1
     assert result.medium_objects.map50_95 == -1

--- a/test/metrics/test_mean_average_precision.py
+++ b/test/metrics/test_mean_average_precision.py
@@ -63,3 +63,257 @@ def test_batch_updates_perfect_detections():
 
     # Should be perfect 1.0 mAP across all batches
     assert abs(result.map50_95 - 1.0) < 1e-6
+
+
+def test_scenario_1_success_case_imperfect_match():
+    """Scenario 1: Success Case with imperfect match"""
+    # Small object (class 0) - area = 30*30 = 900 < 1024
+    small_perfect = Detections(
+        xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.95]),
+        data={"area": np.array([900])}
+    )
+    
+    # Medium object (class 1) - area = 50*50 = 2500 (between 1024 and 9216)
+    medium_target = Detections(
+        xyxy=np.array([[10, 10, 60, 60]], dtype=np.float64),
+        class_id=np.array([1]),
+        data={"area": np.array([2500])}
+    )
+    medium_pred = Detections(
+        xyxy=np.array([[12, 12, 60, 60]], dtype=np.float64),  # Slightly off
+        class_id=np.array([1]),
+        confidence=np.array([0.9]),
+        data={"area": np.array([2304])}  # 48*48
+    )
+    
+    # Large objects (classes 0, 1, 2) - area = 100*100 = 10000 > 9216
+    large_targets = Detections(
+        xyxy=np.array([
+            [10, 10, 110, 110],
+            [120, 120, 220, 220],
+            [230, 230, 330, 330]
+        ], dtype=np.float64),
+        class_id=np.array([2, 0, 1]),
+        data={"area": np.array([10000, 10000, 10000])}
+    )
+    large_preds = Detections(
+        xyxy=np.array([
+            [10, 10, 110, 110],
+            [120, 120, 220, 220],
+            [230, 230, 330, 330]
+        ], dtype=np.float64),
+        class_id=np.array([2, 0, 1]),
+        confidence=np.array([0.9, 0.9, 0.9]),
+        data={"area": np.array([10000, 10000, 10000])}
+    )
+    
+    metric = MeanAveragePrecision()
+    metric.update([small_perfect], [small_perfect])
+    metric.update([medium_pred], [medium_target])
+    metric.update([large_preds], [large_targets])
+    result = metric.compute()
+    
+    # Should be close to 0.9 (slightly less than perfect due to medium object)
+    assert 0.85 < result.map50_95 < 0.98  # Adjusted upper bound
+    assert result.medium_objects.map50_95 < 1.0  # Medium should be less than perfect
+
+
+def test_scenario_2_missed_detection():
+    """Scenario 2: GT Present, No Prediction (Missed Detection)"""
+    # Small object - area = 30*30 = 900 < 1024
+    small_detection = Detections(
+        xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.95]),
+        data={"area": np.array([900])}
+    )
+    
+    # Medium object - area = 50*50 = 2500 (between 1024 and 9216) - no prediction (missed)
+    medium_target = Detections(
+        xyxy=np.array([[10, 10, 60, 60]], dtype=np.float64),
+        class_id=np.array([1]),
+        data={"area": np.array([2500])}
+    )
+    no_medium_pred = Detections.empty()
+    
+    # Large objects - area = 100*100 = 10000 > 9216
+    large_detections = Detections(
+        xyxy=np.array([
+            [10, 10, 110, 110],
+            [120, 120, 220, 220],
+            [230, 230, 330, 330]
+        ], dtype=np.float64),
+        class_id=np.array([2, 0, 1]),
+        confidence=np.array([0.9, 0.9, 0.9]),
+        data={"area": np.array([10000, 10000, 10000])}
+    )
+    
+    metric = MeanAveragePrecision()
+    metric.update([small_detection], [small_detection])
+    metric.update([no_medium_pred], [medium_target])
+    metric.update([large_detections], [large_detections])
+    result = metric.compute()
+    
+    # Medium objects should have 0.0 mAP (missed detection)
+    assert abs(result.medium_objects.map50_95 - 0.0) < 1e-6
+
+
+def test_scenario_3_false_positive():
+    """Scenario 3: No GT, Prediction Present (False Positive)"""
+    # Small object - area = 30*30 = 900 < 1024
+    small_detection = Detections(
+        xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.95]),
+        data={"area": np.array([900])}
+    )
+    
+    # Medium object - area = 50*50 = 2500 - false positive (no GT)
+    medium_pred = Detections(
+        xyxy=np.array([[12, 12, 62, 62]], dtype=np.float64),
+        class_id=np.array([1]),
+        confidence=np.array([0.9]),
+        data={"area": np.array([2500])}
+    )
+    no_medium_target = Detections.empty()
+    
+    # Large objects - area = 100*100 = 10000 > 9216
+    large_detections = Detections(
+        xyxy=np.array([
+            [10, 10, 110, 110],
+            [120, 120, 220, 220],
+            [230, 230, 330, 330]
+        ], dtype=np.float64),
+        class_id=np.array([2, 0, 1]),
+        confidence=np.array([0.9, 0.9, 0.9]),
+        data={"area": np.array([10000, 10000, 10000])}
+    )
+    
+    metric = MeanAveragePrecision()
+    metric.update([small_detection], [small_detection])
+    metric.update([medium_pred], [no_medium_target])
+    metric.update([large_detections], [large_detections])
+    result = metric.compute()
+    
+    # Medium objects should have -1 mAP (false positive, matching pycocotools)
+    assert result.medium_objects.map50_95 == -1
+
+
+def test_scenario_4_no_data():
+    """Scenario 4: No GT, No Prediction (Category has no data)"""
+    # Small object - area = 30*30 = 900 < 1024
+    small_detection = Detections(
+        xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.95]),
+        data={"area": np.array([900])}
+    )
+    
+    # Medium object - no data at all
+    no_medium = Detections.empty()
+    
+    # Large objects - area = 100*100 = 10000 > 9216 - only classes 0 and 2 (no class 1)
+    large_targets = Detections(
+        xyxy=np.array([
+            [10, 10, 110, 110],
+            [120, 120, 220, 220],
+        ], dtype=np.float64),
+        class_id=np.array([2, 0]),
+        data={"area": np.array([10000, 10000])}
+    )
+    large_preds = Detections(
+        xyxy=np.array([
+            [10, 10, 110, 110],
+            [120, 120, 220, 220],
+        ], dtype=np.float64),
+        class_id=np.array([2, 0]),
+        confidence=np.array([0.9, 0.9]),
+        data={"area": np.array([10000, 10000])}
+    )
+    
+    metric = MeanAveragePrecision()
+    metric.update([small_detection], [small_detection])
+    metric.update([no_medium], [no_medium])
+    metric.update([large_preds], [large_targets])
+    result = metric.compute()
+    
+    # Should NOT have negative mAP values for overall
+    assert result.map50_95 >= 0.0
+    # Medium objects should have -1 mAP (no data, matching pycocotools)
+    assert result.medium_objects.map50_95 == -1
+
+
+def test_scenario_5_only_one_class_present():
+    """Scenario 5: Only 1 of 3 Classes Present (Perfect Match)"""
+    # Only class 0 objects with perfect matches
+    detections_class_0 = [
+        Detections(
+            xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
+            class_id=np.array([0]),
+            confidence=np.array([0.95]),
+        ),
+        Detections(
+            xyxy=np.array([[20, 20, 230, 130]], dtype=np.float64),
+            class_id=np.array([0]),
+            confidence=np.array([0.9]),
+        ),
+    ]
+    
+    metric = MeanAveragePrecision()
+    for det in detections_class_0:
+        metric.update([det], [det])
+    
+    result = metric.compute()
+    
+    # Should be 1.0 mAP (perfect match for the only class present)
+    assert abs(result.map50_95 - 1.0) < 1e-6
+    assert abs(result.map50 - 1.0) < 1e-6
+    assert abs(result.map75 - 1.0) < 1e-6
+
+
+def test_mixed_classes_with_missing_detections():
+    """Test mixed scenario with some classes having no detections"""
+    # Class 0: Perfect detection
+    class_0_det = Detections(
+        xyxy=np.array([[10, 10, 50, 50]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.9]),
+    )
+    
+    # Class 1: GT exists but no prediction
+    class_1_target = Detections(
+        xyxy=np.array([[60, 60, 100, 100]], dtype=np.float64),
+        class_id=np.array([1]),
+    )
+    class_1_pred = Detections.empty()
+    
+    # Class 2: Prediction exists but no GT (false positive)
+    class_2_pred = Detections(
+        xyxy=np.array([[110, 110, 150, 150]], dtype=np.float64),
+        class_id=np.array([2]),
+        confidence=np.array([0.8]),
+    )
+    class_2_target = Detections.empty()
+    
+    metric = MeanAveragePrecision()
+    metric.update([class_0_det], [class_0_det])
+    metric.update([class_1_pred], [class_1_target])
+    metric.update([class_2_pred], [class_2_target])
+    result = metric.compute()
+    
+    # Should not have negative mAP
+    assert result.map50_95 >= 0.0
+    # Should be less than 1.0 due to missed detection and false positive
+    assert result.map50_95 < 1.0
+
+
+def test_empty_predictions_and_targets():
+    """Test completely empty predictions and targets"""
+    metric = MeanAveragePrecision()
+    metric.update([Detections.empty()], [Detections.empty()])
+    result = metric.compute()
+    
+    # Should handle empty case gracefully
+    assert result.map50_95 >= -1.0  # Can be -1 to indicate no data

--- a/test/metrics/test_mean_average_precision.py
+++ b/test/metrics/test_mean_average_precision.py
@@ -128,7 +128,7 @@ def test_scenario_2_missed_detection():
         data={"area": np.array([900])},
     )
 
-    # Medium object - area = 50*50 = 2500 (between 1024 and 9216) - no prediction (missed)
+    # Medium object - area = 50*50 = 2500 (between 1024 and 9216) - missed
     medium_target = Detections(
         xyxy=np.array([[10, 10, 60, 60]], dtype=np.float64),
         class_id=np.array([1]),

--- a/test/metrics/test_mean_average_precision.py
+++ b/test/metrics/test_mean_average_precision.py
@@ -1,0 +1,66 @@
+"""
+Tests for Mean Average Precision ID=0 bug fix
+"""
+import numpy as np
+import pytest
+
+from supervision.detection.core import Detections
+from supervision.metrics.mean_average_precision import MeanAveragePrecision
+
+
+def test_single_perfect_detection():
+    """Test that single perfect detection gets 1.0 mAP (not 0.0 due to ID=0 bug)"""
+    # Perfect detection (identical prediction and target)
+    detection = Detections(
+        xyxy=np.array([[10, 10, 50, 50]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.9])
+    )
+    
+    metric = MeanAveragePrecision()
+    metric.update([detection], [detection])
+    result = metric.compute()
+    
+    # Should be perfect 1.0 mAP, not 0.0 due to ID=0 bug
+    assert abs(result.map50_95 - 1.0) < 1e-6
+
+
+def test_multiple_perfect_detections():
+    """Test that multiple perfect detections get 1.0 mAP"""
+    # Multiple perfect detections in one image
+    detections = Detections(
+        xyxy=np.array([
+            [10, 10, 50, 50],
+            [100, 100, 140, 140],
+            [200, 200, 240, 240]
+        ], dtype=np.float64),
+        class_id=np.array([0, 0, 0]),
+        confidence=np.array([0.9, 0.9, 0.9])
+    )
+    
+    metric = MeanAveragePrecision()
+    metric.update([detections], [detections])
+    result = metric.compute()
+    
+    # Should be perfect 1.0 mAP
+    assert abs(result.map50_95 - 1.0) < 1e-6
+
+
+def test_batch_updates_perfect_detections():
+    """Test that batch updates with perfect detections get 1.0 mAP"""
+    # Single perfect detection for multiple batch updates
+    detection = Detections(
+        xyxy=np.array([[10, 10, 50, 50]], dtype=np.float64),
+        class_id=np.array([0]),
+        confidence=np.array([0.9])
+    )
+    
+    metric = MeanAveragePrecision()
+    # Add 3 batch updates
+    metric.update([detection], [detection])
+    metric.update([detection], [detection])
+    metric.update([detection], [detection])
+    result = metric.compute()
+    
+    # Should be perfect 1.0 mAP across all batches
+    assert abs(result.map50_95 - 1.0) < 1e-6 

--- a/test/metrics/test_mean_average_precision.py
+++ b/test/metrics/test_mean_average_precision.py
@@ -315,5 +315,12 @@ def test_empty_predictions_and_targets():
     metric.update([Detections.empty()], [Detections.empty()])
     result = metric.compute()
     
-    # Should handle empty case gracefully
-    assert result.map50_95 >= -1.0  # Can be -1 to indicate no data
+    # Should return -1 for no data (matching pycocotools behavior)
+    assert result.map50_95 == -1
+    assert result.map50 == -1
+    assert result.map75 == -1
+    
+    # All object size categories should also be -1
+    assert result.small_objects.map50_95 == -1
+    assert result.medium_objects.map50_95 == -1
+    assert result.large_objects.map50_95 == -1

--- a/test/metrics/test_mean_average_precision.py
+++ b/test/metrics/test_mean_average_precision.py
@@ -1,8 +1,8 @@
 """
 Tests for Mean Average Precision ID=0 bug fix
 """
+
 import numpy as np
-import pytest
 
 from supervision.detection.core import Detections
 from supervision.metrics.mean_average_precision import MeanAveragePrecision
@@ -14,13 +14,13 @@ def test_single_perfect_detection():
     detection = Detections(
         xyxy=np.array([[10, 10, 50, 50]], dtype=np.float64),
         class_id=np.array([0]),
-        confidence=np.array([0.9])
+        confidence=np.array([0.9]),
     )
-    
+
     metric = MeanAveragePrecision()
     metric.update([detection], [detection])
     result = metric.compute()
-    
+
     # Should be perfect 1.0 mAP, not 0.0 due to ID=0 bug
     assert abs(result.map50_95 - 1.0) < 1e-6
 
@@ -29,19 +29,18 @@ def test_multiple_perfect_detections():
     """Test that multiple perfect detections get 1.0 mAP"""
     # Multiple perfect detections in one image
     detections = Detections(
-        xyxy=np.array([
-            [10, 10, 50, 50],
-            [100, 100, 140, 140],
-            [200, 200, 240, 240]
-        ], dtype=np.float64),
+        xyxy=np.array(
+            [[10, 10, 50, 50], [100, 100, 140, 140], [200, 200, 240, 240]],
+            dtype=np.float64,
+        ),
         class_id=np.array([0, 0, 0]),
-        confidence=np.array([0.9, 0.9, 0.9])
+        confidence=np.array([0.9, 0.9, 0.9]),
     )
-    
+
     metric = MeanAveragePrecision()
     metric.update([detections], [detections])
     result = metric.compute()
-    
+
     # Should be perfect 1.0 mAP
     assert abs(result.map50_95 - 1.0) < 1e-6
 
@@ -52,15 +51,15 @@ def test_batch_updates_perfect_detections():
     detection = Detections(
         xyxy=np.array([[10, 10, 50, 50]], dtype=np.float64),
         class_id=np.array([0]),
-        confidence=np.array([0.9])
+        confidence=np.array([0.9]),
     )
-    
+
     metric = MeanAveragePrecision()
     # Add 3 batch updates
     metric.update([detection], [detection])
     metric.update([detection], [detection])
     metric.update([detection], [detection])
     result = metric.compute()
-    
+
     # Should be perfect 1.0 mAP across all batches
-    assert abs(result.map50_95 - 1.0) < 1e-6 
+    assert abs(result.map50_95 - 1.0) < 1e-6


### PR DESCRIPTION
# Description

This PR fixes an issue where Mean Average Precision (mAP) calculations could return negative values when certain object size categories have no data. The problem occurred because -1 sentinel values (used to indicate "no data") were being included in the mean calculation.

Notebook demonstrating the issue: https://colab.research.google.com/drive/1enb5xJ-28XLTw65GSr1ogCZl5OY7VFfF?usp=sharing

Note that this PR branches of #1895 to include the fix for always having the first ever object being a non-match. Merging that one first will slightly reduce the diff here.

### Problem

When computing mAP for specific object sizes (small/medium/large), if a category had no ground truth objects, the precision array would contain -1 values. These sentinel values were incorrectly included when calculating the mean, resulting in negative mAP scores instead of the expected -1 (no data) indicator.

This behavior didn't match pycocotools, which correctly returns:
- `0.0` for missed detections (GT exists but no predictions)
- `-1.0` for no data scenarios (no GT regardless of predictions)

Here's a notebook reproducing showing the pycocotools behaviour: https://colab.research.google.com/drive/1dyDgHDX68SMcHbCghCZTaHbrn0E8tvKL?usp=sharing

### Solution

1. **Added proper -1 sentinel value handling in `_accumulate` method**:
   - Use `np.ma.masked_equal` to exclude -1 values from mean calculations
   - Check if all values are masked (empty array) to prevent "mean of empty slice" warnings
   - Return -1 for categories with no data

2. **Fixed empty predictions handling**:
   - Added check in `load_predictions` to handle empty prediction lists without IndexError

3. **Refactored for DRY principle**:
   - Created helper function `compute_average_precision` to avoid code duplication
   - Applied consistently across all object size categories (all/small/medium/large)

## Testing

Added comprehensive test coverage for all pycocotools scenarios:
- ✅ Perfect detections → mAP = 1.0
- ✅ Missed detections (GT exists, no prediction) → mAP = 0.0
- ✅ False positives (no GT, prediction exists) → mAP = -1.0
- ✅ No data (no GT, no prediction) → mAP = -1.0
- ✅ Mixed scenarios with different object sizes
- ✅ Empty predictions and targets

All tests pass without warnings.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally, and running tests.

Also ran Model Eval with it. 

Before:
<img width="768" height="418" alt="image" src="https://github.com/user-attachments/assets/44bc65f9-5bc1-4fa4-8e7e-62e92bc6d713" />

After:
<img width="771" height="366" alt="image" src="https://github.com/user-attachments/assets/ced5dd40-0270-4d2a-8932-1f643d1629b2" />

Looks reasonable.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
