### PR TITLE
#1849 - elderberry

### DIFF
--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -594,7 +594,9 @@ class ColorAnnotator(BaseAnnotator):
                 if custom_color_lookup is None
                 else custom_color_lookup,
             )
-            effective_opacity = self.opacity * (color.a / 255 if hasattr(color, "a") else 1.0)
+            effective_opacity = self.opacity * (
+                color.a / 255 if hasattr(color, "a") else 1.0
+            )
             if effective_opacity >= 1:
                 cv2.rectangle(
                     img=scene,
@@ -613,7 +615,12 @@ class ColorAnnotator(BaseAnnotator):
                     thickness=-1,
                 )
                 cv2.addWeighted(
-                    overlay, effective_opacity, scene, 1 - effective_opacity, gamma=0, dst=scene
+                    overlay,
+                    effective_opacity,
+                    scene,
+                    1 - effective_opacity,
+                    gamma=0,
+                    dst=scene,
                 )
         return scene
 
@@ -914,24 +921,40 @@ class BoxCornerAnnotator(BaseAnnotator):
                 opacity = color.a / 255 if hasattr(color, "a") else 1.0
                 if opacity >= 1:
                     cv2.line(
-                        scene, (x, y), (x_end, y), color.as_bgr(), thickness=self.thickness
+                        scene,
+                        (x, y),
+                        (x_end, y),
+                        color.as_bgr(),
+                        thickness=self.thickness,
                     )
                 else:
                     overlay = scene.copy()
                     cv2.line(
-                        overlay, (x, y), (x_end, y), color.as_bgr(), thickness=self.thickness
+                        overlay,
+                        (x, y),
+                        (x_end, y),
+                        color.as_bgr(),
+                        thickness=self.thickness,
                     )
                     cv2.addWeighted(overlay, opacity, scene, 1 - opacity, 0, dst=scene)
 
                 y_end = y + self.corner_length if y == y1 else y - self.corner_length
                 if opacity >= 1:
                     cv2.line(
-                        scene, (x, y), (x, y_end), color.as_bgr(), thickness=self.thickness
+                        scene,
+                        (x, y),
+                        (x, y_end),
+                        color.as_bgr(),
+                        thickness=self.thickness,
                     )
                 else:
                     overlay = scene.copy()
                     cv2.line(
-                        overlay, (x, y), (x, y_end), color.as_bgr(), thickness=self.thickness
+                        overlay,
+                        (x, y),
+                        (x, y_end),
+                        color.as_bgr(),
+                        thickness=self.thickness,
                     )
                     cv2.addWeighted(overlay, opacity, scene, 1 - opacity, 0, dst=scene)
         return scene
@@ -1140,7 +1163,9 @@ class DotAnnotator(BaseAnnotator):
                     if custom_color_lookup is None
                     else custom_color_lookup,
                 )
-                outline_opacity = outline_color.a / 255 if hasattr(outline_color, "a") else 1.0
+                outline_opacity = (
+                    outline_color.a / 255 if hasattr(outline_color, "a") else 1.0
+                )
                 if outline_opacity >= 1:
                     cv2.circle(
                         scene,
@@ -1158,7 +1183,14 @@ class DotAnnotator(BaseAnnotator):
                         outline_color.as_bgr(),
                         self.outline_thickness,
                     )
-                    cv2.addWeighted(overlay2, outline_opacity, scene, 1 - outline_opacity, 0, dst=scene)
+                    cv2.addWeighted(
+                        overlay2,
+                        outline_opacity,
+                        scene,
+                        1 - outline_opacity,
+                        0,
+                        dst=scene,
+                    )
         return scene
 
 
@@ -1386,7 +1418,9 @@ class LabelAnnotator(_BaseLabelAnnotator):
                 xyxy=box_xyxy,
                 color=background_color.as_bgr(),
                 border_radius=self.border_radius,
-                opacity=(background_color.a / 255 if hasattr(background_color, "a") else 1.0),
+                opacity=(
+                    background_color.a / 255 if hasattr(background_color, "a") else 1.0
+                ),
             )
 
             # Handle multiline text
