### PR TITLE
Fix `process_video` and add test case

### DIFF
--- a/test/utils/test_video.py
+++ b/test/utils/test_video.py
@@ -4,7 +4,7 @@ import numpy as np
 from supervision.utils.video import process_video
 
 
-def create_test_video(path, num_frames, width=20, height=10):
+def _create_test_video(path, num_frames, width=20, height=10):
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out = cv2.VideoWriter(path, fourcc, 1.0, (width, height))
 
@@ -19,7 +19,7 @@ def test_process_video_max_frames_exceeds_total_frames(tmp_path):
     source_path = tmp_path / "source.mp4"
     target_path = tmp_path / "target.mp4"
 
-    create_test_video(str(source_path), num_frames=5)
+    _create_test_video(str(source_path), num_frames=5)
 
     process_video(
         source_path=str(source_path),


### PR DESCRIPTION
This PR fixes the `process_video` function.

There used to be an `if-else` but somewhere the `if` fell off the truck resulting in a `for-else` that doesn't make sense.

This PR also fixes the following case of passing a `max_frames` that is larger than the frames in the video.
Before this PR is would give `Exception: Requested frames are outbound` and with it it will simply process the whole video, i.e. treat "max" frames as a max but OK if there are less frames (I think what most users expect/want).
```python
import supervision as sv
from supervision.assets import VideoAssets, download_assets

download_assets(VideoAssets.PEOPLE_WALKING)

video_info = sv.VideoInfo.from_video_path("people-walking.mp4")

sv.process_video(
    source_path="people-walking.mp4",
    target_path="people-talking.mp4",
    callback=lambda frame, _: frame,
    max_frames=1000,
)
```

I also added a test case (the agent wrote it). Not sure if you want such tests or if/how you want to treat temp dirs and example asset video files in this repo. Let me know whatever you prefer and I can remove that or adjust.
