### PR TITLE
fix: removed dependency groups pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,6 @@ Documentation = "https://supervision.roboflow.com/latest/"
 metrics = [
     "pandas>=2.0.0",
 ]
-
-[dependency-groups]
 dev = [
     "pytest>=7.2.2,<9.0.0",
     "tox>=4.11.4",


### PR DESCRIPTION
# Description

Fixes #1970 
- Removed the dependency groups tag to make these part of `[project.optional-dependencies]`
- `--extra` dev, docs, and build work as explained in the contributing guide
- No changes to the guide will be required this way

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Running this command (as given in the guide) works:
`uv pip install -r pyproject.toml --extra dev --extra docs --extra metrics`

## Any specific deployment considerations

None

## Docs

-   [ ] Docs updated? What were the changes:
