### PR TITLE
ci: add UV cache pruning step

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -42,6 +42,9 @@ jobs:
       - name: 🧪 Run the Test
         run: uv run pytest
 
+      - name: Minimize uv cache
+        run: uv cache prune --ci
+
 
   testing-guardian:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a minor improvement to the CI workflow configuration by optimizing the cache usage for the test job.

* Added a step to minimize the `uv` cache after running tests in the `ci-tests.yml` workflow to help reduce disk usage and improve CI efficiency.