@@ -2329,7 +2363,9 @@ class TriangleAnnotator(BaseAnnotator):
                     if custom_color_lookup is None
                     else custom_color_lookup,
                 )
-                outline_opacity = outline_color.a / 255 if hasattr(outline_color, "a") else 1.0
+                outline_opacity = (
+                    outline_color.a / 255 if hasattr(outline_color, "a") else 1.0
+                )
                 if outline_opacity >= 1:
                     cv2.polylines(
                         scene,
@@ -2347,7 +2383,14 @@ class TriangleAnnotator(BaseAnnotator):
                         outline_color.as_bgr(),
                         thickness=self.outline_thickness,
                     )
-                    cv2.addWeighted(overlay2, outline_opacity, scene, 1 - outline_opacity, 0, dst=scene)
+                    cv2.addWeighted(
+                        overlay2,
+                        outline_opacity,
+                        scene,
+                        1 - outline_opacity,
+                        0,
+                        dst=scene,
+                    )
         return scene
 
 
@@ -2828,7 +2871,9 @@ class CropAnnotator(BaseAnnotator):
                     color=color.as_bgr(),
                     thickness=self.border_thickness,
                 )
-                cv2.addWeighted(overlay, border_opacity, scene, 1 - border_opacity, 0, dst=scene)
+                cv2.addWeighted(
+                    overlay, border_opacity, scene, 1 - border_opacity, 0, dst=scene
+                )
 
         return scene
 

--- a/supervision/detection/line_zone.py
+++ b/supervision/detection/line_zone.py
@@ -388,31 +388,70 @@ class LineZoneAnnotator:
         """
         line_start = line_counter.vector.start.as_xy_int_tuple()
         line_end = line_counter.vector.end.as_xy_int_tuple()
-        cv2.line(
-            frame,
-            line_start,
-            line_end,
-            self.color.as_bgr(),
-            self.thickness,
-            lineType=cv2.LINE_AA,
-            shift=0,
-        )
-        cv2.circle(
-            frame,
-            line_start,
-            radius=5,
-            color=self.text_color.as_bgr(),
-            thickness=-1,
-            lineType=cv2.LINE_AA,
-        )
-        cv2.circle(
-            frame,
-            line_end,
-            radius=5,
-            color=self.text_color.as_bgr(),
-            thickness=-1,
-            lineType=cv2.LINE_AA,
-        )
+        opacity = self.color.a / 255 if hasattr(self.color, "a") else 1.0
+        if opacity >= 1:
+            cv2.line(
+                frame,
+                line_start,
+                line_end,
+                self.color.as_bgr(),
+                self.thickness,
+                lineType=cv2.LINE_AA,
+                shift=0,
+            )
+        else:
+            overlay = frame.copy()
+            cv2.line(
+                overlay,
+                line_start,
+                line_end,
+                self.color.as_bgr(),
+                self.thickness,
+                lineType=cv2.LINE_AA,
+                shift=0,
+            )
+            cv2.addWeighted(overlay, opacity, frame, 1 - opacity, 0, dst=frame)
+        t_opacity = self.text_color.a / 255 if hasattr(self.text_color, "a") else 1.0
+        if t_opacity >= 1:
+            cv2.circle(
+                frame,
+                line_start,
+                radius=5,
+                color=self.text_color.as_bgr(),
+                thickness=-1,
+                lineType=cv2.LINE_AA,
+            )
+        else:
+            overlay2 = frame.copy()
+            cv2.circle(
+                overlay2,
+                line_start,
+                radius=5,
+                color=self.text_color.as_bgr(),
+                thickness=-1,
+                lineType=cv2.LINE_AA,
+            )
+            cv2.addWeighted(overlay2, t_opacity, frame, 1 - t_opacity, 0, dst=frame)
+        if t_opacity >= 1:
+            cv2.circle(
+                frame,
+                line_end,
+                radius=5,
+                color=self.text_color.as_bgr(),
+                thickness=-1,
+                lineType=cv2.LINE_AA,
+            )
+        else:
+            overlay3 = frame.copy()
+            cv2.circle(
+                overlay3,
+                line_end,
+                radius=5,
+                color=self.text_color.as_bgr(),
+                thickness=-1,
+                lineType=cv2.LINE_AA,
+            )
+            cv2.addWeighted(overlay3, t_opacity, frame, 1 - t_opacity, 0, dst=frame)
 
         in_text = f"{self.in_text}: {line_counter.in_count}"
         out_text = f"{self.out_text}: {line_counter.out_count}"

--- a/supervision/draw/color.py
+++ b/supervision/draw/color.py
@@ -57,14 +57,14 @@ def _validate_color_hex(color_hex: str):
     color_hex = color_hex.lstrip("#")
     if not all(c in "0123456789abcdefABCDEF" for c in color_hex):
         raise ValueError("Invalid characters in color hash")
-    if len(color_hex) not in (3, 6):
+    if len(color_hex) not in (3, 4, 6, 8):
         raise ValueError("Invalid length of color hash")
 
 
 @dataclass
 class Color:
     """
