### PR TITLE
docs: Update JSONSink example path

### DIFF
--- a/docs/how_to/save_detections.md
+++ b/docs/how_to/save_detections.md
@@ -234,7 +234,7 @@ with
     model = get_model(model_id="yolov8n-640")
     frames_generator = sv.get_video_frames_generator(<SOURCE_VIDEO_PATH>)
 
-    with sv.JSONSink(<TARGET_CSV_PATH>) as sink:
+    with sv.JSONSink(<TARGET_JSON_PATH>) as sink:
         for frame_index, frame in enumerate(frames_generator):
 
             results = model.infer(image)[0]
@@ -250,7 +250,7 @@ with
     model = YOLO("yolov8n.pt")
     frames_generator = sv.get_video_frames_generator(<SOURCE_VIDEO_PATH>)
 
-    with sv.JSONSink(<TARGET_CSV_PATH>) as sink:
+    with sv.JSONSink(<TARGET_JSON_PATH>) as sink:
         for frame_index, frame in enumerate(frames_generator):
 
             results = model(frame)[0]
@@ -268,7 +268,7 @@ with
     model = DetrForObjectDetection.from_pretrained("facebook/detr-resnet-50")
     frames_generator = sv.get_video_frames_generator(<SOURCE_VIDEO_PATH>)
 
-    with sv.JSONSink(<TARGET_CSV_PATH>) as sink:
+    with sv.JSONSink(<TARGET_JSON_PATH>) as sink:
         for frame_index, frame in enumerate(frames_generator):
 
             frame = sv.cv2_to_pillow(frame)


### PR DESCRIPTION
# Description

Currently the docs show an example of saving Detections as JSON with JSONSink, but say "CSV" in the example field.

## Type of change

-   [X] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

This is a minor docs-only change.

## Any specific deployment considerations

None.

## Docs

-   [X] Docs updated? What were the changes: `TARGET_CSV_PATH` -> `TARGET_JSON_PATH`
