### PR TITLE
Standardize examples and error with `uv` CLI

### DIFF
--- a/examples/count_people_in_zone/README.md
+++ b/examples/count_people_in_zone/README.md
@@ -24,14 +24,14 @@ https://github.com/roboflow/supervision/assets/26109316/f84db7b5-79e2-4142-a1da-
 - setup python environment and activate it [optional]
 
     ```bash
-    python3 -m venv venv
-    source venv/bin/activate
+    uv venv
+    source .venv/bin/activate
     ```
 
 - install required dependencies
 
     ```bash
-    pip install -r requirements.txt
+    uv pip install -r requirements.txt
     ```
 
 - download `traffic_analysis.pt` and `traffic_analysis.mov` files

--- a/examples/heatmap_and_track/README.md
+++ b/examples/heatmap_and_track/README.md
@@ -18,14 +18,14 @@ supervision package for multiple tasks such as drawing heatmap annotations, trac
 - setup python environment and activate it [optional]
 
     ```bash
-    python3 -m venv venv
-    source venv/bin/activate
+    uv venv
+    source .venv/bin/activate
     ```
 
 - install required dependencies
 
     ```bash
-    pip install -r requirements.txt
+    uv pip install -r requirements.txt
     ```
 
 ## 🛠️ script arguments

--- a/examples/speed_estimation/README.md
+++ b/examples/speed_estimation/README.md
@@ -29,20 +29,20 @@ https://github.com/roboflow/supervision/assets/26109316/d50118c1-2ae4-458d-915a-
 - setup python environment and activate it [optional]
 
     ```bash
-    python3.10 -m venv venv
-    source venv/bin/activate
+    uv venv
+    source .venv/bin/activate
     ```
 
 - install required dependencies
 
     ```bash
-    pip install -r requirements.txt
+    uv pip install -r requirements.txt
     ```
 
 - download `vehicles.mp4` file
 
     ```bash
-    python3.10 video_downloader.py
+    python video_downloader.py
     ```
 
 ## 🛠️ script arguments

--- a/examples/time_in_zone/README.md
+++ b/examples/time_in_zone/README.md
@@ -23,14 +23,14 @@ https://github.com/roboflow/supervision/assets/26109316/d051cc8a-dd15-41d4-aa36-
 - setup python environment and activate it [optional]
 
     ```bash
-    python3 -m venv venv
-    source venv/bin/activate
+    uv venv
+    source .venv/bin/activate
     ```
 
 - install required dependencies
 
     ```bash
-    pip install -r requirements.txt
+    uv pip install -r requirements.txt
     ```
 
 ## 🛠 scripts

--- a/examples/tracking/README.md
+++ b/examples/tracking/README.md
@@ -17,14 +17,14 @@ detection and Supervision for tracking and annotation.
 - setup python environment and activate it [optional]
 
     ```bash
-    python3 -m venv venv
-    source venv/bin/activate
+    uv venv
+    source .venv/bin/activate
     ```
 
 - install required dependencies
 
     ```bash
-    pip install -r requirements.txt
+    uv pip install -r requirements.txt
     ```
 
 ## 🛠️ script arguments

--- a/examples/traffic_analysis/README.md
+++ b/examples/traffic_analysis/README.md
@@ -20,14 +20,14 @@ https://github.com/roboflow/supervision/assets/26109316/c9436828-9fbf-4c25-ae8c-
 - setup python environment and activate it [optional]
 
     ```bash
-    python3 -m venv venv
-    source venv/bin/activate
+    uv venv
+    source .venv/bin/activate
     ```
 
 - install required dependencies
 
     ```bash
-    pip install -r requirements.txt
+    uv pip install -r requirements.txt
     ```
 
 - download `traffic_analysis.pt` and `traffic_analysis.mov` files

--- a/supervision/metrics/utils/utils.py
+++ b/supervision/metrics/utils/utils.py
@@ -4,7 +4,6 @@ def ensure_pandas_installed() -> None:
     except ImportError:
         raise ImportError(
             "`metrics` extra is required to run the function."
-            " Run `pip install 'supervision[metrics]'` or"
-            " `poetry add supervision -E metrics` or"
-            " `uv pip install 'supervision[metrics]'`"
+            " Run `uv pip install 'supervision[metrics]'` or"
+            " `uv add supervision --extra metrics`."
         )


### PR DESCRIPTION
This pull request updates the project documentation and utility messages to standardize on using the `uv` package manager for Python environment setup and dependency installation, replacing previous instructions that used `python -m venv`, `pip`, and `poetry`. This improves consistency and clarity for users following the setup instructions across multiple example projects.

**Documentation updates for environment setup and dependencies:**

* Updated all example `README.md` files to use `uv` for creating virtual environments (`uv venv`) and installing dependencies (`uv pip install -r requirements.txt`), and to activate the environment from `.venv` instead of `venv`. [[1]](diffhunk://#diff-cac46ed943c13188236ddb2ddca2b2808497da18f3827f46e5284fe1bf173253L27-R34) [[2]](diffhunk://#diff-bb0f207865c09ed97f3c5d97e7cac901141a58e03e4d3a70dea16aeb43709621L23-R30) [[3]](diffhunk://#diff-b30c5b65ce00fe028ebe90cc6e9c400a8cf1854baaf3767699e295853d1f9adeL32-R45) [[4]](diffhunk://#diff-1a8503bc5a10c4db7735fe16f11429a745e9c705f08da2bdc0ebe059764ded1eL26-R33) [[5]](diffhunk://#diff-75208c27f3474301a9b911c4e1ac4e520ec3f74f5689312afdd56eebb58e28beL21-R28) [[6]](diffhunk://#diff-6b20e7969a2229b3c99f8bd68d6432afb88351e88f219719a395bc4a580b48daL20-R27)
* Changed example command for running scripts to use `python` instead of version-specific `python3.10` where applicable.

**Error message improvements:**

* Updated the `ensure_pandas_installed` utility function to reference `uv` commands for installing the required `metrics` extra, removing references to `pip` and `poetry`.

---

Bottom line, due to lose depency ranges, some examples become challenging to install