### PR TITLE
exposing `box_iou_batch`  in `supervision/detection/utils__init__.py`

### DIFF
--- a/supervision/detection/utils/__init__.py
+++ b/supervision/detection/utils/__init__.py
@@ -1,0 +1,3 @@
+from supervision.detection.utils.iou_and_nms import box_iou_batch
+
+__all__ = ["box_iou_batch"]


### PR DESCRIPTION
# Description

Many libraries depend on `supervision`, such as [trackers](http://github.com/roboflow/trackers).

In recent versions `0.26.0` and `0.26.1` of `supervision`, the function `box_iou_batch` was moved from:
`supervision.detection.utils.py` :arrow_right:  `supervision.detection.utils.iou_and_nms`.

As we can see in the links below:
- **v0.25.0**: [supervision/detection/utils.py](https://github.com/roboflow/supervision/blob/0.25.0/supervision/detection/utils.py)
- **v0.26.1**: [supervision/detection/utils/iou_and_nms.py](https://github.com/roboflow/supervision/blob/0.26.1/supervision/detection/utils/iou_and_nms.py)

This change is currently breaking the `trackers` library. One possible solution is to update the import path there, as proposed in [trackers PR 116](https://github.com/roboflow/trackers/pull/116/files). 

However, to preserve backward compatibility and avoid breaking downstream libraries, this PR re-exports `box_iou_batch`  via `__init__.py`.

This way, both the new and old import paths will remain valid:
- ✅ `from supervision.detection.utils import box_iou_batch` (legacy)
- ✅ `from supervision.detection.utils.iou_and_nms import box_iou_batch` (current)

This change avoids import errors and maintains compatibility, without affecting functionality or performance.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

