### PR TITLE
Refine CI with link checks for forked PRs

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -10,4 +10,6 @@ exclude = [
     "http://127.0.0.1:8000",  # hint for local docs server
     "https://sam2.metademolab.com/",  # returns 403 Forbidden
     "https://snyk.io/advisor/python/supervision/badge.svg",  # badge URL
+    "https://universe.roboflow.com/",
+    "https://universe.roboflow.com/model-examples/segmented-animals-basic",
 ]

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -30,6 +30,7 @@ jobs:
           cat README.md
 
       - name: 🔗 Link Checker
+        if: github.repository == 'roboflow/supervision'
         uses: lycheeverse/lychee-action@v2
         with:
           lycheeVersion: v0.22.0

--- a/.github/workflows/ci-check-links.yml
+++ b/.github/workflows/ci-check-links.yml
@@ -27,7 +27,6 @@ jobs:
           lycheeVersion: v0.22.0
           args: |
             --config .github/lychee.toml
-            ${{ secrets.UNIVERSE_RATELIMIT_BYPASS_KEY != '' && format('--header "x-ratelimit-bypass: {0}"', secrets.UNIVERSE_RATELIMIT_BYPASS_KEY) || '--exclude "https://universe.roboflow.com/.*"' }}
             './**/*.md'
           # TODO: enable also following file types
           # './**/*.toml'


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflows related to link checking. The main update is that the link checker job in the `build-package.yml` workflow will now only run for the `roboflow/supervision` repository.

* The link checker step in `.github/workflows/build-package.yml` is now conditional and will only execute if the workflow is running in the `roboflow/supervision` repository.

No other significant changes were made.