### PR TITLE
fix: AttributeError: 'numpy.int64' object has no attribute 'splitlines'

### DIFF
--- a/supervision/annotators/utils.py
+++ b/supervision/annotators/utils.py
@@ -175,7 +175,7 @@ def wrap_text(text: Any, max_line_length=None) -> list[str]:
         return text.splitlines() or [""]
 
     if max_line_length <= 0:
-        raise ValueError(f"max_line_length must be a positive integer")
+        raise ValueError("max_line_length must be a positive integer")
 
     paragraphs = text.split("\n")
     all_lines: list[str] = []

--- a/supervision/annotators/utils.py
+++ b/supervision/annotators/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import textwrap
 from enum import Enum
+from typing import Any
 
 import numpy as np
 
@@ -151,30 +152,36 @@ def resolve_color(
     return get_color_by_index(color=color, idx=idx)
 
 
-def wrap_text(text: str, max_line_length=None) -> list[str]:
+def wrap_text(text: Any, max_line_length=None) -> list[str]:
     """
-    Wraps text to the specified maximum line length, respecting existing newlines.
-    Uses the textwrap library for robust text wrapping.
+    Wrap `text` to the specified maximum line length, respecting existing
+    newlines. Falls back to str() if `text` is not already a string.
 
     Args:
-        text (str): The text to wrap.
+        text (Any): The text (or object) to wrap.
+        max_line_length (int | None): Maximum width for each wrapped line.
 
     Returns:
-        List[str]: A list of text lines after wrapping.
+        list[str]: Wrapped lines.
     """
 
     if not text:
         return [""]
 
+    if not isinstance(text, str):
+        text = str(text)
+
     if max_line_length is None:
         return text.splitlines() or [""]
 
+    if max_line_length <= 0:
+        raise ValueError(f"max_line_length must be a positive integer")
+
     paragraphs = text.split("\n")
-    all_lines = []
+    all_lines: list[str] = []
 
     for paragraph in paragraphs:
-        if not paragraph:
-            # Keep empty lines
+        if paragraph == "":
             all_lines.append("")
             continue
 
@@ -186,12 +193,9 @@ def wrap_text(text: str, max_line_length=None) -> list[str]:
             drop_whitespace=True,
         )
 
-        if wrapped:
-            all_lines.extend(wrapped)
-        else:
-            all_lines.append("")
+        all_lines.extend(wrapped or [""])
 
-    return all_lines if all_lines else [""]
+    return all_lines or [""]
 
 
 def validate_labels(labels: list[str] | None, detections: Detections):

