### PR TITLE
Debugging workflow permissions and add PR dry-run

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -33,8 +33,7 @@ jobs:
           activate-environment: true
 
       - name: 🏗️ Install dependencies
-        run: |
-          uv pip install -r pyproject.toml --group docs
+        run: uv pip install -r pyproject.toml --group docs
 
       - name: 🧪 Test Docs Build
         run: uv run mkdocs build --verbose

--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -7,11 +7,18 @@ on:
       - "[0-9]+.[0-9]+[0-9]+.[0-9]+b[0-9]"
       - "[0-9]+.[0-9]+[0-9]+.[0-9]+rc[0-9]"
   workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/build-package.yml'
+      - '.github/workflows/publish-pre-release.yml'
 
 permissions: {} # Explicitly remove all permissions by default
 
 jobs:
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-package.yml
 
   publish-pre-release:
@@ -32,6 +39,7 @@ jobs:
           name: dist
 
       - name: 🚀 Publish to PyPi
+        if: github.event_name != 'pull_request'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           attestations: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,11 +5,18 @@ on:
     tags:
       - "[0-9]+.[0-9]+[0-9]+.[0-9]"
   workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/build-package.yml'
+      - '.github/workflows/publish-release.yml'
 
 permissions: {} # Explicitly remove all permissions by default
 
 jobs:
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-package.yml
 
   publish-release:
@@ -30,6 +37,7 @@ jobs:
           name: dist
 
       - name: 🚀 Publish to PyPi
+        if: github.event_name != 'pull_request'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           attestations: true

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -2,11 +2,18 @@ name: Publish Supervision Releases to TestPyPI
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/build-package.yml'
+      - '.github/workflows/publish-testpypi.yml'
 
 permissions: {} # Explicitly remove all permissions by default
 
 jobs:
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-package.yml
 
   publish-testpypi:
@@ -27,6 +34,7 @@ jobs:
           name: dist
 
       - name: 🚀 Publish to Test-PyPi
+        if: github.event_name != 'pull_request'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows related to documentation builds and package publishing. The main changes are to improve workflow security, add support for pull request-triggered builds on key branches, and ensure that publishing steps only run for non-pull-request events.

**Workflow trigger and permission improvements:**

* Added `pull_request` triggers for the `publish-testpypi.yml`, `publish-pre-release.yml`, and `publish-release.yml` workflows, limited to the `main` and `develop` branches and relevant workflow files. This allows these workflows to run on pull requests that modify packaging workflows, improving CI coverage. [[1]](diffhunk://#diff-300b085d7483ad9987af81e1ffc77b5b989917ed56dba37ff61d59770bce0e0bR5-R16) [[2]](diffhunk://#diff-b4219a56ad03f746dc054c7747e46c5352d2c05712015a7b4e2d15d30ef67986R10-R21) [[3]](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R8-R19)
* Set explicit `contents: read` permissions for the `build` job in all three publishing workflows to follow the principle of least privilege. [[1]](diffhunk://#diff-300b085d7483ad9987af81e1ffc77b5b989917ed56dba37ff61d59770bce0e0bR5-R16) [[2]](diffhunk://#diff-b4219a56ad03f746dc054c7747e46c5352d2c05712015a7b4e2d15d30ef67986R10-R21) [[3]](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R8-R19)

**Publishing safeguards:**

* Added a conditional (`if: github.event_name != 'pull_request'`) to all PyPI/TestPyPI publishing steps to prevent accidental publishing from pull requests. [[1]](diffhunk://#diff-300b085d7483ad9987af81e1ffc77b5b989917ed56dba37ff61d59770bce0e0bR37) [[2]](diffhunk://#diff-b4219a56ad03f746dc054c7747e46c5352d2c05712015a7b4e2d15d30ef67986R42) [[3]](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R40)

**Minor workflow cleanup:**

* Simplified the docs build workflow by removing unnecessary line breaks in the dependency installation step in `.github/workflows/ci-build-docs.yml`.