### PR TITLE
Update `pyproject.toml`: simplify license field and remove legacy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
   "Roboflow",
   "vision",
 ]
-license = { text = "MIT" }
+license = "MIT"
 maintainers = [
   { name = "Piotr Skalski", email = "piotr@roboflow.com" },
 ]
@@ -29,7 +29,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Education",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: MacOS",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [ ] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [ ] Added docs entry for autogeneration (if new functions/classes)
- [ ] Added/updated tests
- [x] All tests pass locally

</details>

## Description

This pull request makes minor updates to the `pyproject.toml` file, focusing on license metadata. The changes clarify the license specification and adjust the list of classifiers.

- License metadata update:
  * Changed the `license` field from a table to a simple string format for better compatibility.
  * Removed the redundant `License :: OSI Approved :: MIT License` entry from the `classifiers` list.

## Type of Change

<!-- Mark the relevant option with an "x" and delete the others -->

- 🔧 Chore (dependencies, configs, etc.)

## Motivation and Context

Addresses
```
Building wheel from source distribution...
/home/runner/work/_temp/setup-uv-cache/builds-v0/.tmpBkbnI9/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2027-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/home/runner/work/_temp/setup-uv-cache/builds-v0/.tmpBkbnI9/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
/home/runner/work/_temp/setup-uv-cache/builds-v0/.tmpBkbnI9/lib/python3.10/site-packages/setuptools/dist.py:765: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```
