### PR TITLE
Fix MeanAverageRecall: compute mAR@K using top-K detections per image (COCO-compliant)

### DIFF
--- a/supervision/metrics/mean_average_recall.py
+++ b/supervision/metrics/mean_average_recall.py
@@ -219,9 +219,8 @@ class MeanAverageRecall(Metric):
                 large_objects=None,
             )
 
-        concatenated_stats = [np.concatenate(items, 0) for items in zip(*stats)]
         recall_scores_per_k, recall_per_class, unique_classes = (
-            self._compute_average_recall_for_classes(*concatenated_stats)
+            self._compute_average_recall_for_classes(stats)
         )
 
         return MeanAverageRecallResult(
@@ -238,25 +237,30 @@ class MeanAverageRecall(Metric):
 
     def _compute_average_recall_for_classes(
         self,
-        matches: np.ndarray,
-        prediction_confidence: np.ndarray,
-        prediction_class_ids: np.ndarray,
-        true_class_ids: np.ndarray,
+        stats: list[tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]],
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        sorted_indices = np.argsort(-prediction_confidence)
-        matches = matches[sorted_indices]
-        prediction_class_ids = prediction_class_ids[sorted_indices]
-        unique_classes, class_counts = np.unique(true_class_ids, return_counts=True)
-
         recalls_at_k = []
+    
         for max_detections in self.max_detections:
+            filtered_stats = []
+            for matches, confidence, class_id, true_class_id in stats:
+                sorted_indices = np.argsort(-confidence)[:max_detections]
+                filtered_stats.append((
+                    matches[sorted_indices],
+                    class_id[sorted_indices],
+                    true_class_id,
+                ))
+            concatenated_stats = [np.concatenate(items, 0) for items in zip(*filtered_stats)]
+
+            filtered_matches, prediction_class_ids, true_class_ids = concatenated_stats
+            unique_classes, class_counts = np.unique(true_class_ids, return_counts=True)
+
             # Shape: PxTh,P,C,C -> CxThx3
             confusion_matrix = self._compute_confusion_matrix(
-                matches,
+                filtered_matches,
                 prediction_class_ids,
                 unique_classes,
                 class_counts,
-                max_detections=max_detections,
             )
 
             # Shape: CxThx3 -> CxTh


### PR DESCRIPTION
# Description

This PR fixes the calculation of mAR@K in `MeanAverageRecall` to comply with the COCO evaluation protocol.  
Previously, the implementation selected the top-K predictions globally across all images, rather than per image.
According to the [COCO evaluation protocol](https://cocodataset.org/#detection-eval), mAR@K should be calculated by considering the top-K highest-confidence detections **for each image**.

This issue is tracked in issue #1966 

To resolve this, I modified the `_compute` and `_compute_average_recall_for_classes` function so that only the top-K predictions per image are considered when calculating mAR@K.

No new dependencies are required for this change.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested the change by running the metric on a dataset with varying numbers of predictions per image and verified that, for each image, only the top-K predictions (by confidence) were used in the mAR@K calculation.

## Any specific deployment considerations

No special deployment considerations are required.

## Docs

-   [ ] Docs updated? What were the changes: N/A
