### PR TITLE
docs: update detection core with tips for using Gemini integration

### DIFF
--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -1471,7 +1471,8 @@ class Detections:
                 relative to image dimensions, scale to [0, 1000]. You need to convert
                 these normalized coordinates back to pixel coordinates based on your
                 original image size.
-                According to the [Gemini API documentation on image prompts](https://ai.google.dev/gemini-api/docs/vision?lang=python#image_prompts), when using
+                According to the [Gemini API documentation on image prompts](
+                https://ai.google.dev/gemini-api/docs/vision?lang=python#image_prompts), when using
                 a single image with text, the recommended approach is to place the text
                 prompt after the image part in the `contents` array (for example,
                 `contents=[image_part, text_part]`). This ordering has been shown to
@@ -1521,7 +1522,8 @@ class Detections:
                 including small, distant, or partially visible ones, and to return
                 tight bounding boxes.
 
-                According to the [Gemini API documentation on image prompts](https://ai.google.dev/gemini-api/docs/vision?hl=en),
+                According to the [Gemini API documentation on image prompts](
+                https://ai.google.dev/gemini-api/docs/vision?hl=en),
                 when using a single image with text, place the text prompt after the image
                 part in the `contents` array. For example, with the `google-genai` client:
 


### PR DESCRIPTION
# Description

On request of @SkalskiP at PR: [https://github.com/roboflow/notebooks/pull/384](url)

This PR improves the documentation regarding the ordering of content in requests that combine images with text prompts. Following Google's Gemini API best practices, text prompts are now placed after image parts in the contents array when using a single image with text.

## Type of change

-   [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

According to the [Gemini API documentation on image prompts](https://ai.google.dev/gemini-api/docs/files#single-image-prompts), when using a single image with text, the recommended approach is to place the text prompt after the image part in the contents array. This ordering has been shown to produce significantly better results in practice.

In our testing with Process & Instrument Diagrams (P&IDs) using object detection, this reordering led to drastically improved accuracy in bounding box positioning. While the object labels were already accurate, the spatial precision of detected elements improved considerably with the optimized prompt ordering

## Docs

-   [x] Docs updated? What were the changes: updated the tips for prompt engineering
