### PR TITLE
test: add regression test for numpy color lookup

### DIFF
--- a/test/annotators/test_core.py
+++ b/test/annotators/test_core.py
@@ -119,6 +119,28 @@ class TestBoxAnnotator:
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert_image_mostly_same(test_image, result, similarity_threshold=0.85)
 
+    def test_annotate_with_numpy_color_lookup(self, test_image):
+        """Test that annotate method works when color lookup is provided as numpy array"""
+        detections = Detections(
+            xyxy=np.array([[10, 10, 20, 20], [30, 30, 40, 40]], dtype=np.float32),
+            confidence=np.array([0.38, 0.21], dtype=np.float32),
+            class_id=np.array([0, 0], dtype=np.int64),
+            tracker_id=None,
+        )
+
+        lookup = np.array([1, 0], dtype=np.int16)
+
+        annotator = BoxAnnotator(
+            color=Color.WHITE, thickness=2, color_lookup=ColorLookup.INDEX
+        )
+
+        result = annotator.annotate(
+            scene=test_image.copy(),
+            detections=detections,
+            custom_color_lookup=lookup,
+        )
+        assert result.shape == test_image.shape
+
 
 class TestOrientedBoxAnnotator:
     """Tests for OrientedBoxAnnotator class"""
@@ -530,3 +552,9 @@ class TestComparisonAnnotator:
             scene=image.copy(), detections_1=detections1, detections_2=detections2
         )
         assert not np.array_equal(image, result)
+
+
+
+
+
+

--- a/test/annotators/test_core.py
+++ b/test/annotators/test_core.py
@@ -139,7 +139,7 @@ class TestBoxAnnotator:
             detections=detections,
             custom_color_lookup=lookup,
         )
-        assert result.shape == test_image.shape
+        assert_image_mostly_same(test_image, result, similarity_threshold=0.85)
 
 
 class TestOrientedBoxAnnotator:

--- a/test/annotators/test_core.py
+++ b/test/annotators/test_core.py
@@ -552,9 +552,3 @@ class TestComparisonAnnotator:
             scene=image.copy(), detections_1=detections1, detections_2=detections2
         )
         assert not np.array_equal(image, result)
-
-
-
-
-
-

--- a/test/annotators/test_core.py
+++ b/test/annotators/test_core.py
@@ -120,7 +120,7 @@ class TestBoxAnnotator:
         assert_image_mostly_same(test_image, result, similarity_threshold=0.85)
 
     def test_annotate_with_numpy_color_lookup(self, test_image):
-        """Test that annotate method works when color lookup is provided as numpy array"""
+        """Test that annotate works when color lookup is a NumPy array"""
         detections = Detections(
             xyxy=np.array([[10, 10, 20, 20], [30, 30, 40, 40]], dtype=np.float32),
             confidence=np.array([0.38, 0.21], dtype=np.float32),


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [ ] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [ ] Added docs entry for autogeneration (if new functions/classes)
- [x] Added/updated tests
- [x] All tests pass locally

</details>

## Description

Add a regression test to ensure `BoxAnnotator.annotate` works when the color lookup is provided as a numpy array.

## Type of Change

- [x] 🧪 Test update
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Prevents regressions for the crash reported in #1983 when passing a numpy array as a custom color lookup.

Closes #1983

## Changes Made

- Added a regression test in `test/annotators/test_core.py` covering numpy array color lookup in `BoxAnnotator.annotate`.

## Testing

- [x] I have tested this code locally (`poetry run pytest`)
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
