### PR TITLE
#1929 carrot

### DIFF
--- a/docs/utils/video.md
+++ b/docs/utils/video.md
@@ -2,34 +2,63 @@
 comments: true
 ---
 
-# Video Utils
+# Video API (v2)
 
-<div class="md-typeset">
-    <h2><a href="#supervision.utils.video.VideoInfo">VideoInfo</a></h2>
-</div>
+The new unified video interface lives in `supervision.Video` and is **backend-agnostic**. It supersedes the helpers previously found in `supervision.utils.video`.
 
-:::supervision.utils.video.VideoInfo
+## Quick-start
 
-<div class="md-typeset">
-    <h2><a href="#supervision.utils.video.VideoSink">VideoSink</a></h2>
-</div>
+```python
+import supervision as sv
 
-:::supervision.utils.video.VideoSink
+# Static video
+video = sv.Video("example.mp4")
+print(video.info)
 
-<div class="md-typeset">
-    <h2><a href="#supervision.utils.video.FPSMonitor">FPSMonitor</a></h2>
-</div>
+# Iterate with stride & resize
+for frame in video.frames(stride=5, resolution_wh=(1280, 720)):
+    ...
 
-:::supervision.utils.video.FPSMonitor
+# Process and save
+video.save(
+    "blurred.mp4",
+    callback=lambda f, i: cv2.GaussianBlur(f, (11, 11), 0),
+    show_progress=True,
+)
+```
 
-<div class="md-typeset">
-    <h2><a href="#supervision.utils.video.get_video_frames_generator">get_video_frames_generator</a></h2>
-</div>
+## `sv.Video` reference
 
-:::supervision.utils.video.get_video_frames_generator
+::: supervision.video.Video
 
-<div class="md-typeset">
-    <h2><a href="#supervision.utils.video.process_video">process_video</a></h2>
-</div>
+## `sv.VideoInfo` reference
 
-:::supervision.utils.video.process_video
+::: supervision.video.common.VideoInfo
+
+## Backends
+
+`Video` delegates decoding/encoding to pluggable backends. Two are bundled:
+
+| Name   | Package  | Notes                               |
+| ------ | -------- | ----------------------------------- |
+| opencv | OpenCV   | Default. Fast, ubiquitous.          |
+| pyav   | PyAV/FFmpeg | Optional, install `pip install av` |
+
+Select backend via the constructor:
+
+```python
+sv.Video("clip.mkv", backend="pyav")
+```
+
+## Writing frames manually
+
+```python
+src = sv.Video("input.mp4")
+with src.sink("out.mp4") as sink:
+    for fr in src.frames():
+        sink.write(fr)
+```
+
+## Legacy helpers
+
+Functions and classes in `supervision.utils.video` are **deprecated** and will be removed in 5 releases. They transparently wrap the new API and emit a `SupervisionWarnings` warning. Migrate as soon as convenient.

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -128,14 +128,16 @@ from supervision.utils.image import (
     scale_image,
 )
 from supervision.utils.notebook import plot_image, plot_images_grid
-from supervision.video import Video, VideoInfo
 from supervision.utils.video import (
     FPSMonitor,
-    VideoInfo as _DeprecatedVideoInfo,
     VideoSink,
     get_video_frames_generator,
     process_video,
 )
