### PR TITLE
fix: Overlapmetric should check string using uppercase conversion

### DIFF
--- a/supervision/detection/utils/iou_and_nms.py
+++ b/supervision/detection/utils/iou_and_nms.py
@@ -72,7 +72,7 @@ class OverlapMetric(Enum):
         if isinstance(value, cls):
             return value
         if isinstance(value, str):
-            value = value.lower()
+            value = value.upper()
             try:
                 return cls(value)
             except ValueError:


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed or implemented. 

OverlapMetric should check input string after conversion to upper instead of to lower

List any dependencies that are required for this change.
No dependencies change required

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?
now able to specify overlapmetric with string input of "iou" or "ios"

## Any specific deployment considerations
None

## Docs

No change required
