### PR TITLE
Remove unnecessary `fetch-depth` parameter from CI docs

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: 🐍 Install uv and set Python
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration by removing the `fetch-depth: 0` option from the repository checkout step. This change simplifies the repository checkout process in the `.github/workflows/ci-build-docs.yml` workflow.