-    Represents a color in RGB format.
+    Represents a color in RGBA format.
 
     This class provides methods to work with colors, including creating colors from hex
     codes, converting colors to hex strings, RGB tuples, and BGR tuples.
@@ -97,6 +97,7 @@ class Color:
     r: int
     g: int
     b: int
+    a: int = 255
 
     @classmethod
     def from_hex(cls, color_hex: str) -> Color:
@@ -125,10 +126,16 @@ class Color:
         """
         _validate_color_hex(color_hex)
         color_hex = color_hex.lstrip("#")
-        if len(color_hex) == 3:
+        if len(color_hex) in (3, 4):
             color_hex = "".join(c * 2 for c in color_hex)
-        r, g, b = (int(color_hex[i : i + 2], 16) for i in range(0, 6, 2))
-        return cls(r, g, b)
+        if len(color_hex) == 6:
+            r, g, b = (int(color_hex[i : i + 2], 16) for i in range(0, 6, 2))
+            a = 255
+        else:
+            r, g, b, a = (
+                int(color_hex[i : i + 2], 16) for i in (0, 2, 4, 6)
+            )
+        return cls(r, g, b, a)
 
     @classmethod
     def from_rgb_tuple(cls, color_tuple: tuple[int, int, int]) -> Color:
@@ -191,7 +198,8 @@ class Color:
             # '#ffff00'
             ```
         """
-        return f"#{self.r:02x}{self.g:02x}{self.b:02x}"
+        base = f"#{self.r:02x}{self.g:02x}{self.b:02x}"
+        return base if self.a == 255 else f"{base}{self.a:02x}"
 
     def as_rgb(self) -> tuple[int, int, int]:
         """
@@ -227,6 +235,23 @@ class Color:
         """
         return self.b, self.g, self.r
 
+    def as_rgba(self) -> tuple[int, int, int, int]:
+        """
+        Returns the color as an RGBA tuple.
+
+        Returns:
+            Tuple[int, int, int, int]: RGBA tuple.
+
+        Example:
+            ```python
+            import supervision as sv
+
+            sv.Color(r=255, g=255, b=0, a=128).as_rgba()
+            # (255, 255, 0, 128)
+            ```
+        """
+        return self.r, self.g, self.b, self.a
+
     @classproperty
     def WHITE(cls) -> Color:
         return Color.from_hex("#FFFFFF")
@@ -260,7 +285,7 @@ class Color:
         return Color.from_hex("#A351FB")
 
     def __hash__(self):
-        return hash((self.r, self.g, self.b))
+        return hash((self.r, self.g, self.b, self.a))
 
     def __eq__(self, other):
         return (
@@ -268,6 +293,7 @@ class Color:
             and self.r == other.r
             and self.g == other.g
             and self.b == other.b
+            and self.a == other.a
         )
 
 

--- a/supervision/draw/color.py
+++ b/supervision/draw/color.py
@@ -132,9 +132,7 @@ class Color:
             r, g, b = (int(color_hex[i : i + 2], 16) for i in range(0, 6, 2))
             a = 255
         else:
