### PR TITLE
GHA: Unify workflows for build/test/publish documentation

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -32,7 +32,7 @@ jobs:
         run: uv run mkdocs build --verbose
 
       - name: 📤 Upload docs site as artifact
-        uses: actions/upload-artifact@4.33.0
+        uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: site/

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -32,7 +32,7 @@ jobs:
         run: uv run mkdocs build --verbose
 
       - name: 📤 Upload docs site as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.4.3
         with:
           name: docs-site
           path: site/

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,64 @@
+name: Build Docs
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: false
+        type: string
+        default: "3.10"
+      insiders:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      MKDOCS_APP_ID:
+        required: false
+      MKDOCS_PEM:
+        required: false
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: 📥 Checkout the repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: 🐍 Install uv and set Python ${{ inputs.python-version }}
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+        with:
+          python-version: ${{ inputs.python-version }}
+          activate-environment: true
+
+      - name: 🏗️ Install dependencies
+        run: |
+          uv pip install -r pyproject.toml --group docs
+
+      - name: 🔑 Create GitHub App token (mkdocs)
+        # todo: this template need to be public for proper testing
+        if: inputs.insiders
+        id: mkdocs_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.MKDOCS_APP_ID }}
+          private-key: ${{ secrets.MKDOCS_PEM }}
+          owner: roboflow
+          repositories: mkdocs-material-insiders
+
+      - name: 🏗️ Install mkdocs-material-insiders
+        if: inputs.insiders
+        run: |
+          uv pip install "git+https://roboflow:${{ steps.mkdocs_token.outputs.token }}@github.com/roboflow/mkdocs-material-insiders.git@9.5.49-insiders-4.53.14#egg=mkdocs-material[imaging]"
+
+      - name: 🧪 Build Docs
+        run: uv run mkdocs build --verbose
+
+      - name: 📤 Upload docs site as artifact
+        uses: actions/upload-artifact@4.33.0
+        with:
+          name: docs-site
+          path: site/

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -7,15 +7,6 @@ on:
         required: false
         type: string
         default: "3.10"
-      insiders:
-        required: false
-        type: boolean
-        default: false
-    secrets:
-      MKDOCS_APP_ID:
-        required: false
-      MKDOCS_PEM:
-        required: false
 
 jobs:
   build:
@@ -37,23 +28,6 @@ jobs:
       - name: 🏗️ Install dependencies
         run: |
           uv pip install -r pyproject.toml --group docs
-
-      - name: 🔑 Create GitHub App token (mkdocs)
-        # todo: this template need to be public for proper testing
-        if: inputs.insiders
-        id: mkdocs_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.MKDOCS_APP_ID }}
-          private-key: ${{ secrets.MKDOCS_PEM }}
-          owner: roboflow
-          repositories: mkdocs-material-insiders
-
-      - name: 🏗️ Install mkdocs-material-insiders
-        if: inputs.insiders
-        run: |
-          uv pip install "git+https://roboflow:${{ steps.mkdocs_token.outputs.token }}@github.com/roboflow/mkdocs-material-insiders.git@9.5.49-insiders-4.53.14#egg=mkdocs-material[imaging]"
-
       - name: 🧪 Build Docs
         run: uv run mkdocs build --verbose
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -31,8 +31,8 @@ jobs:
       - name: 🧪 Build Docs
         run: uv run mkdocs build --verbose
 
-      - name: 📤 Upload docs site as artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.4.3
+      - name: 📤 Upload docs site artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: docs-site
           path: site/

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -20,40 +20,34 @@ permissions:
   pull-requests: write # Required for PR comments
 
 jobs:
+  build-docs:
+    uses: ./.github/workflows/build-docs.yml
+    with:
+      insiders: true
+    secrets:
+      MKDOCS_APP_ID: ${{ secrets.MKDOCS_APP_ID }}
+      MKDOCS_PEM: ${{ secrets.MKDOCS_PEM }}
+
   deploy:
     name: Publish Docs
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.10"]
+    needs: build-docs
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
 
-      - name: 🐍 Install uv and set Python ${{ matrix.python-version }}
+      - name: 🐍 Install uv and set Python 3.10
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           activate-environment: true
-
-
-      - name: 🔑 Create GitHub App token (mkdocs)
-        id: mkdocs_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.MKDOCS_APP_ID }}
-          private-key: ${{ secrets.MKDOCS_PEM }}
-          owner: roboflow
-          repositories: mkdocs-material-insiders
 
       - name: 🏗️ Install dependencies
         run: |
           uv pip install -r pyproject.toml --group docs
