### PR TITLE
fix: border thickness parameter usage for `PercentageBarAnnotator`

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -2239,8 +2239,11 @@ class PercentageBarAnnotator(BaseAnnotator):
         self.position: Position = position
         self.color_lookup: ColorLookup = color_lookup
 
-        if border_thickness is None:
-            self.border_thickness = int(0.15 * self.height)
+        self.border_thickness = (
+            border_thickness
+            if border_thickness is not None
+            else int(0.15 * self.height)
+        )
 
     @ensure_cv2_image_for_annotation
     def annotate(


### PR DESCRIPTION
# Description

Fixes https://github.com/roboflow/supervision/issues/1905

List any dependencies that are required for this change.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Using the following script:

```python
from ultralytics import YOLO
import supervision as sv
from supervision.assets import download_assets, VideoAssets


download_assets(VideoAssets.PEOPLE_WALKING)
model = YOLO("yolov8m.pt")

box_annotator = sv.BoxAnnotator()
percentage_bar_annotator = sv.PercentageBarAnnotator(border_thickness=8)

def callback(frame, _):
    results = model(frame, verbose=False)[0]
    detections = sv.Detections.from_ultralytics(results)
    detections = detections[detections.class_id == 0]
    annotated_frame = box_annotator.annotate(
        scene=frame, detections=detections
    )
    annotated_frame = percentage_bar_annotator.annotate(
        scene=annotated_frame, detections=detections
    )
    return annotated_frame

sv.process_video(
    source_path="people-walking.mp4",
    target_path="output.mp4",
    callback=callback,
    show_progress=True,
    max_frames=100,
)
```