### PR TITLE
fix: process video bug on unused else

### DIFF
--- a/supervision/utils/video.py
+++ b/supervision/utils/video.py
@@ -249,10 +249,6 @@ def process_video(
         ):
             result_frame = callback(frame, index)
             sink.write_frame(frame=result_frame)
-        else:
-            for index, frame in enumerate(video_frames_generator):
-                result_frame = callback(frame, index)
-                sink.write_frame(frame=result_frame)
 
 
 class FPSMonitor:


### PR DESCRIPTION
The loop never uses break, so the else clause always executes. However, since it iterates over a generator, the generator is already exhausted after the first pass... so the else block would iterate over nothing.

So, i believe the 'else' is redundant.


## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

```
>>> def g():
...   for x in range(3):
...     yield x
... 
>>> gen = g()
>>> for x in gen:
...   print(x)
... else:
...   for y in gen:
...     print("y", y)
... 
0
1
2

```

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