+from supervision.utils.video import (
+    VideoInfo as _DeprecatedVideoInfo,
+)
+from supervision.video import Video, VideoInfo
 
 __all__ = [
     "LMM",

--- a/supervision/__init__.py
+++ b/supervision/__init__.py
@@ -128,9 +128,10 @@ from supervision.utils.image import (
     scale_image,
 )
 from supervision.utils.notebook import plot_image, plot_images_grid
+from supervision.video import Video, VideoInfo
 from supervision.utils.video import (
     FPSMonitor,
-    VideoInfo,
+    VideoInfo as _DeprecatedVideoInfo,
     VideoSink,
     get_video_frames_generator,
     process_video,
@@ -192,6 +193,7 @@ __all__ = [
     "TriangleAnnotator",
     "VertexAnnotator",
     "VertexLabelAnnotator",
+    "Video",
     "VideoInfo",
     "VideoSink",
     "approximate_polygon",

--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -9,8 +9,8 @@ import cv2
 import numpy as np
 from tqdm.auto import tqdm
 
-from supervision.video import Video as _NewVideo
 from supervision.utils.internal import deprecated, warn_deprecated
+from supervision.video import Video as _NewVideo
 
 warn_deprecated(
     "The module 'supervision.utils.video' is deprecated and will be removed in a future release. "
@@ -54,6 +54,7 @@ class VideoInfo:
     @classmethod
     def from_video_path(cls, video_path: str) -> VideoInfo:
         from supervision.video import Video as _NewVideo
+
         video = _NewVideo(video_path)
         return video.info
 
@@ -180,6 +181,7 @@ def get_video_frames_generator(
         ```
     """
     from supervision.video import Video as _NewVideo
+
     vid = _NewVideo(source_path)
     yield from vid.frames(stride=stride, start=start, end=end)
 
@@ -226,6 +228,7 @@ def process_video(
     frame_iter = vid.frames()
     if max_frames is not None:
         from itertools import islice
+
         frame_iter = islice(frame_iter, max_frames)
     writer_ctx = vid.sink(target_path)
     iterator = frame_iter

--- a/supervision/video/__init__.py
+++ b/supervision/video/__init__.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Callable, Iterator, Any
+from typing import Any
+from collections.abc import Callable
 
 import cv2  # Only needed for resize utility even when using PyAV backend
 import numpy as np
 from tqdm.auto import tqdm
 
 from supervision.utils.internal import warn_deprecated
-from supervision.video.common import VideoInfo, Writer
 from supervision.video.backends.base import Backend
 from supervision.video.backends.opencv_backend import OpenCVBackend
 from supervision.video.backends.pyav_backend import PyAVBackend
+from supervision.video.common import VideoInfo, Writer
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +119,9 @@ class Video:
             try:
                 self._backend.seek(self._handle, start)
             except Exception as e:
-                logger.debug("Backend seek failed (%s). Falling back to iterative seek.", e)
+                logger.debug(
+                    "Backend seek failed (%s). Falling back to iterative seek.", e
+                )
                 # fallback: iterative grabbing
                 for _ in range(start):
                     ok = self._backend.grab(self._handle)
@@ -220,4 +224,3 @@ class Video:
         warn_deprecated(
             f"{name} will be removed in a future release. Use the new supervision.Video class instead."
         )
-

--- a/supervision/video/__init__.py
+++ b/supervision/video/__init__.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Callable, Iterator, Any
+
+import cv2  # Only needed for resize utility even when using PyAV backend
+import numpy as np
+from tqdm.auto import tqdm
+
+from supervision.utils.internal import warn_deprecated
+from supervision.video.common import VideoInfo, Writer
+from supervision.video.backends.base import Backend
+from supervision.video.backends.opencv_backend import OpenCVBackend
+from supervision.video.backends.pyav_backend import PyAVBackend
+
+logger = logging.getLogger(__name__)
+
+# Public API -----------------------------------------------------------------
+__all__ = [
+    "Video",
+    "VideoInfo",
+]
+
+
+_BACKENDS: dict[str, Backend] = {
+    "opencv": OpenCVBackend(),
+    "pyav": PyAVBackend(),
+}
+
+
+def _get_backend(name: str) -> Backend:
+    if name not in _BACKENDS:
+        raise ValueError(
+            f"Unknown video backend '{name}'. Supported backends: {list(_BACKENDS)}"
+        )
+    return _BACKENDS[name]
+
+
+class _WriterContext:
+    """Context manager around backend *Writer*."""
+
+    def __init__(self, writer: Writer):
+        self._writer = writer
+
+    def __enter__(self):
+        return self
+
+    def write(self, frame: np.ndarray) -> None:
+        self._writer.write(frame)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._writer.close()
+
+
+class Video:
+    """Unified abstraction for reading and writing videos.
+
+    The class acts as a thin wrapper delegating heavy-lifting to backend
+    implementations (OpenCV by default). It provides convenient helpers for
+    iterating over frames, slicing, resizing on-the-fly and saving processed
+    videos.
+    """
+
+    def __init__(self, source: Any, *, backend: str = "opencv") -> None:
+        self._backend_name = backend.lower()
+        self._backend: Backend = _get_backend(self._backend_name)
+        self._handle = self._backend.open(source)
+        self._info = self._backend.info(self._handle)
+        self._source = source  # keep for reference
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+    @property
+    def info(self) -> VideoInfo:
+        """Return :class:`VideoInfo` describing the stream."""
+
+        return self._info
+
+    # ------------------------------------------------------------------
+    # Iteration helpers
+    # ------------------------------------------------------------------
+    def __iter__(self) -> Iterator[np.ndarray]:
+        """Iterate over **all** frames in the stream."""
+
+        while True:
+            success, frame = self._backend.read(self._handle)
+            if not success:
+                break
+            yield frame
+
+    def frames(
+        self,
+        *,
+        stride: int = 1,
+        start: int = 0,
+        end: int | None = None,
+        resolution_wh: tuple[int, int] | None = None,
+    ) -> Iterator[np.ndarray]:
+        """Advanced frame generator.
+
+        Parameters
+        ----------
+        stride:
+            Return every *stride*-th frame. *1* returns consecutive frames.
+        start:
+            Frame index to start reading from (inclusive).
+        end:
+            Frame index to stop before (exclusive). ``None`` means *read to end*.
+        resolution_wh:
+            Optionally resize every returned frame to this *(width, height)* while
+            maintaining **BGR** channel order.
+        """
+
+        if start:
+            try:
+                self._backend.seek(self._handle, start)
+            except Exception as e:
+                logger.debug("Backend seek failed (%s). Falling back to iterative seek.", e)
+                # fallback: iterative grabbing
+                for _ in range(start):
+                    ok = self._backend.grab(self._handle)
+                    if not ok:
+                        return  # out-of-stream
+
+        idx = start
+        while True:
+            success, frame = self._backend.read(self._handle)
+            if not success:
+                break
+            if end is not None and idx >= end:
+                break
+
+            if resolution_wh is not None:
+                frame = cv2.resize(frame, resolution_wh)
+            yield frame
+
+            # skip *stride-1* frames via grab to reduce decoding cost
+            for _ in range(stride - 1):
+                idx += 1
+                if end is not None and idx >= end:
+                    break
+                ok = self._backend.grab(self._handle)
+                if not ok:
+                    break
+            idx += 1
+
+    # ------------------------------------------------------------------
+    # Saving helpers
+    # ------------------------------------------------------------------
+    def save(
+        self,
+        target_path: str,
+        *,
+        callback: Callable[[np.ndarray, int], np.ndarray],
+        show_progress: bool = False,
+        fps: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        codec: str = "mp4v",
+    ) -> None:
+        """Process the stream frame-by-frame and save as a new video.
+
+        The *callback* is executed **synchronously** for every frame and must
+        return a processed frame with the **same resolution** as provided to the
+        writer.
+        """
+
+        # Determine target info -------------------------------------------------
+        target_info = VideoInfo(
+            width=width or self._info.width,
+            height=height or self._info.height,
+            fps=fps or self._info.fps,
+        )
+
+        writer = self._backend.writer(target_path, info=target_info, codec=codec)
+
+        frame_iter = self.frames()
+        if show_progress:
+            total = self._info.total_frames
+            frame_iter = tqdm(frame_iter, total=total, desc="Saving video")
+
+        for i, frame in enumerate(frame_iter):
+            processed = callback(frame, i)
+            writer.write(processed)
+        writer.close()
+
+    # ------------------------------------------------------------------
+    # Context helpers
+    # ------------------------------------------------------------------
+    def sink(
+        self, target_path: str, *, info: VideoInfo | None = None, codec: str = "mp4v"
+    ) -> _WriterContext:
+        """Return a context manager for manually writing frames."""
+
+        return _WriterContext(
+            self._backend.writer(target_path, info or self._info, codec=codec)
+        )
+
+    # ------------------------------------------------------------------
+    # Cleanup helpers
+    # ------------------------------------------------------------------
+    def release(self):
+        """Release underlying handle (if applicable)."""
+
+        # Only OpenCV backend currently needs explicit release
+        release_func = getattr(self._handle, "release", None)
+        if callable(release_func):
+            release_func()
+
+    def __del__(self):
+        self.release()
+
+    # ------------------------------------------------------------------
+    # Legacy helpers bridging old API
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _warn_deprecated_old_api(name: str):
+        warn_deprecated(
+            f"{name} will be removed in a future release. Use the new supervision.Video class instead."
+        )
+

--- a/supervision/video/backends/base.py
+++ b/supervision/video/backends/base.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import numpy as np
+
+from supervision.video.common import VideoInfo, Writer
+
+
+class Backend(Protocol):
+    """Protocol that every decoding/encoding backend must follow."""
+
+    # ---------------------------------------------------------------------
+    # Lifecycle
+    # ---------------------------------------------------------------------
+    def open(self, source: Any):  # pragma: no cover
+        """Open the *source* and return an opaque handle.
+
+        The *source* can be anything accepted by the backend (file path, RTSP
+        url, integer camera index, etc.). The returned *handle* MUST be passed
+        to any other backend method.
+        """
+
+        ...
+
+    def info(self, handle: Any) -> VideoInfo:  # pragma: no cover
+        """Return :class:`~supervision.video.common.VideoInfo` for the opened stream."""
+
+        ...
+
+    # ------------------------------------------------------------------
+    # Reading
+    # ------------------------------------------------------------------
+    def read(self, handle: Any) -> tuple[bool, np.ndarray]:  # pragma: no cover
+        """Return ``(success, frame)`` where *frame* is a **BGR** image."""
+
+        ...
+
+    def grab(self, handle: Any) -> bool:  # pragma: no cover
+        """Skip a single frame. Return *False* if grabbing failed/end-of-stream."""
+
+        ...
+
+    def seek(self, handle: Any, frame_idx: int) -> None:  # pragma: no cover
+        """Seek to *frame_idx* from the start of the stream."""
+
+        ...
+
+    # ------------------------------------------------------------------
+    # Writing
+    # ------------------------------------------------------------------
+    def writer(self, path: str, info: VideoInfo, codec: str = "mp4v") -> Writer:  # pragma: no cover
+        """Return a :class:`Writer` instance for saving frames."""
+
+        ...
+

--- a/supervision/video/backends/base.py
+++ b/supervision/video/backends/base.py
@@ -49,8 +49,9 @@ class Backend(Protocol):
     # ------------------------------------------------------------------
     # Writing
     # ------------------------------------------------------------------
-    def writer(self, path: str, info: VideoInfo, codec: str = "mp4v") -> Writer:  # pragma: no cover
+    def writer(
+        self, path: str, info: VideoInfo, codec: str = "mp4v"
+    ) -> Writer:  # pragma: no cover
         """Return a :class:`Writer` instance for saving frames."""
 
         ...
-

--- a/supervision/video/backends/opencv_backend.py
+++ b/supervision/video/backends/opencv_backend.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import cv2
+import numpy as np
+
+from supervision.video.common import VideoInfo, Writer
+from supervision.video.backends.base import Backend
+
+
+class _OpenCVWriter:
+    """Simple wrapper around :class:`cv2.VideoWriter` implementing ``Writer``."""
+
+    def __init__(self, path: str, info: VideoInfo, codec: str) -> None:
+        fourcc = cv2.VideoWriter_fourcc(*codec)
+        self._writer = cv2.VideoWriter(path, fourcc, info.fps, info.resolution_wh)
+        if not self._writer.isOpened():
+            raise RuntimeError(f"Failed to open VideoWriter at {path} using codec {codec}.")
+
+    def write(self, frame: np.ndarray) -> None:  # type: ignore[override]
+        self._writer.write(frame)
+
+    def close(self) -> None:  # type: ignore[override]
+        self._writer.release()
+
+
+class OpenCVBackend(Backend):
+    """Backend that relies on the high-level OpenCV *cv2* API."""
+
+    # The backend keeps no state – all info is inside the *handle* returned by
+    # :py:meth:`open` (a :class:`cv2.VideoCapture` instance).
+
+    # ------------------------------------------------------------------
+    # Lifecycle helpers
+    # ------------------------------------------------------------------
+    def open(self, source: Any) -> cv2.VideoCapture:  # type: ignore[override]
+        cap = cv2.VideoCapture(source)
+        if not cap.isOpened():
+            raise RuntimeError(f"Unable to open video source: {source}")
+        return cap
+
+    def info(self, handle: cv2.VideoCapture) -> VideoInfo:  # type: ignore[override]
+        width = int(handle.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(handle.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        fps = handle.get(cv2.CAP_PROP_FPS)
+        # Guard against some cameras returning 0 for fps
+        fps = int(fps) if fps and fps > 0 else 30
+        total = int(handle.get(cv2.CAP_PROP_FRAME_COUNT))
+        total = total if total > 0 else None
+        return VideoInfo(width=width, height=height, fps=fps, total_frames=total)
+
+    # ------------------------------------------------------------------
+    # Reading helpers
+    # ------------------------------------------------------------------
+    def read(self, handle: cv2.VideoCapture):  # type: ignore[override]
+        return handle.read()
+
+    def grab(self, handle: cv2.VideoCapture):  # type: ignore[override]
+        return handle.grab()
+
+    def seek(self, handle: cv2.VideoCapture, frame_idx: int):  # type: ignore[override]
+        handle.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
+
+    # ------------------------------------------------------------------
+    # Writing helpers
+    # ------------------------------------------------------------------
+    def writer(self, path: str, info: VideoInfo, codec: str = "mp4v") -> Writer:  # type: ignore[override]
+        return _OpenCVWriter(path=path, info=info, codec=codec)
+

--- a/supervision/video/backends/opencv_backend.py
+++ b/supervision/video/backends/opencv_backend.py
@@ -5,8 +5,8 @@ from typing import Any
 import cv2
 import numpy as np
 
-from supervision.video.common import VideoInfo, Writer
 from supervision.video.backends.base import Backend
+from supervision.video.common import VideoInfo, Writer
 
 
 class _OpenCVWriter:
@@ -16,7 +16,9 @@ class _OpenCVWriter:
         fourcc = cv2.VideoWriter_fourcc(*codec)
         self._writer = cv2.VideoWriter(path, fourcc, info.fps, info.resolution_wh)
         if not self._writer.isOpened():
-            raise RuntimeError(f"Failed to open VideoWriter at {path} using codec {codec}.")
+            raise RuntimeError(
+                f"Failed to open VideoWriter at {path} using codec {codec}."
+            )
 
     def write(self, frame: np.ndarray) -> None:  # type: ignore[override]
         self._writer.write(frame)
@@ -67,4 +69,3 @@ class OpenCVBackend(Backend):
     # ------------------------------------------------------------------
     def writer(self, path: str, info: VideoInfo, codec: str = "mp4v") -> Writer:  # type: ignore[override]
         return _OpenCVWriter(path=path, info=info, codec=codec)
-

--- a/supervision/video/backends/pyav_backend.py
+++ b/supervision/video/backends/pyav_backend.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+import numpy as np
+
+from supervision.video.common import VideoInfo, Writer
+from supervision.video.backends.base import Backend
+
+# PyAV is an optional dependency – we import lazily and fail with clear message.
+try:
+    import av  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    av = None  # type: ignore
+
+
+class _PyAVWriter(Writer):
+    """Simple PyAV writer wrapping a mux and encoded stream."""
+
+    def __init__(self, path: str, info: VideoInfo, codec: str):
+        if av is None:
+            raise RuntimeError("PyAV is not installed. Install with `pip install av`." )
+        self._container = av.open(path, mode="w")
+        self._stream = self._container.add_stream(codec, rate=info.fps)
+        self._stream.width = info.width
+        self._stream.height = info.height
+        self._stream.pix_fmt = "yuv420p"
+
+    def write(self, frame: np.ndarray) -> None:  # type: ignore[override]
+        frame_rgb = frame[:, :, ::-1]  # BGR to RGB
+        av_frame = av.VideoFrame.from_ndarray(frame_rgb, format="rgb24")
+        for packet in self._stream.encode(av_frame):
+            self._container.mux(packet)
+
+    def close(self) -> None:  # type: ignore[override]
+        # flush encoder
+        for packet in self._stream.encode():
+            self._container.mux(packet)
+        self._container.close()
+
+
+class PyAVBackend(Backend):
+    """Backend powered by *PyAV* (ffmpeg bindings) for robust decoding/encoding."""
+
+    def _require_av(self):
+        if av is None:
+            raise RuntimeError("PyAV backend requested but PyAV is not installed.")
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def open(self, source: Any):  # type: ignore[override]
+        self._require_av()
+        return av.open(source)
+
+    def info(self, handle):  # type: ignore[override]
+        self._require_av()
+        # Assume first video stream
+        stream = next((s for s in handle.streams if s.type == "video"), None)
+        if stream is None:
+            raise RuntimeError("No video stream found.")
+        width = stream.codec_context.width
+        height = stream.codec_context.height
+        fps = int(stream.average_rate) if stream.average_rate else 30
+        total_frames = stream.frames if stream.frames else None
+        return VideoInfo(width=width, height=height, fps=fps, total_frames=total_frames)
+
+    # Reading -------------------------------------------------------------
+    def _frame_iter(self, handle) -> Iterator[np.ndarray]:
+        for packet in handle.demux(video=0):
+            for frame in packet.decode():
+                img = frame.to_ndarray(format="bgr24")
+                yield img
+
+    def read(self, handle):  # type: ignore[override]
+        try:
+            img = next(self._frame_iter(handle))
+            return True, img
+        except StopIteration:
+            return False, None  # type: ignore[return-value]
+
+    def grab(self, handle):  # type: ignore[override]
+        # Grabbing without decoding not trivial – decode and drop one frame.
+        success, _ = self.read(handle)
+        return success
+
+    def seek(self, handle, frame_idx: int):  # type: ignore[override]
+        self._require_av()
+        # Use timestamp seek – approximate
+        stream = next((s for s in handle.streams if s.type == "video"), None)
+        if stream is None:
+            raise RuntimeError("No video stream found.")
+        time_base = stream.time_base
+        target_ts = int(frame_idx / stream.average_rate / time_base)
+        handle.seek(target_ts, stream=stream)
+
+    # Writing -------------------------------------------------------------
+    def writer(self, path: str, info: VideoInfo, codec: str = "libx264") -> Writer:  # type: ignore[override]
+        self._require_av()
+        return _PyAVWriter(path, info, codec)
+

--- a/supervision/video/backends/pyav_backend.py
+++ b/supervision/video/backends/pyav_backend.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 import numpy as np
 
-from supervision.video.common import VideoInfo, Writer
 from supervision.video.backends.base import Backend
+from supervision.video.common import VideoInfo, Writer
 
 # PyAV is an optional dependency – we import lazily and fail with clear message.
 try:
@@ -19,7 +20,7 @@ class _PyAVWriter(Writer):
 
     def __init__(self, path: str, info: VideoInfo, codec: str):
         if av is None:
-            raise RuntimeError("PyAV is not installed. Install with `pip install av`." )
+            raise RuntimeError("PyAV is not installed. Install with `pip install av`.")
         self._container = av.open(path, mode="w")
         self._stream = self._container.add_stream(codec, rate=info.fps)
         self._stream.width = info.width
@@ -98,4 +99,3 @@ class PyAVBackend(Backend):
     def writer(self, path: str, info: VideoInfo, codec: str = "libx264") -> Writer:  # type: ignore[override]
         self._require_av()
         return _PyAVWriter(path, info, codec)
-

--- a/supervision/video/common.py
+++ b/supervision/video/common.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+
+@dataclass
+class VideoInfo:
+    """Container for video metadata.
+
+    Attributes
+    ----------
+    width:
+        Width of the video in pixels.
+    height:
+        Height of the video in pixels.
+    fps:
+        Frames-per-second of the stream.
+    total_frames:
+        Optional number of frames in the stream. For live streams or webcams this
+        value can be *None*.
+    """
+
+    width: int
+    height: int
+    fps: int
+    total_frames: int | None = None
+
+    # Convenience helpers --------------------------------------------------
+    @property
+    def resolution_wh(self) -> tuple[int, int]:
+        """Return width/height tuple matching cv2 / numpy order."""
+
+        return self.width, self.height
+
+
+class Writer(Protocol):
+    """Protocol describing minimal video writer interface used by ``Video``.
+
+    Any backend-specific writer must implement these two methods.
+    """
+
+    def write(self, frame: np.ndarray) -> None:  # pragma: no cover
+        ...
+
+    def close(self) -> None:  # pragma: no cover
+        ...
+

--- a/supervision/video/common.py
+++ b/supervision/video/common.py
@@ -47,4 +47,3 @@ class Writer(Protocol):
 
     def close(self) -> None:  # pragma: no cover
         ...
-

--- a/test/video/test_video.py
+++ b/test/video/test_video.py
@@ -1,0 +1,79 @@
+import numpy as np
+import cv2
+import os
+import pytest
+
+import supervision as sv
+
+
+def _create_temp_video(path: str, width=320, height=240, fps=30, frames=10):
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(path, fourcc, fps, (width, height))
+    for _ in range(frames):
+        frame = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
+        writer.write(frame)
+    writer.release()
+
+
+def test_video_info_and_iteration(tmp_path):
+    vid_path = tmp_path / "test.mp4"
+    _create_temp_video(str(vid_path))
+
+    video = sv.Video(str(vid_path))
+    info = video.info
+
+    assert info.width == 320
+    assert info.height == 240
+    assert info.total_frames == 10
+
+    frames = list(video.frames())
+    assert len(frames) == 10
+
+
+def test_frames_stride(tmp_path):
+    vid_path = tmp_path / "test_stride.mp4"
+    _create_temp_video(str(vid_path), frames=9)
+
+    video = sv.Video(str(vid_path))
+    frames = list(video.frames(stride=2))
+    assert len(frames) == 5  # ceil(9/2)
+
+
+def test_save_with_callback(tmp_path):
+    src = tmp_path / "src.mp4"
+    dst = tmp_path / "dst.mp4"
+    _create_temp_video(str(src))
+
+    def identity(frame, i):
+        return frame
+
+    sv.Video(str(src)).save(str(dst), callback=identity, show_progress=False)
+
+    # confirm destination exists and metadata matches
+    dst_video = sv.Video(str(dst))
+    assert dst_video.info.total_frames == 10
+
+
+def test_legacy_get_video_frames_generator(tmp_path):
+    vid_path = tmp_path / "legacy.mp4"
+    _create_temp_video(str(vid_path), frames=6)
+
+    frames = list(sv.get_video_frames_generator(str(vid_path)))
+    assert len(frames) == 6
+
+
+def test_legacy_process_video(tmp_path):
+    src = tmp_path / "legacy_src.mp4"
+    dst = tmp_path / "legacy_dst.mp4"
+    _create_temp_video(str(src), frames=4)
+
+    sv.process_video(
+        source_path=str(src),
+        target_path=str(dst),
+        callback=lambda f, i: f,
+        show_progress=False,
+    )
+
+    assert os.path.exists(dst)
+    assert sv.Video(str(dst)).info.total_frames == 4
+

--- a/test/video/test_video.py
+++ b/test/video/test_video.py
@@ -1,7 +1,7 @@
-import numpy as np
-import cv2
 import os
-import pytest
+
+import cv2
+import numpy as np
 
 import supervision as sv
 
@@ -76,4 +76,3 @@ def test_legacy_process_video(tmp_path):
 
     assert os.path.exists(dst)
     assert sv.Video(str(dst)).info.total_frames == 4
-


### PR DESCRIPTION
# Description

Video subsystem overhaul – end-to-end recap

1. Assessment & planning  
   • Audited the legacy `supervision.utils.video` helpers and Issue #1687 (FPS & metadata accuracy).  
   • Produced a task-tracked plan (10 TODO items) covering design, implementation, deprecation, tests, and docs.

2. New architecture  
   • Added `supervision/video/common.py` with:
     – `VideoInfo` dataclass (width, height, fps, total_frames, `resolution_wh`).  
     – `Writer` protocol.  
   • Defined pluggable `Backend` protocol (`open`, `info`, `read`, `grab`, `seek`, `writer`) in `video/backends/base.py`.

3. Backend implementations  
   • `OpenCVBackend` – default, zero-dependency, full seek/grab support.  
   • `PyAVBackend` – optional FFmpeg-powered backend with graceful fallback when `av` is absent.  
   • Each ships its own `_Writer` implementing the protocol.

4. Unified high-level API  
   • `supervision.video.Video` class:  
     – `info` property.  
     – `__iter__` for simple iteration.  
     – `frames(stride, start, end, resolution_wh)` for advanced slicing & on-the-fly resize.  
     – `save(target_path, callback, show_progress, fps/width/height/codec)` for in-place processing.  
     – `sink(target_path, info, codec)` context manager for manual writing.  
     – Backend selection via `backend="opencv" | "pyav"`.

5. Integration & exports  
   • Added backend registry, exported `Video` & `VideoInfo` through `supervision.__init__`.  
   • Ensured public `__all__` list includes the new class.

6. Deprecation of legacy API  
   • Marked `VideoInfo`, `VideoSink`, `get_video_frames_generator`, `process_video` in `supervision.utils.video` with `@deprecated` (5-release period).  
   • Internals now delegate to the new `Video` methods, emitting `SupervisionWarnings`.

7. Tests  
   • Created `test/video/test_video.py` – synthetic video helper + tests for:
     – Metadata correctness, iteration, stride logic.  
     – `save` with callback.  
     – Legacy wrappers’ continued functionality.  
   • All lints pass.

8. Documentation  
   • Rewrote `docs/utils/video.md`: quick-start, backend table, sink usage, and deprecation notice.  
   • mkdocs auto-generates API reference sections for `Video` and `VideoInfo`.

All 10 TODO tasks progressed from pending → completed; code, tests, and docs are ready for release.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
 test