### PR TITLE
resolve docs build / pin `mkdocstrings-python<2.0.0`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,7 +133,7 @@ plugins:
         python:
           options:
             parameter_headings: true
-            paths: [supervision]
+            path: [supervision]
             load_external_modules: true
             allow_inspection: true
             show_bases: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,7 +133,7 @@ plugins:
         python:
           options:
             parameter_headings: true
-            path: [supervision]
+            paths: [supervision]
             load_external_modules: true
             allow_inspection: true
             show_bases: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dev = [
 docs = [
     "mkdocs-material[imaging]>=9.5.5",
     "mkdocstrings>=0.25.2,<0.31.0",
-    "mkdocstrings-python>=1.10.9",
+    "mkdocstrings-python>=1.10.9, <2.0.0",  # todo: breaking changes in 2.x
     "mike>=2.0.0",
     "mkdocs-jupyter>=0.24.3",
     "mkdocs-git-committers-plugin-2>=2.4.1; python_version >= '3.9' and python_version < '4'",


### PR DESCRIPTION
# Description

This pull request makes a small update to the documentation dependencies in `pyproject.toml` by restricting the version of `mkdocstrings-python` to below 2.0.0 to avoid breaking changes in the 2.x series.

In particular, it shall resolve failing docs' CI failing on the default branch...
```
ERROR   -  Error reading page 'assets.md':
ERROR   -  Invalid options: PythonOptions.__init__() got an unexpected keyword argument 'paths'

Aborted with a BuildError!
Error: Process completed with exit code 1.
```

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update