--- a/test/annotators/test_utils.py
+++ b/test/annotators/test_utils.py
@@ -113,72 +113,29 @@ def test_resolve_color_idx(
 @pytest.mark.parametrize(
     "text, max_line_length, expected_result, exception",
     [
+        (None, None, [""], DoesNotRaise()),  # text is None
+        ("", None, [""], DoesNotRaise()),  # empty string
+        ("   \t  ", 3, [""], DoesNotRaise()),  # whitespace-only (spaces + tab)
+        (12345, None, ["12345"], DoesNotRaise()),  # plain integer
+        (-6789, None, ["-6789"], DoesNotRaise()),  # negative integer
+        (np.int64(1000), None, ["1000"], DoesNotRaise()),  # NumPy int64
+        ([1, 2, 3], None, ["[1, 2, 3]"], DoesNotRaise()),  # list to string
         (
-            None,
-            None,
-            [""],
-            DoesNotRaise()
-        ),  # text is None
-        (
-            "",
-            None,
-            [""],
-            DoesNotRaise()
-        ),  # empty string
-        (
-            "   \t  ",
-            3,
-            [""],
-            DoesNotRaise()
-        ),  # whitespace-only (spaces + tab)
-
-        (
-            12345,
-            None,
-            ["12345"],
-            DoesNotRaise()
-        ),  # plain integer
-        (
-            -6789,
-            None,
-            ["-6789"],
-            DoesNotRaise()
-        ),  # negative integer
-        (
-            np.int64(1000),
-            None,
-            ["1000"],
-            DoesNotRaise()
-        ),  # NumPy int64
-        (
-            [1, 2, 3],
-            None,
-            ["[1, 2, 3]"],
-            DoesNotRaise()
-        ),  # list to string
-
-        (
-            "When you play the game of thrones, you win or you die.\nFear cuts deeper than swords.\nA mind needs books as a sword needs a whetstone.", # noqa: E501
+            "When you play the game of thrones, you win or you die.\nFear cuts deeper than swords.\nA mind needs books as a sword needs a whetstone.",  # noqa: E501
             None,
             [
                 "When you play the game of thrones, you win or you die.",
                 "Fear cuts deeper than swords.",
                 "A mind needs books as a sword needs a whetstone.",
             ],
-            DoesNotRaise()
+            DoesNotRaise(),
         ),  # Game-of-Thrones quotes, multiline
-        (
-            "\n",
-            None,
-            [""],
-            DoesNotRaise()
-        ),  # single newline
-
+        ("\n", None, [""], DoesNotRaise()),  # single newline
         (
             "valarmorghulisvalardoharis",
             6,
             ["valarm", "orghul", "isvala", "rdohar", "is"],
-            DoesNotRaise()
+            DoesNotRaise(),
         ),  # long Valyrian phrase, wrapped
         (
             "Winter is coming\nFire and blood",
@@ -189,28 +146,21 @@ def test_resolve_color_idx(
                 "Fire and",
                 "blood",
             ],
-            DoesNotRaise()
+            DoesNotRaise(),
         ),  # mix of short/long with newline
-
         (
             "What is dead may never die",
             0,
             None,
-            pytest.raises(ValueError)
+            pytest.raises(ValueError),
         ),  # width 0 – invalid
         (
             "A Lannister always pays his debts",
             -1,
             None,
-            pytest.raises(ValueError)
+            pytest.raises(ValueError),
         ),  # width -1 – invalid
-
-        (
-            None,
-            10,
-            [""],
-            DoesNotRaise()
-        ),  # text None, width set
+        (None, 10, [""], DoesNotRaise()),  # text None, width set
     ],
 )
 def test_wrap_text(

--- a/test/annotators/test_utils.py
+++ b/test/annotators/test_utils.py
@@ -5,7 +5,7 @@ from contextlib import ExitStack as DoesNotRaise
 import numpy as np
 import pytest
 
-from supervision.annotators.utils import ColorLookup, resolve_color_idx
+from supervision.annotators.utils import ColorLookup, resolve_color_idx, wrap_text
 from supervision.detection.core import Detections
 from test.test_utils import mock_detections
 
@@ -107,4 +107,118 @@ def test_resolve_color_idx(
             detection_idx=detection_idx,
             color_lookup=color_lookup,
         )
+        assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "text, max_line_length, expected_result, exception",
+    [
+        (
+            None,
+            None,
+            [""],
+            DoesNotRaise()
+        ),  # text is None
+        (
+            "",
+            None,
+            [""],
+            DoesNotRaise()
+        ),  # empty string
+        (
+            "   \t  ",
+            3,
+            [""],
+            DoesNotRaise()
+        ),  # whitespace-only (spaces + tab)
+
+        (
+            12345,
+            None,
+            ["12345"],
+            DoesNotRaise()
+        ),  # plain integer
+        (
+            -6789,
+            None,
+            ["-6789"],
+            DoesNotRaise()
+        ),  # negative integer
+        (
+            np.int64(1000),
+            None,
+            ["1000"],
+            DoesNotRaise()
+        ),  # NumPy int64
+        (
+            [1, 2, 3],
+            None,
+            ["[1, 2, 3]"],
+            DoesNotRaise()
+        ),  # list to string
+
+        (
+            "When you play the game of thrones, you win or you die.\nFear cuts deeper than swords.\nA mind needs books as a sword needs a whetstone.", # noqa: E501
+            None,
+            [
+                "When you play the game of thrones, you win or you die.",
+                "Fear cuts deeper than swords.",
+                "A mind needs books as a sword needs a whetstone.",
+            ],
+            DoesNotRaise()
+        ),  # Game-of-Thrones quotes, multiline
+        (
+            "\n",
+            None,
+            [""],
+            DoesNotRaise()
+        ),  # single newline
+
+        (
+            "valarmorghulisvalardoharis",
+            6,
+            ["valarm", "orghul", "isvala", "rdohar", "is"],
+            DoesNotRaise()
+        ),  # long Valyrian phrase, wrapped
+        (
+            "Winter is coming\nFire and blood",
+            10,
+            [
+                "Winter is",
+                "coming",
+                "Fire and",
+                "blood",
+            ],
+            DoesNotRaise()
+        ),  # mix of short/long with newline
+
+        (
+            "What is dead may never die",
+            0,
+            None,
+            pytest.raises(ValueError)
+        ),  # width 0 – invalid
+        (
+            "A Lannister always pays his debts",
+            -1,
+            None,
+            pytest.raises(ValueError)
+        ),  # width -1 – invalid
+
+        (
+            None,
+            10,
+            [""],
+            DoesNotRaise()
+        ),  # text None, width set
+    ],
+)
+def test_wrap_text(
+    text: object,
+    max_line_length: int | None,
+    expected_result: list[str],
+    exception: Exception,
+) -> None:
+    with exception:
+        result = wrap_text(text=text, max_line_length=max_line_length)
         assert result == expected_result

--- a/test/annotators/test_utils.py
+++ b/test/annotators/test_utils.py
@@ -113,48 +113,13 @@ def test_resolve_color_idx(
 @pytest.mark.parametrize(
     "text, max_line_length, expected_result, exception",
     [
-        (
-            None,
-            None,
-            [""],
-            DoesNotRaise()
-        ),  # text is None
-        (
-            "",
-            None,
-            [""],
-            DoesNotRaise()
-        ),  # empty string
-        (
-            "   \t  ",
-            3,
-            [""],
-            DoesNotRaise()
-        ),  # whitespace-only (spaces + tab)
-        (
-            12345,
-            None,
-            ["12345"],
-            DoesNotRaise()
-        ),  # plain integer
-        (
-            -6789,
-            None,
-            ["-6789"],
-            DoesNotRaise()
-        ),  # negative integer
-        (
-            np.int64(1000),
-            None,
-            ["1000"],
-            DoesNotRaise()
-        ),  # NumPy int64
-        (
-            [1, 2, 3],
-            None,
-            ["[1, 2, 3]"],
-            DoesNotRaise()
-        ),  # list to string
+        (None, None, [""], DoesNotRaise()),  # text is None
+        ("", None, [""], DoesNotRaise()),  # empty string
+        ("   \t  ", 3, [""], DoesNotRaise()),  # whitespace-only (spaces + tab)
+        (12345, None, ["12345"], DoesNotRaise()),  # plain integer
+        (-6789, None, ["-6789"], DoesNotRaise()),  # negative integer
+        (np.int64(1000), None, ["1000"], DoesNotRaise()),  # NumPy int64
+        ([1, 2, 3], None, ["[1, 2, 3]"], DoesNotRaise()),  # list to string
         (
             "When you play the game of thrones, you win or you die.\nFear cuts deeper than swords.\nA mind needs books as a sword needs a whetstone.",  # noqa: E501
             None,

--- a/test/annotators/test_utils.py
+++ b/test/annotators/test_utils.py
@@ -113,13 +113,48 @@ def test_resolve_color_idx(
 @pytest.mark.parametrize(
     "text, max_line_length, expected_result, exception",
     [
-        (None, None, [""], DoesNotRaise()),  # text is None
-        ("", None, [""], DoesNotRaise()),  # empty string
-        ("   \t  ", 3, [""], DoesNotRaise()),  # whitespace-only (spaces + tab)
-        (12345, None, ["12345"], DoesNotRaise()),  # plain integer
-        (-6789, None, ["-6789"], DoesNotRaise()),  # negative integer
-        (np.int64(1000), None, ["1000"], DoesNotRaise()),  # NumPy int64
-        ([1, 2, 3], None, ["[1, 2, 3]"], DoesNotRaise()),  # list to string
+        (
+            None,
+            None,
+            [""],
+            DoesNotRaise()
+        ),  # text is None
+        (
+            "",
+            None,
+            [""],
+            DoesNotRaise()
+        ),  # empty string
+        (
+            "   \t  ",
+            3,
+            [""],
+            DoesNotRaise()
+        ),  # whitespace-only (spaces + tab)
+        (
+            12345,
+            None,
+            ["12345"],
+            DoesNotRaise()
+        ),  # plain integer
+        (
+            -6789,
+            None,
+            ["-6789"],
+            DoesNotRaise()
+        ),  # negative integer
+        (
+            np.int64(1000),
+            None,
+            ["1000"],
+            DoesNotRaise()
+        ),  # NumPy int64
+        (
+            [1, 2, 3],
+            None,
+            ["[1, 2, 3]"],
+            DoesNotRaise()
+        ),  # list to string
         (
             "When you play the game of thrones, you win or you die.\nFear cuts deeper than swords.\nA mind needs books as a sword needs a whetstone.",  # noqa: E501
             None,
@@ -153,13 +188,13 @@ def test_resolve_color_idx(
             0,
             None,
             pytest.raises(ValueError),
-        ),  # width 0 – invalid
+        ),  # width 0 - invalid
         (
             "A Lannister always pays his debts",
             -1,
             None,
             pytest.raises(ValueError),
-        ),  # width -1 – invalid
+        ),  # width -1 - invalid
         (None, 10, [""], DoesNotRaise()),  # text None, width set
     ],
 )


### PR DESCRIPTION
# Description

The example trackers code is currently throwing an `AttributeError: 'numpy.int64' object has no attribute 'splitlines'`. This PR resolves the issue.

```python
CONFIDENCE_THRESHOLD = 0.3
NMS_THRESHOLD = 0.3

SOURCE_VIDEO_PATH = "/content/bikes-1280x720-1.mp4"
TARGET_VIDEO_PATH = "/content/bikes-1280x720-1-result.mp4"

frame_samples = []

def callback(frame, i):
    result = model.infer(frame, confidence=CONFIDENCE_THRESHOLD)[0]
    detections = sv.Detections.from_inference(result).with_nms(threshold=NMS_THRESHOLD)
    detections = tracker.update(detections)

    print(detections.tracker_id)
    print(type(detections.tracker_id[0]))
    print(type(str(detections.tracker_id[0])))

    annotated_image = frame.copy()
    annotated_image = box_annotator.annotate(annotated_image, detections)
    annotated_image = trace_annotator.annotate(annotated_image, detections)
    annotated_image = label_annotator.annotate(annotated_image, detections, detections.tracker_id)

    if i % 30 == 0 and i != 0:
        frame_samples.append(annotated_image)

    return annotated_image

tracker.reset()

sv.process_video(
    source_path=SOURCE_VIDEO_PATH,
    target_path=TARGET_VIDEO_PATH,
    callback=callback,
    show_progress=True,
)
```

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
[/tmp/ipython-input-3880691708.py](https://localhost:8080/#) in <cell line: 0>()
     28 tracker.reset()
     29 
---> 30 sv.process_video(
     31     source_path=SOURCE_VIDEO_PATH,
     32     target_path=TARGET_VIDEO_PATH,

5 frames
[/usr/local/lib/python3.11/dist-packages/supervision/annotators/utils.py](https://localhost:8080/#) in wrap_text(text, max_line_length)
    168 
    169     if max_line_length is None:
--> 170         return text.splitlines() or [""]
    171 
    172     paragraphs = text.split("\n")

AttributeError: 'numpy.int64' object has no attribute 'splitlines'
```
