### PR TITLE
Enable rendering of type annotations in signature headers

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,8 @@ plugins:
             show_root_heading: True
             show_symbol_type_toc: true
             show_category_heading: true
+            # Optional: render types in the signature header itself
+            show_signature_annotations: true
           inventories:
           - url: https://docs.python-requests.org/en/master/objects.inv
             domains: [std, py]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,7 +143,6 @@ plugins:
             show_root_heading: True
             show_symbol_type_toc: true
             show_category_heading: true
-            # Optional: render types in the signature header itself
             show_signature_annotations: true
           inventories:
           - url: https://docs.python-requests.org/en/master/objects.inv


### PR DESCRIPTION
This pull request makes a small configuration enhancement to the documentation build process by enabling the display of type annotations in function signatures.

- Documentation configuration:
  * [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R146-R147): Enabled the `show_signature_annotations` option in the `plugins` section to render type annotations in the signature headers.

REF: https://mkdocstrings.github.io/python/usage/configuration/signatures/#show_signature_annotations