### PR TITLE
Add GitHub Action for labeling PRs with conflicts

### DIFF
--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🤖 Check conflicts and manage label
-        uses: sequelize/pr-auto-update-and-handle-conflicts@v1
+        uses: sequelize/pr-auto-update-and-handle-conflicts@1.0.1
         with:
           conflict-label: "has conflict"

--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -15,4 +15,4 @@ jobs:
       - name: 🤖 Check conflicts and manage label
         uses: sequelize/pr-auto-update-and-handle-conflicts@v1
         with:
-          conflict-label: has-conflict
+          conflict-label: "has conflict"

--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -10,9 +10,11 @@ permissions:
 
 jobs:
   label:
+    name: Label PRs with conflicts
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: 🤖 Check conflicts and manage label
-        uses: sequelize/pr-auto-update-and-handle-conflicts@1.0.1
+        uses: sequelize/pr-auto-update-and-handle-conflicts@6e4c1f2f8c9634b0c4a96522132f3aaba3a0998a # v1
         with:
           conflict-label: "has conflict"

--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -1,0 +1,18 @@
+name: 🔴 PR Conflict Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🤖 Check conflicts and manage label
+        uses: sequelize/pr-auto-update-and-handle-conflicts@v1
+        with:
+          conflict-label: has-conflict

--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -1,7 +1,9 @@
 name: 🔴 PR Conflict Labeler
 
 on:
-  pull_request:
+  push:
+    branches: [main, develop]
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -17,5 +19,7 @@ jobs:
     steps:
       - name: 🤖 Check conflicts and manage label
         uses: sequelize/pr-auto-update-and-handle-conflicts@74929c430b8843e691e7b83d229d8d13d78d89e3 # pinned latest commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           conflict-label: has-conflict

--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -15,6 +15,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 🤖 Check conflicts and manage label
-        uses: sequelize/pr-auto-update-and-handle-conflicts@6e4c1f2f8c9634b0c4a96522132f3aaba3a0998a # v1
+        uses: sequelize/pr-auto-update-and-handle-conflicts@74929c430b8843e691e7b83d229d8d13d78d89e3 # pinned latest commit
         with:
-          conflict-label: "has conflict"
+          conflict-label: has-conflict

--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
+  contents: write
   pull-requests: write
   issues: write
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically label pull requests that have merge conflicts. This helps the team quickly identify PRs that require conflict resolution before merging.

**Automation and workflow improvements:**

* Added a `.github/workflows/pr-conflict-labeler.yml` workflow that uses the `sequelize/pr-auto-update-and-handle-conflicts` action to check for merge conflicts and apply a "has conflict" label to affected pull requests.