### PR TITLE
Add Discord link to issues for community collaboration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -12,3 +12,6 @@ contact_links:
   - name: 🌟 Show and Tell
     url: https://github.com/roboflow/supervision/discussions/categories/show-and-tell
     about: Share your projects and creations built with Supervision
+  - name: 🗣️ Roboflow Discord
+    url: https://discord.com/invite/GbfgXGJ8Bk
+    about: Join our Discord to collaborate with other community members.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -14,4 +14,4 @@ contact_links:
     about: Share your projects and creations built with Supervision
   - name: 🗣️ Roboflow Discord
     url: https://discord.com/invite/GbfgXGJ8Bk
-    about: Join our Discord to collaborate with other community members.
+    about: Join our Discord to collaborate with other community members


### PR DESCRIPTION
This pull request adds a new contact link to the GitHub issue template configuration, making it easier for users to join the Roboflow Discord community.

Community engagement:

* Added a "Roboflow Discord" contact link to `.github/ISSUE_TEMPLATE/config.yml` so users can easily join the Discord server and collaborate with other community members.

Resolves https://github.com/roboflow/supervision/pull/2052#issuecomment-3738350645