### PR TITLE
Chore release to use GH release events for PyPI & asset publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: 🚀 Publish to PyPi
         # We only want to publish to PyPi if the event is a release and it's not a pre-release.
-        if: github.event_name == 'release' && github.event.release.prerelease != true
+        if: (github.event_name == 'release' && github.event.release.prerelease != true) || github.event_name == 'workflow_dispatch'
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           attestations: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,7 +46,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🚀 Publish to PyPi
-        if: github.event_name != 'release' || github.event.release.prerelease != true
+        # We only want to publish to PyPi if the event is a release and it's not a pre-release.
+        if: github.event_name == 'release' && github.event.release.prerelease != true
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           attestations: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,7 +46,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🚀 Publish to PyPi
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'release' || github.event.release.prerelease != true
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           attestations: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,9 +1,8 @@
 name: Publish Supervision Releases to PyPI
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+[0-9]+.[0-9]"
+  release:
+    types: [published]
   workflow_dispatch:
   pull_request:
     branches: [main, develop]
@@ -29,7 +28,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       id-token: write # Required for PyPI publishing
-      contents: read # Required for checkout
+      contents: write # Required for checkout and upload assets
     steps:
       - name: 📥 Download distribution artifacts
         uses: actions/download-artifact@v7
@@ -38,6 +37,13 @@ jobs:
           path: dist/
       - name: List distribution artifacts
         run: ls -lh dist/
+
+      - name: 📦 Upload assets to Release
+        if: github.event_name == 'release'
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: 'dist/*'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🚀 Publish to PyPi
         if: github.event_name != 'pull_request'

--- a/release_process.md
+++ b/release_process.md
@@ -14,7 +14,7 @@ It assumes you already have the code changes, as well as a draft of the release 
     - Run `git tag x.y.z`, with your version
     - Check with `git log`.
     - Run `git push origin --tags`
-    - Upon pushing the tag, the [PyPi](https://pypi.org/project/supervision/) should update to the new version. Check this!
+    - Upon pushing the Github release, the [PyPi](https://pypi.org/project/supervision/) should update to the new version. Check this!
 4. Open and merge a PR, merging `main` into `develop`.
 5. Update the docs by running the [Supervision Release Documentation Workflow 📚](https://github.com/roboflow/supervision/actions/workflows/publish-release-docs.yml) workflow from GitHub.
     - Select the `main` branch from the dropdown.


### PR DESCRIPTION
This pull request updates the release workflow for publishing to PyPI, making the process trigger on GitHub release publication instead of tag pushes. It also improves how release assets are managed and clarifies the release process documentation.

**Workflow trigger and permissions changes:**

* Changed the workflow trigger in `.github/workflows/publish-release.yml` to run on GitHub release publication (`release: published`) instead of tag pushes.
* Updated permissions for the workflow job to allow writing to `contents`, which is needed for both checkout and uploading assets.

**Release asset management:**

* Added a step to upload distribution artifacts from the `dist/` directory as assets to the GitHub Release using the `AButler/upload-release-assets` action.

**Documentation update:**

* Updated `release_process.md` to indicate that publishing to PyPI is now triggered by publishing a GitHub release, not by pushing a tag.