### PR TITLE
Add jsonargparse dependency for CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ Documentation = "https://supervision.roboflow.com/latest/"
 metrics = [
     "pandas>=2.0.0",
 ]
+cli = [
+    # to be used for examples and other CLI utilities
+    "jsonargparse[signatures]>=4.38.0",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
This pull request adds a new optional dependency group for CLI utilities in the `pyproject.toml` file. This group includes the `jsonargparse` package, which will be used for examples and other command-line interface utilities.

Dependency management:

* Added a `cli` dependency group with `jsonargparse[signatures]>=4.38.0` to support CLI utilities and examples in `pyproject.toml`.

Will impact: #2059, #2058, #2057, #2056, #2055, #2054