### PR TITLE
chore(pre_commit): remove exclusion for trailing-whitespace hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: test/.*\.py
       - id: check-yaml
         exclude: mkdocs.yml
       - id: check-executables-have-shebangs

--- a/test/utils/test_file.py
+++ b/test/utils/test_file.py
@@ -12,12 +12,11 @@ Line 2
 Line 3
 """
 
-FILE_2_CONTENT = """   
-Line 2
+FILE_2_CONTENT = """   \nLine 2
 
 Line 4
 
-"""  # noqa
+"""
 
 FILE_3_CONTENT = """
 Line 2


### PR DESCRIPTION
This pull request includes minor updates to the `.pre-commit-config.yaml` and a test utility file. The main focus is on improving consistency and formatting in test content and pre-commit hook configuration.

Formatting and configuration improvements:

* Updated the `FILE_2_CONTENT` string in `test/utils/test_file.py` to have consistent newline and whitespace formatting.
* Removed the `exclude: test/.*\.py` rule from the `trailing-whitespace` hook in `.pre-commit-config.yaml`, so test files will now be checked for trailing whitespace.