### PR TITLE
chore(pre_commit): update Ruff rules with its references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ line-length = 88
 indent-width = 4
 
 [tool.ruff.lint]
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+# Enable linting rules for code style, imports, and best practices.
 select = [
     "E",    # pycodestyle errors - https://docs.astral.sh/ruff/rules/#error-e
     "F",    # Pyflakes - https://docs.astral.sh/ruff/rules/#pyflakes-f

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,13 +130,13 @@ indent-width = 4
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 select = [
-    "E",    # pycodestyle errors - https://docs.astral.sh/ruff/rules/#pycodestyle-e
+    "E",    # pycodestyle errors - https://docs.astral.sh/ruff/rules/#error-e
     "F",    # Pyflakes - https://docs.astral.sh/ruff/rules/#pyflakes-f
     "I",    # isort - https://docs.astral.sh/ruff/rules/#isort-i
     "A",    # flake8-builtins - https://docs.astral.sh/ruff/rules/#flake8-builtins-a
     "Q",    # flake8-quotes - https://docs.astral.sh/ruff/rules/#flake8-quotes-q
     "W",    # pycodestyle warnings - https://docs.astral.sh/ruff/rules/#pycodestyle-w
-    "RUF",  # Ruff-specific rules - https://docs.astral.sh/ruff/rules/#ruff-ruf
+    "RUF",  # Ruff-specific rules - https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
     "UP",   # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
 ignore = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ select = [
     "W",    # pycodestyle warnings - https://docs.astral.sh/ruff/rules/#pycodestyle-w
     "RUF",  # Ruff-specific rules - https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
     "UP",   # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
-    "S",
+    "S",    # bandit - https://docs.astral.sh/ruff/rules/#flake8-bandit-s
 ]
 ignore = []
 unfixable = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,55 +129,17 @@ indent-width = 4
 
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "I", "A", "Q", "W", "RUF", "UP"]
-ignore = []
-# Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = [
-    "A",
-    "B",
-    "C",
-    "D",
-    "E",
-    "F",
-    "G",
-    "I",
-    "N",
-    "Q",
-    "S",
-    "T",
-    "W",
-    "ANN",
-    "ARG",
-    "BLE",
-    "COM",
-    "DJ",
-    "DTZ",
-    "EM",
-    "ERA",
-    "EXE",
-    "FBT",
-    "ICN",
-    "INP",
-    "ISC",
-    "NPY",
-    "PD",
-    "PGH",
-    "PIE",
-    "PL",
-    "PT",
-    "PTH",
-    "PYI",
-    "RET",
-    "RSE",
-    "RUF",
-    "SIM",
-    "SLF",
-    "TCH",
-    "TID",
-    "TRY",
-    "UP",
-    "YTT",
+select = [
+    "E",    # pycodestyle errors - https://docs.astral.sh/ruff/rules/#pycodestyle-e
+    "F",    # Pyflakes - https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "I",    # isort - https://docs.astral.sh/ruff/rules/#isort-i
+    "A",    # flake8-builtins - https://docs.astral.sh/ruff/rules/#flake8-builtins-a
+    "Q",    # flake8-quotes - https://docs.astral.sh/ruff/rules/#flake8-quotes-q
+    "W",    # pycodestyle warnings - https://docs.astral.sh/ruff/rules/#pycodestyle-w
+    "RUF",  # Ruff-specific rules - https://docs.astral.sh/ruff/rules/#ruff-ruf
+    "UP",   # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
+ignore = []
 unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"


### PR DESCRIPTION
The `fixanle` they do not have any impact if they are not listed in selected.

In Ruff, the select list determines which rules are active (checked). The fixable list merely controls which of those active rules are allowed to automatically modify your code when running with --fix.

If a rule is listed in fixable but not in select, it is effectively disabled; Ruff won't look for it, so there will be no errors to fix. Listing extra items in fixable is harmless but redundant code clutter.

The default value for fixable in Ruff is ["ALL"].