### PR TITLE
typing/assets: Add type hints to methods and polish docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,8 +205,6 @@ module = [
   # TODO: fix type errors in the following modules
   "supervision.annotators.core",
   "supervision.annotators.utils",
-  "supervision.assets.downloader",
-  "supervision.assets.list",
   "supervision.classification.core",
   "supervision.dataset.core",
   "supervision.dataset.formats.coco",

--- a/supervision/assets/downloader.py
+++ b/supervision/assets/downloader.py
@@ -19,11 +19,11 @@ def is_md5_hash_matching(filename: str, original_md5_hash: str) -> bool:
     not for cryptographic security purposes.
 
     Parameters:
-        filename (str): The path to the file to be checked as a string.
-        original_md5_hash (str): The original MD5 hash to compare against.
+        filename: The path to the file to be checked as a string.
+        original_md5_hash: The original MD5 hash to compare against.
 
     Returns:
-        bool: True if the hashes match, False otherwise.
+        True if the hashes match, False otherwise.
     """
     if not os.path.exists(filename):
         return False
@@ -40,11 +40,11 @@ def download_assets(asset_name: VideoAssets | str) -> str:
     Download a specified asset if it doesn't already exist or is corrupted.
 
     Parameters:
-        asset_name (Union[VideoAssets, str]): The name or type of the asset to be
+        asset_name: The name or type of the asset to be
             downloaded.
 
     Returns:
-        str: The filename of the downloaded asset.
+        The filename of the downloaded asset.
 
     Example:
         ```python

--- a/supervision/assets/list.py
+++ b/supervision/assets/list.py
@@ -34,7 +34,7 @@ class VideoAssets(Enum):
     SKIING = "skiing.mp4"
 
     @classmethod
-    def list(cls):
+    def list(cls) -> list[str]:
         return list(map(lambda c: c.value, cls))
 
 


### PR DESCRIPTION
This pull request introduces minor improvements to type annotations and docstrings for better code clarity and consistency. The changes are primarily focused on specifying return types and simplifying docstring parameter descriptions.

Type annotation improvements:

* Added an explicit return type annotation (`-> list[str]`) to the `list` class method in the `VideoAssets` enum in `list.py`.

Docstring simplification and clarification:

* Simplified parameter and return value descriptions in the docstrings of `is_md5_hash_matching` and `download_assets` by removing redundant type information and making the descriptions more concise in `downloader.py`. [[1]](diffhunk://#diff-d9921872917855303ab3c08d0fe3093edae712908603836071dbf7a18b58bec1L22-R26) [[2]](diffhunk://#diff-d9921872917855303ab3c08d0fe3093edae712908603836071dbf7a18b58bec1L43-R47)

---

Part of #2088