-            r, g, b, a = (
-                int(color_hex[i : i + 2], 16) for i in (0, 2, 4, 6)
-            )
+            r, g, b, a = (int(color_hex[i : i + 2], 16) for i in (0, 2, 4, 6))
         return cls(r, g, b, a)
 
     @classmethod

--- a/supervision/draw/utils.py
+++ b/supervision/draw/utils.py
@@ -185,7 +185,9 @@ def draw_rounded_rectangle(
             thickness=-1,
         )
     if target is not scene:
-        cv2.addWeighted(target, effective_opacity, scene, 1 - effective_opacity, 0, dst=scene)
+        cv2.addWeighted(
+            target, effective_opacity, scene, 1 - effective_opacity, 0, dst=scene
+        )
     return scene
 
 

--- a/supervision/key_points/annotators.py
+++ b/supervision/key_points/annotators.py
@@ -86,13 +86,25 @@ class VertexAnnotator(BaseKeyPointAnnotator):
 
         for xy in key_points.xy:
             for x, y in xy:
-                cv2.circle(
-                    img=scene,
-                    center=(int(x), int(y)),
-                    radius=self.radius,
-                    color=self.color.as_bgr(),
-                    thickness=-1,
-                )
+                opacity = self.color.a / 255 if hasattr(self.color, "a") else 1.0
+                if opacity >= 1:
+                    cv2.circle(
+                        img=scene,
+                        center=(int(x), int(y)),
+                        radius=self.radius,
+                        color=self.color.as_bgr(),
+                        thickness=-1,
+                    )
+                else:
+                    overlay = scene.copy()
+                    cv2.circle(
+                        img=overlay,
+                        center=(int(x), int(y)),
+                        radius=self.radius,
+                        color=self.color.as_bgr(),
+                        thickness=-1,
+                    )
+                    cv2.addWeighted(overlay, opacity, scene, 1 - opacity, 0, dst=scene)
 
         return scene
 
@@ -178,13 +190,25 @@ class EdgeAnnotator(BaseKeyPointAnnotator):
                 if missing_a or missing_b:
                     continue
 
-                cv2.line(
-                    img=scene,
-                    pt1=(int(xy_a[0]), int(xy_a[1])),
-                    pt2=(int(xy_b[0]), int(xy_b[1])),
-                    color=self.color.as_bgr(),
-                    thickness=self.thickness,
-                )
+                opacity = self.color.a / 255 if hasattr(self.color, "a") else 1.0
+                if opacity >= 1:
+                    cv2.line(
+                        img=scene,
+                        pt1=(int(xy_a[0]), int(xy_a[1])),
+                        pt2=(int(xy_b[0]), int(xy_b[1])),
+                        color=self.color.as_bgr(),
+                        thickness=self.thickness,
+                    )
+                else:
+                    overlay = scene.copy()
+                    cv2.line(
+                        img=overlay,
+                        pt1=(int(xy_a[0]), int(xy_a[1])),
+                        pt2=(int(xy_b[0]), int(xy_b[1])),
+                        color=self.color.as_bgr(),
+                        thickness=self.thickness,
+                    )
+                    cv2.addWeighted(overlay, opacity, scene, 1 - opacity, 0, dst=scene)
 
         return scene
 

--- a/test/draw/test_color.py
+++ b/test/draw/test_color.py
@@ -18,9 +18,11 @@ from supervision.draw.color import Color
         ("0f0", Color.GREEN, DoesNotRaise()),
         ("00f", Color.BLUE, DoesNotRaise()),
         ("#808000", Color(r=128, g=128, b=0), DoesNotRaise()),
+        ("#ff00ff80", Color(r=255, g=0, b=255, a=128), DoesNotRaise()),
+        ("f0f8", Color(r=255, g=0, b=255, a=136), DoesNotRaise()),
         ("", None, pytest.raises(ValueError)),
         ("00", None, pytest.raises(ValueError)),
-        ("0000", None, pytest.raises(ValueError)),
+        ("00000", None, pytest.raises(ValueError)),
         ("0000000", None, pytest.raises(ValueError)),
         ("ffg", None, pytest.raises(ValueError)),
     ],
