### PR TITLE
pre-commit autoupdate 2025-10-04

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: test/.*\.py
@@ -32,7 +32,7 @@ repos:
           additional_dependencies: ["bandit[toml]"]
 
   -   repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.12.5
+      rev: v0.13.3
       hooks:
       -   id: ruff
           args: [--fix, --exit-non-zero-on-fix]

--- a/supervision/annotators/core.py
+++ b/supervision/annotators/core.py
@@ -764,7 +764,7 @@ class EllipseAnnotator(BaseAnnotator):
         """
         assert isinstance(scene, np.ndarray)
         for detection_idx in range(len(detections)):
-            x1, y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
+            x1, _y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
             color = resolve_color(
                 color=self.color,
                 detections=detections,
@@ -1621,7 +1621,7 @@ class RichLabelAnnotator(_BaseLabelAnnotator):
                 )
 
                 # Move to the next line position
-                left, top, right, bottom = draw.textbbox((0, 0), line, font=self.font)
+                _left, top, _right, bottom = draw.textbbox((0, 0), line, font=self.font)
                 line_height = bottom - top
                 y_position += line_height + self.text_padding
 
@@ -1917,7 +1917,7 @@ class TraceAnnotator(BaseAnnotator):
 
             if len(xy) > 3 and self.smooth:
                 x, y = xy[:, 0], xy[:, 1]
-                tck, u = splprep([x, y], s=20)
+                tck, _u = splprep([x, y], s=20)
                 x_new, y_new = splev(np.linspace(0, 1, 100), tck)
                 spline_points = np.stack([x_new, y_new], axis=1).astype(np.int32)
 

--- a/supervision/detection/utils/masks.py
+++ b/supervision/detection/utils/masks.py
@@ -98,7 +98,7 @@ def calculate_masks_centroids(masks: np.ndarray) -> np.ndarray:
         A 2D NumPy array of shape (num_masks, 2), where each row contains the x and y
             coordinates (in that order) of the centroid of the corresponding mask.
     """
-    num_masks, height, width = masks.shape
+    _num_masks, height, width = masks.shape
     total_pixels = masks.sum(axis=(1, 2))
 
     # offset for 1-based indexing

--- a/supervision/tracker/byte_tracker/core.py
+++ b/supervision/tracker/byte_tracker/core.py
@@ -247,7 +247,7 @@ class ByteTrack:
             if strack_pool[i].state == TrackState.Tracked
         ]
         dists = matching.iou_distance(r_tracked_stracks, detections_second)
-        matches, u_track, u_detection_second = matching.linear_assignment(
+        matches, u_track, _u_detection_second = matching.linear_assignment(
             dists, thresh=0.5
         )
         for itracked, idet in matches:

--- a/supervision/utils/notebook.py
+++ b/supervision/utils/notebook.py
@@ -98,7 +98,7 @@ def plot_images_grid(
             " or reduce the number of images."
         )
 
-    fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=size)
+    _fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=size)
 
     for idx, ax in enumerate(axes.flat):
         if idx < len(images):


### PR DESCRIPTION
# Description

This is #1928 with a fix. 
* #1928

% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v5.0.0 -> v6.0.0
[https://github.com/PyCQA/bandit] already up to date!
[https://github.com/astral-sh/ruff-pre-commit] updating v0.12.5 -> v0.13.3
[https://github.com/codespell-project/codespell] already up to date!
[https://github.com/asottile/pyupgrade] already up to date!
```
% `ruff check --select=RUF059 --fix --unsafe-fixes`
```
Found 7 errors (7 fixed, 0 remaining).
```

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

% `pre-commit run --all-files`

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:

---
% `ruff rule RUF059`
# unused-unpacked-variable (RUF059)

Derived from the **Ruff-specific rules** linter.

Fix is sometimes available.

## What it does
Checks for the presence of unused variables in unpacked assignments.

## Why is this bad?
A variable that is defined but never used can confuse readers.

If a variable is intentionally defined-but-not-used, it should be
prefixed with an underscore, or some other value that adheres to the
[`lint.dummy-variable-rgx`] pattern.

## Example

```python
def get_pair():
    return 1, 2


def foo():
    x, y = get_pair()
    return x
```

Use instead:

```python
def foo():
    x, _ = get_pair()
    return x
```

## See also

This rule applies only to unpacked assignments. For regular assignments, see
[`unused-variable`][F841].

## Options
- `lint.dummy-variable-rgx`

[F841]: https://docs.astral.sh/ruff/rules/unused-variable/

