### PR TITLE
Switch PR Conflict Labeler workflow to `eps1lon/actions-label-merge-conflict`

### DIFF
--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -1,25 +1,21 @@
-name: 🔴 PR Conflict Labeler
+name: PR Conflict Labeler
 
 on:
+  # So that PRs touching the same files as the push are updated
   push:
-    branches: [main, develop]
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
-
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+    types: [synchronize]
 
 jobs:
-  label:
-    name: Label PRs with conflicts
+  main:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
-      - name: 🤖 Check conflicts and manage label
-        uses: sequelize/pr-auto-update-and-handle-conflicts@74929c430b8843e691e7b83d229d8d13d78d89e3 # pinned latest commit
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@v3
         with:
-          conflict-label: has-conflict
+          dirtyLabel: "has conflicts"
+          removeOnDirtyLabel: "has conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -3,12 +3,18 @@ name: PR Conflict Labeler
 on:
   # So that PRs touching the same files as the push are updated
   push:
-  # So that the `dirtyLabel` is removed if conflicts are resolve
+    branches:
+      - main
+      - develop
+  # So that the `dirtyLabel` is removed if conflicts are resolved
   # We recommend `pull_request_target` so that github secrets are available.
   # In `pull_request` we wouldn't be able to change labels of fork PRs
   pull_request_target:
     types: [synchronize]
 
+permissions:
+  pull-requests: write
+  issues: write
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the `.github/workflows/pr-conflict-labeler.yml` workflow to improve how pull requests with merge conflicts are labeled and managed. The changes modernize the workflow, switch to a different GitHub Action for conflict labeling, and clarify event triggers.

**Workflow improvements:**

* Changed the workflow to use the `eps1lon/actions-label-merge-conflict@v3` action instead of `sequelize/pr-auto-update-and-handle-conflicts`, simplifying the configuration and focusing on labeling PRs with conflicts.
* Updated event triggers: now uses `push` and `pull_request_target` (with only the `synchronize` type) to ensure the conflict label is added or removed as appropriate, and to allow label management on forked PRs.

**Configuration and naming updates:**

* Updated the workflow and job names for clarity and removed emojis for a more standard naming convention.
* Removed unnecessary permissions and timeout settings, streamlining the workflow file.
* Adjusted input parameters to match the new action, specifying `dirtyLabel`, `removeOnDirtyLabel`, and `repoToken`.