### PR TITLE
Fixed: random print("hm") in merge_metadata

### DIFF
--- a/supervision/detection/utils/internal.py
+++ b/supervision/detection/utils/internal.py
@@ -271,7 +271,6 @@ def merge_metadata(metadata_list: list[dict[str, Any]]) -> dict[str, Any]:
                     "{type(value)}, {type(other_value)}."
                 )
             else:
-                print("hm")
                 if merged_metadata[key] != value:
                     raise ValueError(f"Conflicting metadata for key: '{key}'.")
 


### PR DESCRIPTION
# Description

Simple change, removed a stray `print("hm")` in the `merge_metadata` function in `supervision/detection/utils/internal.py`

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

## Any specific deployment considerations

## Docs

-   [ ] Docs updated? What were the changes: NA

Fixes #1963 