### PR TITLE
Add testing-guardian job to aggregate test results

### DIFF
--- a/.github/workflows/uv-test.yml
+++ b/.github/workflows/uv-test.yml
@@ -24,7 +24,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
 
-
       - name: 🚀 Install Packages
         run: uv pip install -r pyproject.toml --group dev --group docs --extra metrics
 
@@ -33,3 +32,17 @@ jobs:
 
       - name: 🧪 Run the Test
         run: uv run pytest
+
+  testing-guardian:
+    runs-on: ubuntu-latest
+    needs: run-tests
+    if: always()
+    steps:
+      - run: echo "${{ needs.run-tests.result }}"
+      - name: failing...
+        if: needs.run-tests.result == 'failure'
+        run: exit 1
+      - name: cancelled or skipped...
+        if: contains(fromJSON('["cancelled", "skipped"]'), needs.run-tests.result)
+        timeout-minutes: 1
+        run: sleep 90

--- a/.github/workflows/uv-test.yml
+++ b/.github/workflows/uv-test.yml
@@ -50,3 +50,6 @@ jobs:
         if: contains(fromJSON('["cancelled", "skipped"]'), needs.run-tests.result)
         timeout-minutes: 1
         run: sleep 90
+      - name: tests succeeded
+        if: needs.run-tests.result == 'success'
+        run: echo "All tests completed successfully in job 'run-tests'."

--- a/.github/workflows/uv-test.yml
+++ b/.github/workflows/uv-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Import Test and Pytest Run

--- a/.github/workflows/uv-test.yml
+++ b/.github/workflows/uv-test.yml
@@ -24,7 +24,6 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
-      - run: exit 1 # FIXME
       - name: 📥 Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 

--- a/.github/workflows/uv-test.yml
+++ b/.github/workflows/uv-test.yml
@@ -36,6 +36,7 @@ jobs:
       - name: 🧪 Run the Test
         run: uv run pytest
 
+
   testing-guardian:
     runs-on: ubuntu-latest
     needs: run-tests
@@ -46,10 +47,13 @@ jobs:
       - name: Fail guardian on test failure
         if: needs.run-tests.result == 'failure'
         run: exit 1
-      - name: Handle cancelled or skipped tests
+      # Ensure that cancelled or skipped test runs still cause this guardian job to fail,
+      # using an explicit exit code instead of relying on timeout behavior.
+      - name: cancelled or skipped...
         if: contains(fromJSON('["cancelled", "skipped"]'), needs.run-tests.result)
-        timeout-minutes: 1
-        run: sleep 90
+        run: |
+          echo "run-tests job result is '${{ needs.run-tests.result }}'; failing explicitly."
+          exit 1
       - name: tests succeeded
         if: needs.run-tests.result == 'success'
         run: echo "All tests completed successfully in job 'run-tests'."

--- a/.github/workflows/uv-test.yml
+++ b/.github/workflows/uv-test.yml
@@ -41,11 +41,12 @@ jobs:
     needs: run-tests
     if: always()
     steps:
-      - run: echo "${{ needs.run-tests.result }}"
-      - name: failing...
+      - name: Display test result
+        run: echo "${{ needs.run-tests.result }}"
+      - name: Fail guardian on test failure
         if: needs.run-tests.result == 'failure'
         run: exit 1
-      - name: cancelled or skipped...
+      - name: Handle cancelled or skipped tests
         if: contains(fromJSON('["cancelled", "skipped"]'), needs.run-tests.result)
         timeout-minutes: 1
         run: sleep 90

--- a/.github/workflows/uv-test.yml
+++ b/.github/workflows/uv-test.yml
@@ -24,6 +24,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
+      - run: exit 1 # FIXME
       - name: 📥 Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 


### PR DESCRIPTION
# Description

This pull request updates the GitHub Actions workflow to improve test result handling and reporting. The main change is the addition of a new job that reacts to the outcome of the primary test jobs.

**Workflow enhancements:**

* Added a new `testing-guardian` job to `.github/workflows/uv-test.yml` that monitors the result of the `run-tests` job and takes different actions based on whether it failed, was cancelled, or was skipped.

**Other changes:**

* Minor formatting update in the package installation step of the workflow file.

## How has this change been tested, please provide a testcase or example of how you tested the change?

none