@@ -42,6 +44,7 @@ def test_color_from_hex(
         (Color.GREEN, "#00ff00", DoesNotRaise()),
         (Color.BLUE, "#0000ff", DoesNotRaise()),
         (Color(r=128, g=128, b=0), "#808000", DoesNotRaise()),
+        (Color(r=255, g=0, b=255, a=128), "#ff00ff80", DoesNotRaise()),
     ],
 )
 def test_color_as_hex(
@@ -50,3 +53,8 @@ def test_color_as_hex(
     with exception:
         result = color.as_hex()
         assert result == expected_result
+
+
+def test_color_as_rgba() -> None:
+    color = Color(r=10, g=20, b=30, a=40)
+    assert color.as_rgba() == (10, 20, 30, 40)


### PR DESCRIPTION
# Description

Changes implemented

- Hex parsing and Color class
  - Updated `supervision/draw/color.py`:
    - `_validate_color_hex` now allows lengths 3, 4, 6, 8.
    - `Color` dataclass extended with `a: int = 255`.
    - `Color.from_hex` supports `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`.
    - `as_hex()` returns `#RRGGBB` when `a == 255` else `#RRGGBBAA`.
    - Added `as_rgba()`; kept `as_rgb()` unchanged.
    - Equality and hashing now include `a`.

- Drawing utilities honor alpha
  - Updated `supervision/draw/utils.py` to blend with alpha (using an overlay + `cv2.addWeighted`) when `color.a != 255`:
    - `draw_line`, `draw_rectangle`, `draw_polygon`.
    - `draw_filled_rectangle` and `draw_filled_polygon` combine explicit opacity param with `color.a` via multiplication.
    - `draw_rounded_rectangle` gained an optional `opacity` param (default 1.0) and blends accordingly.
    - `draw_text` background already uses `draw_filled_rectangle`, so it benefits from alpha automatically.

- Annotators draw with opacity when Color has alpha
  - Updated `supervision/annotators/core.py` to honor `Color.a` via overlay blending for calls that render with OpenCV:
    - `BoxAnnotator`, `OrientedBoxAnnotator`, `EllipseAnnotator`, `BoxCornerAnnotator`, `DotAnnotator`, `TraceAnnotator`, `TriangleAnnotator`, `RoundBoxAnnotator`, `PercentageBarAnnotator`.
    - `ColorAnnotator` now blends per detection and multiplies annotator `opacity` by the color’s alpha.
    - `LabelAnnotator`’s internal `draw_rounded_rectangle` gained an optional `opacity` and now receives `background_color.a / 255`.
    - Kept class signatures unchanged.
  - Updated `supervision/detection/line_zone.py` and `supervision/key_points/annotators.py` to blend for lines/circles when alpha is present.

- Tests
  - Extended `test/draw/test_color.py`:
    - Support for 4-/8-digit hex inputs, including alpha.
    - `as_hex()` with alpha produces `#RRGGBBAA`.
    - Added `test_color_as_rgba` for tuple output.
    - Adjusted invalid-length tests to reflect allowed lengths 3, 4, 6, 8.

- Docs
  - Updated `Color` docstrings to indicate RGBA and how 4-/8-digit hex is parsed; added `as_rgba` docstring.

What I validated (5–7 sources distilled to the 1–2 most likely + validation)

- Possible sources:
  - Hex validator rejected 4/8 digits.
  - `Color` lacked `a`.
  - `from_hex` didn’t parse 4/8-digit forms.
  - `as_hex` didn’t emit alpha.
  - Drawing utilities ignored alpha.
  - Annotators rendered with OpenCV ignoring opacity.
  - Tests/docs didn’t cover the new behavior.

- Most likely root causes:
  - The validator and `from_hex` support were missing; annotators didn’t factor color alpha into rendering.

- Validation added:
  - Unit tests covering 4-/8-digit hex, `as_hex` with alpha, and `as_rgba`.
  - Lints passed on all changed files.

Notes and assumptions

- Where annotators use OpenCV primitives, alpha is respected via overlay blending without changing public signatures.
- For PIL-based `RichLabelAnnotator`, background fill uses RGB (PIL `ImageDraw` fill); alpha blending for that path is not changed in this pass.


## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

no - part of llm testing with Joseph
