### PR TITLE
Add push triggers for `main` and `develop` branches in workflow files

### DIFF
--- a/.github/workflows/test-doc.yml
+++ b/.github/workflows/test-doc.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+concurrency:
+  group: docs-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Restrict permissions by default
 permissions:
   contents: read # Required for checkout

--- a/.github/workflows/test-doc.yml
+++ b/.github/workflows/test-doc.yml
@@ -1,6 +1,8 @@
 name: 🧪 Docs Test WorkFlow 📚
 
 on:
+  push:
+    branches: [main, develop]
   pull_request:
     branches: [main, develop]
 

--- a/.github/workflows/uv-test.yml
+++ b/.github/workflows/uv-test.yml
@@ -1,6 +1,8 @@
 name: 🔧 Pytest/Test Workflow
 
 on:
+  push:
+    branches: [main, develop]
   pull_request:
     branches: [main, develop]
 

--- a/.github/workflows/uv-test.yml
+++ b/.github/workflows/uv-test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+concurrency:
+  group: pytest-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   run-tests:
     name: Import Test and Pytest Run


### PR DESCRIPTION
# Description

This pull request updates the GitHub Actions workflows to ensure that tests are run not only on pull requests but also on direct pushes to the `main` and `develop` branches. This change helps catch issues earlier and maintain code quality for these important branches.

**Workflow trigger updates:**

* [`.github/workflows/test-doc.yml`](diffhunk://#diff-d844558257f15ffddf0f19f61fdb9082de92a53e3784dd39b89602bbc97d3dadR4-R5): Added `push` event triggers for `main` and `develop` branches to the Docs Test workflow.
* [`.github/workflows/uv-test.yml`](diffhunk://#diff-f0041189b24edd278b2a01654f1941e8809d87fc8c146b6b84e655796c61ffa2R4-R5): Added `push` event triggers for `main` and `develop` branches to the Pytest/Test workflow.

## How has this change been tested, please provide a testcase or example of how you tested the change?

none