-          # Install mkdocs-material-insiders using the GitHub App token
-          uv pip install "git+https://roboflow:${{ steps.mkdocs_token.outputs.token }}@github.com/roboflow/mkdocs-material-insiders.git@9.5.49-insiders-4.53.14#egg=mkdocs-material[imaging]"
 
       - name: ⚙️ Configure git for github-actions
         run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -36,28 +36,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🐍 Install uv and set Python 3.10
-        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+      - name: 📥 Download docs site artifacts
+        uses: actions/download-artifact@v4
         with:
-          python-version: "3.10"
-          activate-environment: true
-
-      - name: 🏗️ Install dependencies
-        run: |
-          uv pip install -r pyproject.toml --group docs
-
-      - name: ⚙️ Configure git for github-actions
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          name: docs-site
 
       - name: 🚀 Deploy Development Docs
         if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'workflow_dispatch'
-        run: |
-          MKDOCS_GIT_COMMITTERS_APIKEY=${{ secrets.GITHUB_TOKEN }} uv run mike deploy --push develop
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site
+          destination_dir: develop
 
       - name: 🚀 Deploy Release Docs
         if: github.event_name == 'release' && github.event.action == 'published'
-        run: |
-          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          MKDOCS_GIT_COMMITTERS_APIKEY=${{ secrets.GITHUB_TOKEN }} uv run mike deploy --push --update-aliases $latest_tag latest
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site
+          destination_dir: ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,11 +22,6 @@ permissions:
 jobs:
   build-docs:
     uses: ./.github/workflows/build-docs.yml
-    with:
-      insiders: true
-    secrets:
-      MKDOCS_APP_ID: ${{ secrets.MKDOCS_APP_ID }}
-      MKDOCS_PEM: ${{ secrets.MKDOCS_PEM }}
 
   deploy:
     name: Publish Docs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: docs-site
+          path: site
 
       - name: 🚀 Deploy Development Docs
         if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,6 +21,8 @@ permissions:
 
 jobs:
   build-docs:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-docs.yml
 
   deploy:

--- a/.github/workflows/test-doc.yml
+++ b/.github/workflows/test-doc.yml
@@ -18,5 +18,3 @@ permissions:
 jobs:
   docs-build-test:
     uses: ./.github/workflows/build-docs.yml
-    with:
-      insiders: false

--- a/.github/workflows/test-doc.yml
+++ b/.github/workflows/test-doc.yml
@@ -17,27 +17,6 @@ permissions:
 
 jobs:
   docs-build-test:
-    name: Test docs build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    steps:
-      - name: 📥 Checkout the repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          fetch-depth: 0
-
-      - name: 🐍 Install uv and set Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
-        with:
-          python-version: ${{ matrix.python-version }}
-          activate-environment: true
-
-      - name: 🏗️ Install dependencies
-        run: |
-          uv pip install -r pyproject.toml --group docs
-
-      - name: 🧪 Test Docs Build
-        run: uv run mkdocs build --verbose
+    uses: ./.github/workflows/build-docs.yml
+    with:
+      insiders: false

--- a/.github/workflows/test-doc.yml
+++ b/.github/workflows/test-doc.yml
@@ -17,4 +17,7 @@ permissions:
 
 jobs:
   docs-build-test:
+    permissions:
+      contents: read
+      checks: write
     uses: ./.github/workflows/build-docs.yml


### PR DESCRIPTION
# Description

This pull request refactors the documentation build process in GitHub Actions by introducing a reusable workflow, `.github/workflows/build-docs.yml`, and updating the existing workflows to use it. This change centralizes and streamlines the logic for building documentation, reduces duplication, and makes it easier to manage updates in one place.

**Reusable workflow introduction and adoption:**

* Added a new reusable workflow, `build-docs.yml`, which handles building documentation with configurable Python version and support for MkDocs Material Insiders via GitHub App authentication. (.github/workflows/build-docs.yml)
* Updated `publish-docs.yml` to use the new reusable `build-docs.yml` workflow for the documentation build step, removing duplicated logic and simplifying the deploy job. (.github/workflows/publish-docs.yml)
* Updated `test-doc.yml` to use the new reusable workflow for testing the documentation build, eliminating redundant steps and configuration. (.github/workflows/test-doc.yml)

## How has this change been tested, please provide a testcase or example of how you tested the change?

none

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.
