### PR TITLE
Enable testing doctest in the package docstrings

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: uv run python -c "import supervision; from supervision import assets; from supervision import metrics; print(supervision.__version__)"
 
       - name: 🧪 Run the Test
-        run: uv run pytest --cov=supervision --cov-report=xml
+        run: uv run pytest --cov=supervision --cov-report=xml --exclude=examples
 
       - name: Generate Coverage Report
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: uv run python -c "import supervision; from supervision import assets; from supervision import metrics; print(supervision.__version__)"
 
       - name: 🧪 Run the Test
-        run: uv run pytest --cov=supervision --cov-report=xml --exclude=examples
+        run: uv run pytest --cov=supervision --cov-report=xml --ignore=examples
 
       - name: Generate Coverage Report
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,3 +260,10 @@ ignore_errors = true
 [tool.autoflake]
 check = true
 imports = [ "cv2", "supervision" ]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--doctest-modules",
+    "--color=yes",
+]
+doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,13 @@ count = true
 quiet-level = 3
 ignore-words-list = "STrack,sTrack,strack"
 
+[tool.pytest.ini_options]
+addopts = [
+  "--doctest-modules",
+  "--color=yes",
+]
+doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"
+
 [tool.mypy]
 python_version = "3.9"
 ignore_missing_imports = false
@@ -260,10 +267,3 @@ ignore_errors = true
 [tool.autoflake]
 check = true
 imports = [ "cv2", "supervision" ]
-
-[tool.pytest.ini_options]
-addopts = [
-    "--doctest-modules",
-    "--color=yes",
-]
-doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"

--- a/supervision/validators/__init__.py
+++ b/supervision/validators/__init__.py
@@ -4,6 +4,10 @@ import numpy as np
 
 
 def validate_xyxy(xyxy: Any) -> None:
+    """Validate that xyxy is a 2D np.ndarray with shape (N, 4).
+
+    >>> validate_xyxy(np.array([[0, 0, 1, 1], [1, 1, 2, 2]]))
+    """
     expected_shape = "(_, 4)"
     actual_shape = str(getattr(xyxy, "shape", None))
     is_valid = isinstance(xyxy, np.ndarray) and xyxy.ndim == 2 and xyxy.shape[1] == 4


### PR DESCRIPTION
This pull request adds configuration options for running doctests and improves test output readability. The most important changes are grouped below:

Testing configuration improvements:

* Added a `[tool.pytest.ini_options]` section to `pyproject.toml` to enable doctest discovery (`--doctest-modules`), colored test output (`--color=yes`), and set doctest option flags to allow ellipsis and whitespace normalization.

---

bottom line, requirement to start work on #2106