### PR TITLE
Debugging workflow permissions and add PR dry-run

### DIFF
--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -37,8 +37,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist
+          path: dist/
       - name: List distribution artifacts
-        run: ls -lh .
+        run: ls -lh dist/
 
       - name: 🚀 Publish to PyPi
         if: github.event_name != 'pull_request'

--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -37,6 +37,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist
+      - name: List distribution artifacts
+        run: ls -lh dist/
 
       - name: 🚀 Publish to PyPi
         if: github.event_name != 'pull_request'

--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           name: dist
       - name: List distribution artifacts
-        run: ls -lh dist/
+        run: ls -lh .
 
       - name: 🚀 Publish to PyPi
         if: github.event_name != 'pull_request'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist
+          path: dist/
       - name: List distribution artifacts
         run: ls -lh dist/
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist
+      - name: List distribution artifacts
+        run: ls -lh dist/
 
       - name: 🚀 Publish to PyPi
         if: github.event_name != 'pull_request'

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist
+          path: dist/
       - name: List distribution artifacts
         run: ls -lh dist/
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist
+      - name: List distribution artifacts
+        run: ls -lh dist/
 
       - name: 🚀 Publish to Test-PyPi
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for publishing to PyPI and TestPyPI. The main change is the addition of a step to list the distribution artifacts after downloading them, which helps with debugging and verifying the build output in CI logs.

**Workflow improvements:**

* Added a step to list the contents of the `dist/` directory after downloading build artifacts in the `publish-release.yml`, `publish-pre-release.yml`, and `publish-testpypi.yml` workflows for improved visibility and troubleshooting. [[1]](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R38-R40) [[2]](diffhunk://#diff-b4219a56ad03f746dc054c7747e46c5352d2c05712015a7b4e2d15d30ef67986R40-R42) [[3]](diffhunk://#diff-300b085d7483ad9987af81e1ffc77b5b989917ed56dba37ff61d59770bce0e0bR35-R37)
* Explicitly specified the `path: dist/` option when downloading the `dist` artifact in all three workflows to ensure artifacts are placed in the correct directory. [[1]](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R38-R40) [[2]](diffhunk://#diff-b4219a56ad03f746dc054c7747e46c5352d2c05712015a7b4e2d15d30ef67986R40-R42) [[3]](diffhunk://#diff-300b085d7483ad9987af81e1ffc77b5b989917ed56dba37ff61d59770bce0e0bR35-R37)