### PR TITLE
ci: Remove conflicted `removeOnDirtyLabel` from PR labeling

### DIFF
--- a/.github/workflows/pr-conflict-labeler.yml
+++ b/.github/workflows/pr-conflict-labeler.yml
@@ -23,5 +23,4 @@ jobs:
         uses: eps1lon/actions-label-merge-conflict@v3
         with:
           dirtyLabel: "has conflicts"
-          removeOnDirtyLabel: "has conflicts"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This pull request makes a minor update to the pull request conflict labeling workflow by removing the `removeOnDirtyLabel` configuration from the `.github/workflows/pr-conflict-labeler.yml` file. This simplifies the workflow configuration.

---

The `removeOnDirtyLabel` parameter is configured with the same value as `dirtyLabel`. This parameter should specify labels to remove when a PR becomes dirty (has conflicts), not the label that indicates conflicts. Setting both to "has conflicts" creates a logical conflict. Either remove this parameter entirely (the action automatically removes `dirtyLabel` when conflicts are resolved), or set it to a different label like "ready to merge" if you want to remove that label when conflicts appear.