### PR TITLE
fix PT011: Add `match` arguments to all `pytest.raises`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,8 +166,7 @@ lint.per-file-ignores."src/**" = [
   "S101", # TODO: Replace asserts with proper error handling
 ]
 lint.per-file-ignores."tests/**" = [
-  "PT011", # TODO: `pytest.raises(Exception)` is too broad, set the `match` parameter or use a more specific exception
-  "S101",  # Use of `assert` detected
+  "S101", # Use of `assert` detected
 ]
 lint.unfixable = [  ]
 # Allow unused variables when underscore-prefixed.

--- a/tests/annotators/test_utils.py
+++ b/tests/annotators/test_utils.py
@@ -51,7 +51,7 @@ from tests.helpers import _create_detections
             0,
             ColorLookup.INDEX,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="out of bounds for detections of length 0"),
         ),  # no detections; index lookup; out of bounds
         (
             _create_detections(
@@ -62,21 +62,21 @@ from tests.helpers import _create_detections
             2,
             ColorLookup.INDEX,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Detection index 2"),
         ),  # multiple detections; index lookup; out of bounds
         (
             _create_detections(xyxy=[[10, 10, 20, 20], [20, 20, 30, 30]]),
             0,
             ColorLookup.CLASS,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="resolve color by class"),
         ),  # multiple detections; class lookup; no class_id
         (
             _create_detections(xyxy=[[10, 10, 20, 20], [20, 20, 30, 30]]),
             0,
             ColorLookup.TRACK,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="resolve color by track"),
         ),  # multiple detections; class lookup; no track_id
         (
             _create_detections(xyxy=[[10, 10, 20, 20], [20, 20, 30, 30]]),
@@ -90,7 +90,7 @@ from tests.helpers import _create_detections
             0,
             np.array([1]),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Length of color lookup 1"),
         ),  # multiple detections; custom lookup; wrong length
     ],
 )
@@ -152,13 +152,13 @@ def test_resolve_color_idx(
             "What is dead may never die",
             0,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="max_line_length must be"),
         ),  # width 0 - invalid
         (
             "A Lannister always pays his debts",
             -1,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="positive integer"),
         ),  # width -1 - invalid
         (None, 10, [""], DoesNotRaise()),  # text None, width set
     ],

--- a/tests/assets/test_downloader.py
+++ b/tests/assets/test_downloader.py
@@ -102,7 +102,7 @@ class TestDownloadAssets:
         """Test download_assets with invalid asset name."""
         invalid_filename = "invalid.mp4"
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="Invalid asset") as exc_info:
             download_assets(invalid_filename)
 
         assert "Invalid asset" in str(exc_info.value)

--- a/tests/classification/test_core.py
+++ b/tests/classification/test_core.py
@@ -37,14 +37,14 @@ from supervision.classification.core import Classifications
             np.array([]),
             5,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match=r"confidence must be 1d np\.ndarray"),
         ),  # class_id with 5 numbers and 0 confidences
         (
             [0, 1, 2, 3, 4],
             [0.1, 0.2, 0.3, 0.4],
             5,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="\\(n, \\) shape"),
         ),  # class_id with 5 numbers and 4 confidences
     ],
 )

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -168,7 +168,7 @@ from tests.helpers import _create_detections
                 ),
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="not unique across datasets"),
         ),
     ],
 )

--- a/tests/dataset/test_utils.py
+++ b/tests/dataset/test_utils.py
@@ -136,7 +136,7 @@ def test_merge_class_maps(
             ["dog", "person"],
             [],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Class dog not found"),
         ),  # empty target class list
         (
             ["dog", "person"],
@@ -160,7 +160,7 @@ def test_merge_class_maps(
             ["dog", "person"],
             ["cat", "dog"],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Class person not found"),
         ),  # source class list is not a subset of target class list
     ],
 )
@@ -184,7 +184,7 @@ def test_build_class_index_mapping(
             {},
             _create_detections(xyxy=[[0, 0, 10, 10]], class_id=[0]),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="subset of source_to_target_mapping"),
         ),  # empty mapping
         (
             {0: 1},
@@ -214,7 +214,7 @@ def test_build_class_index_mapping(
             {0: 1, 1: 2},
             _create_detections(xyxy=[[0, 0, 10, 10]], class_id=[2]),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="source_to_target_mapping keys"),
         ),  # class_id not in mapping
         (
             {0: 1, 1: 2},
@@ -279,12 +279,12 @@ def test_map_detections_class_id(
         (
             np.array([[[]]]).astype(bool),
             None,
-            pytest.raises(AssertionError),
+            pytest.raises(AssertionError, match="Input mask must be 2D"),
         ),  # raises AssertionError because mask dimensionality is not 2D
         (
             np.array([[]]).astype(bool),
             None,
-            pytest.raises(AssertionError),
+            pytest.raises(AssertionError, match="Input mask cannot be empty"),
         ),  # raises AssertionError because mask is empty
     ],
 )
@@ -349,7 +349,9 @@ def test_mask_to_rle(
             np.array([0, 5, 5, 5, 5, 5]),
             [2, 2],
             None,
-            pytest.raises(AssertionError),
+            pytest.raises(
+                AssertionError, match="sum of the number of pixels in the RLE"
+            ),
         ),  # raises AssertionError because number of pixels in RLE does not match
         # number of pixels in expected mask (width x height).
     ],

--- a/tests/detection/test_core.py
+++ b/tests/detection/test_core.py
@@ -231,16 +231,26 @@ TEST_DET_DIFFERENT_METADATA = Detections(
         ),
         # Scenario: Index out of range.
         # Expected: IndexError is raised.
-        (DETECTIONS, 10, None, pytest.raises(IndexError)),
-        (DETECTIONS, [0, 2, 10], None, pytest.raises(IndexError)),
-        (DETECTIONS, np.array([0, 2, 10]), None, pytest.raises(IndexError)),
+        (DETECTIONS, 10, None, pytest.raises(IndexError, match="index 10 is out")),
+        (
+            DETECTIONS,
+            [0, 2, 10],
+            None,
+            pytest.raises(IndexError, match="out of bounds for axis 0"),
+        ),
+        (
+            DETECTIONS,
+            np.array([0, 2, 10]),
+            None,
+            pytest.raises(IndexError, match="axis 0 with size"),
+        ),
         (
             DETECTIONS,
             np.array(
                 [True, True, True, True, True, True, True, True, True, True, True]
             ),
             None,
-            pytest.raises(IndexError),
+            pytest.raises(IndexError, match="boolean index did not match"),
         ),
         # Scenario: Filter an empty Detections object.
         # Expected: Returns an empty Detections object without crashing.
@@ -321,18 +331,18 @@ def test_getitem(
                 TEST_DET_NONE,
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="mask' fields must be None"),
         ),  # Empty detection, but not Detections.empty()
         # Errors: Non-zero-length differently defined keys & data
         (
             [TEST_DET_1, TEST_DET_DIFFERENT_FIELDS],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="confidence' fields must be None"),
         ),  # Non-empty detections with different fields
         (
             [TEST_DET_1, TEST_DET_DIFFERENT_DATA],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="same keys to merge"),
         ),  # Non-empty detections with different data keys
         (
             [
@@ -377,7 +387,7 @@ def test_getitem(
                 Detections(xyxy=np.array([[30, 30, 40, 40]]), class_id=np.array([2])),
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="metadata dictionaries must have the same"),
         ),  # Empty and non-empty metadata
         (
             [
@@ -428,7 +438,9 @@ def test_getitem(
                 ),
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError, match="Conflicting metadata for key: 'source'\\."
+            ),
         ),  # Different metadata values
         (
             [
@@ -457,7 +469,7 @@ def test_getitem(
                 ),
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="metadata for key: 'source'"),
         ),  # Inconsistent types in metadata values
         (
             [
@@ -469,7 +481,7 @@ def test_getitem(
                 ),
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="same keys to merge"),
         ),  # Metadata key mismatch
         (
             [
@@ -526,7 +538,7 @@ def test_getitem(
                 ),
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="calibration_matrix"),
         ),  # Mismatching 2D numpy arrays in metadata
     ],
 )
@@ -694,7 +706,7 @@ def test_equal(
             ),
             Detections.empty(),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="exactly 1 detected object"),
         ),  # merge with empty: error
         (
             _create_detections(
@@ -704,7 +716,7 @@ def test_equal(
                 xyxy=[[10, 10, 30, 30], [40, 40, 60, 60]],
             ),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Both Detections should have"),
         ),  # merge with 2+ objects: error
         (
             _create_detections(
@@ -797,7 +809,7 @@ def test_equal(
                 confidence=[0.2],
             ),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Field 'confidence'"),
         ),  # confidence: None + [x]
         (
             _create_detections(
@@ -809,7 +821,7 @@ def test_equal(
                 mask=None,
             ),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Field 'mask'"),
         ),  # mask: None + [x]
         (
             _create_detections(xyxy=[[0, 0, 20, 20]], tracker_id=[1]),
@@ -818,7 +830,7 @@ def test_equal(
                 tracker_id=None,
             ),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Field 'tracker_id'"),
         ),  # tracker_id: None + []
         (
             _create_detections(xyxy=[[0, 0, 20, 20]], class_id=[1]),
@@ -827,7 +839,7 @@ def test_equal(
                 class_id=None,
             ),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Field 'class_id'"),
         ),  # class_id: None + []
     ],
 )

--- a/tests/detection/test_line_counter.py
+++ b/tests/detection/test_line_counter.py
@@ -15,12 +15,12 @@ from tests.helpers import _create_detections
         (
             Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=0.0)),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="magnitude of the vector"),
         ),
         (
             Vector(start=Point(x=1.0, y=1.0), end=Point(x=1.0, y=1.0)),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="cannot be zero"),
         ),
         (
             Vector(start=Point(x=0.0, y=0.0), end=Point(x=0.0, y=4.0)),

--- a/tests/detection/test_polygonzone.py
+++ b/tests/detection/test_polygonzone.py
@@ -96,7 +96,7 @@ def test_polygon_zone_trigger(
         (
             POLYGON,
             [],
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Triggering anchors cannot be empty"),
         ),
     ],
 )

--- a/tests/detection/test_vlm.py
+++ b/tests/detection/test_vlm.py
@@ -170,14 +170,26 @@ from supervision.detection.vlm import (
             ),
         ),  # partial valid again
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution must be positive\. "
+                    r"Got \(0, 1000\)"
+                ),
+            ),
             "<loc0256><loc0256><loc0768><loc0768> cat",
             (0, 1000),
             None,
             None,
         ),  # zero width -> ValueError
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution must be positive\. "
+                    r"Got \(1000, -200\)"
+                ),
+            ),
             "<loc0256><loc0256><loc0768><loc0768> dog",
             (1000, -200),
             None,
@@ -358,7 +370,13 @@ def test_from_paligemma(
             ),
         ),  # truncated response, last object unfinished, previous ones recovered
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution must be positive\. "
+                    r"Got \(0, 640\)"
+                ),
+            ),
             """```json
             [
                 {"bbox_2d": [10, 20, 110, 120], "label": "cat"}
@@ -370,7 +388,13 @@ def test_from_paligemma(
             None,  # invalid input_wh
         ),
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution must be positive\. "
+                    r"Got \(1280, -100\)"
+                ),
+            ),
             """```json
             [
                 {"bbox_2d": [10, 20, 110, 120], "label": "dog"}
@@ -503,7 +527,13 @@ def test_from_qwen_2_5_vl(
             ),
         ),  # complete class filtering with multiple boxes
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution must be positive\. "
+                    r"Got \(0, 480\)"
+                ),
+            ),
             """```json
             [
                 {"box_2d": [10, 20, 110, 120], "label": "cat"}
@@ -514,7 +544,13 @@ def test_from_qwen_2_5_vl(
             None,
         ),  # zero resolution width -> ValueError
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution must be positive\. "
+                    r"Got \(640, -100\)"
+                ),
+            ),
             """```json
             [
                 {"box_2d": [10, 20, 110, 120], "label": "cat"}
@@ -607,7 +643,13 @@ def test_from_google_gemini(
             np.array([[0.0, 0.0, 1000.0, 800.0]]),
         ),  # full image box
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution_wh must be positive\. "
+                    r"Got \(0, 480\)"
+                ),
+            ),
             {
                 "objects": [
                     {"x_min": 0.1, "y_min": 0.2, "x_max": 0.3, "y_max": 0.4},
@@ -617,7 +659,13 @@ def test_from_google_gemini(
             None,
         ),  # zero width -> ValueError
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution_wh must be positive\. "
+                    r"Got \(640, -100\)"
+                ),
+            ),
             {
                 "objects": [
                     {"x_min": 0.1, "y_min": 0.2, "x_max": 0.3, "y_max": 0.4},
@@ -672,7 +720,7 @@ def test_from_moondream(
             {"<CAPTION>": "A green car parked in front of a yellow building."},
             (10, 10),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="<CAPTION> not supported"),
         ),
         (  # Detailed Caption: unsupported
             {
@@ -682,7 +730,7 @@ def test_from_moondream(
             },
             (10, 10),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="<DETAILED_CAPTION> not supported"),
         ),
         (  # More Detailed Caption: unsupported
             {
@@ -698,7 +746,7 @@ def test_from_moondream(
             },
             (10, 10),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="<MORE_DETAILED_CAPTION> not supported"),
         ),
         (  # Caption to Phrase Grounding: empty
             {"<CAPTION_TO_PHRASE_GROUNDING>": {"bboxes": [], "labels": []}},
@@ -796,7 +844,7 @@ def test_from_moondream(
             {"<OCR>": "A"},
             (10, 10),
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="<OCR> not supported"),
         ),
         (  # OCR with Region: obb boxes
             {
@@ -1026,7 +1074,13 @@ def test_florence_2(
             ),
         ),
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution must be positive\. "
+                    r"Got \(0, 480\)"
+                ),
+            ),
             """```json
             [
                 {"box_2d": [10, 20, 110, 120], "label": "cat"}
@@ -1037,7 +1091,13 @@ def test_florence_2(
             None,
         ),
         (
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError,
+                match=(
+                    r"Both dimensions in resolution must be positive\. "
+                    r"Got \(640, -100\)"
+                ),
+            ),
             """```json
             [
                 {"box_2d": [10, 20, 110, 120], "label": "cat"}
@@ -1136,14 +1196,14 @@ def test_from_google_gemini_2_5(
     ("exception", "result", "resolution_wh", "classes", "expected_detections"),
     [
         (
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match=r"xyxy must be a 2D np\.ndarray"),
             "",
             (100, 100),
             None,
             None,
         ),  # empty text
         (
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match=r"xyxy must be a 2D np\.ndarray"),
             "random text",
             (100, 100),
             None,
@@ -1193,14 +1253,14 @@ def test_from_google_gemini_2_5(
             ),
         ),  # multiple boxes, one class correct
         (
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="ref tags \\(1\\)"),
             "<|ref|>cat<|/ref|>",
             (100, 100),
             None,
             None,
         ),  # only ref
         (
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="ref tags \\(0\\)"),
             "<|det|>[[100, 200, 300, 400]]<|/det|>",
             (100, 100),
             None,

--- a/tests/detection/utils/test_internal.py
+++ b/tests/detection/utils/test_internal.py
@@ -336,7 +336,7 @@ def test_process_roboflow_result(
                 {"test_2": [3, 2, 1]},
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="same keys to merge"),
         ),  # two data dicts with different field names
         (
             [
@@ -382,7 +382,7 @@ def test_process_roboflow_result(
                 {"test_1": np.array([[3, 2, 1]])},
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="same number of dimensions"),
         ),  # two data dicts with the same field name and 1D and 2D arrays values
         (
             [
@@ -390,12 +390,12 @@ def test_process_roboflow_result(
                 {"test_1": np.array([3, 2, 1]), "test_2": np.array(["c", "b", "a"])},
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="equal length"),
         ),  # two data dicts with the same field name and different length arrays values
         (
             [{}, {"test_1": [1, 2, 3]}],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="same keys to merge"),
         ),  # two data dicts; one empty and one non-empty dict
         (
             [{"test_1": [], "test_2": []}, {"test_1": [1, 2, 3], "test_2": [1, 2, 3]}],
@@ -405,7 +405,7 @@ def test_process_roboflow_result(
         (
             [{"test_1": []}, {"test_1": [1, 2, 3], "test_2": [4, 5, 6]}],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="same keys to merge"),
         ),  # two data dicts; one empty and one non-empty dict; different keys
         (
             [
@@ -417,7 +417,7 @@ def test_process_roboflow_result(
                 {"test_1": [1, 2, 3], "test_2": [4, 5, 6]},
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="same keys to merge"),
         ),  # two data dicts; one with three keys, one with two keys
         (
             [
@@ -425,7 +425,7 @@ def test_process_roboflow_result(
                 {"test_1": [1, 2, 3], "test_2": [1, 2, 3]},
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="same keys to merge"),
         ),  # some keys missing in one dict
         (
             [
@@ -433,7 +433,7 @@ def test_process_roboflow_result(
                 {"test_1": [4, 5], "test_2": ["c", "d", "e"]},
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="equal length"),
         ),  # different value lengths for the same key
     ],
 )
@@ -646,9 +646,17 @@ def test_get_data_item(
             DoesNotRaise(),
         ),
         # Conflicting values for the same key
-        ([{"key1": "value1"}, {"key1": "value2"}], None, pytest.raises(ValueError)),
+        (
+            [{"key1": "value1"}, {"key1": "value2"}],
+            None,
+            pytest.raises(ValueError, match="Conflicting metadata for key: 'key1'\\."),
+        ),
         # Different sets of keys across dictionaries
-        ([{"key1": "value1"}, {"key2": "value2"}], None, pytest.raises(ValueError)),
+        (
+            [{"key1": "value1"}, {"key2": "value2"}],
+            None,
+            pytest.raises(ValueError, match="same keys to merge"),
+        ),
         # Empty metadata list
         ([], {}, DoesNotRaise()),
         # Empty metadata dictionaries
@@ -705,21 +713,29 @@ def test_get_data_item(
             DoesNotRaise(),
         ),
         # Conflicting lists for the same key
-        ([{"key1": [1, 2, 3]}, {"key1": [4, 5, 6]}], None, pytest.raises(ValueError)),
+        (
+            [{"key1": [1, 2, 3]}, {"key1": [4, 5, 6]}],
+            None,
+            pytest.raises(ValueError, match="Conflicting metadata for key: 'key1'\\."),
+        ),
         # Conflicting numpy arrays for the same key
         (
             [{"key1": np.array([1, 2, 3])}, {"key1": np.array([4, 5, 6])}],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Conflicting metadata for key: 'key1':"),
         ),
         # Mixed data types: list and numpy array for the same key
         (
             [{"key1": [1, 2, 3]}, {"key1": np.array([1, 2, 3])}],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="type\\(value\\)"),
         ),
         # Empty lists and numpy arrays for the same key
-        ([{"key1": []}, {"key1": np.array([])}], None, pytest.raises(ValueError)),
+        (
+            [{"key1": []}, {"key1": np.array([])}],
+            None,
+            pytest.raises(ValueError, match="type\\(other_value\\)"),
+        ),
         # Identical multi-dimensional lists across metadata dictionaries
         (
             [{"key1": [[1, 2], [3, 4]]}, {"key1": [[1, 2], [3, 4]]}],
@@ -739,7 +755,7 @@ def test_get_data_item(
         (
             [{"key1": [[1, 2], [3, 4]]}, {"key1": [[5, 6], [7, 8]]}],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Conflicting metadata for key: 'key1'\\."),
         ),
         # Conflicting multi-dimensional numpy arrays for the same key
         (
@@ -748,13 +764,13 @@ def test_get_data_item(
                 {"key1": np.arange(4, 8).reshape(2, 2)},
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Conflicting metadata for key: 'key1':"),
         ),
         # Mixed types with multi-dimensional list and array for the same key
         (
             [{"key1": [[1, 2], [3, 4]]}, {"key1": np.arange(4).reshape(2, 2)}],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="type\\(value\\)"),
         ),
         # Identical higher-dimensional (3D) numpy arrays across
         # metadata dictionaries
@@ -774,7 +790,7 @@ def test_get_data_item(
                 {"key1": np.arange(8).reshape(4, 1, 2)},
             ],
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Conflicting metadata for key: 'key1':"),
         ),
     ],
 )

--- a/tests/detection/utils/test_iou_and_nms.py
+++ b/tests/detection/utils/test_iou_and_nms.py
@@ -1056,7 +1056,7 @@ def test_box_iou(
             np.array([[0.0, 0.0, 10.0, 10.0]], dtype=np.float32),
             "invalid",
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Invalid value: INVALID"),
         ),
     ],
 )

--- a/tests/detection/utils/test_masks.py
+++ b/tests/detection/utils/test_masks.py
@@ -488,7 +488,7 @@ def test_contains_holes(
             ),
             5,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Incorrect connectivity value"),
         ),  # Incorrect connectivity parameter value, raises ValueError
     ],
 )

--- a/tests/draw/test_color.py
+++ b/tests/draw/test_color.py
@@ -18,11 +18,15 @@ from supervision.draw.color import Color
         ("0f0", Color.GREEN, DoesNotRaise()),
         ("00f", Color.BLUE, DoesNotRaise()),
         ("#808000", Color(r=128, g=128, b=0), DoesNotRaise()),
-        ("", None, pytest.raises(ValueError)),
-        ("00", None, pytest.raises(ValueError)),
-        ("0000", None, pytest.raises(ValueError)),
-        ("0000000", None, pytest.raises(ValueError)),
-        ("ffg", None, pytest.raises(ValueError)),
+        ("", None, pytest.raises(ValueError, match="Invalid length of color hash")),
+        ("00", None, pytest.raises(ValueError, match="Invalid length of color hash")),
+        ("0000", None, pytest.raises(ValueError, match="Invalid length of color hash")),
+        (
+            "0000000",
+            None,
+            pytest.raises(ValueError, match="Invalid length of color hash"),
+        ),
+        ("ffg", None, pytest.raises(ValueError, match="Invalid characters in color")),
     ],
 )
 def test_color_from_hex(
@@ -76,10 +80,28 @@ def test_color_as_hex(
         ((0, 255, 0), Color.GREEN, DoesNotRaise()),
         ((0, 0, 255), Color.BLUE, DoesNotRaise()),
         ((128, 128, 0), Color(r=128, g=128, b=0), DoesNotRaise()),
-        ((300, 0, 0), None, pytest.raises(ValueError)),  # R out of range
-        ((0, -10, 0), None, pytest.raises(ValueError)),  # G out of range
-        ((0, 0, 500), None, pytest.raises(ValueError)),  # B out of range
-        ((300, -10, 500), None, pytest.raises(ValueError)),  # All out of range
+        (
+            (300, 0, 0),
+            None,
+            pytest.raises(ValueError, match=r"RGB values must be in range.*300, 0, 0"),
+        ),  # R out of range
+        (
+            (0, -10, 0),
+            None,
+            pytest.raises(ValueError, match=r"RGB values must be in range.*0, -10, 0"),
+        ),  # G out of range
+        (
+            (0, 0, 500),
+            None,
+            pytest.raises(ValueError, match=r"RGB values must be in range.*0, 0, 500"),
+        ),  # B out of range
+        (
+            (300, -10, 500),
+            None,
+            pytest.raises(
+                ValueError, match=r"RGB values must be in range.*300, -10, 500"
+            ),
+        ),  # All out of range
     ],
 )
 def test_color_from_rgb_tuple(
@@ -101,10 +123,28 @@ def test_color_from_rgb_tuple(
         ((0, 255, 0), Color.GREEN, DoesNotRaise()),  # BGR format
         ((255, 0, 0), Color.BLUE, DoesNotRaise()),  # BGR format
         ((0, 128, 128), Color(r=128, g=128, b=0), DoesNotRaise()),  # BGR format
-        ((300, 0, 0), None, pytest.raises(ValueError)),  # B out of range
-        ((0, -10, 0), None, pytest.raises(ValueError)),  # G out of range
-        ((0, 0, 500), None, pytest.raises(ValueError)),  # R out of range
-        ((300, -10, 500), None, pytest.raises(ValueError)),  # All out of range
+        (
+            (300, 0, 0),
+            None,
+            pytest.raises(ValueError, match=r"BGR values must be in range.*300, 0, 0"),
+        ),  # B out of range
+        (
+            (0, -10, 0),
+            None,
+            pytest.raises(ValueError, match=r"BGR values must be in range.*0, -10, 0"),
+        ),  # G out of range
+        (
+            (0, 0, 500),
+            None,
+            pytest.raises(ValueError, match=r"BGR values must be in range.*0, 0, 500"),
+        ),  # R out of range
+        (
+            (300, -10, 500),
+            None,
+            pytest.raises(
+                ValueError, match=r"BGR values must be in range.*300, -10, 500"
+            ),
+        ),  # All out of range
     ],
 )
 def test_color_from_bgr_tuple(

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -285,7 +285,7 @@ def test_key_points_setitem():
     assert "custom_data" in key_points.data
     assert np.array_equal(key_points.data["custom_data"], np.array(["value1"]))
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r"Value must be a np\.ndarray or a list"):
         key_points["invalid_data"] = 123
 
 

--- a/tests/metrics/test_f1_score.py
+++ b/tests/metrics/test_f1_score.py
@@ -213,7 +213,7 @@ class TestF1Score:
         metric = F1Score()
 
         # Should raise ValueError for mismatched lengths
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="number of predictions"):
             metric.update([detections_50_50], [targets_50_50, targets_50_50])
 
     @pytest.mark.parametrize(

--- a/tests/metrics/test_precision.py
+++ b/tests/metrics/test_precision.py
@@ -181,7 +181,7 @@ class TestPrecision:
         metric = Precision()
 
         # Should raise ValueError for mismatched lengths
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="number of predictions"):
             metric.update([detections_50_50], [targets_50_50, targets_50_50])
 
     @pytest.mark.parametrize(

--- a/tests/metrics/test_recall.py
+++ b/tests/metrics/test_recall.py
@@ -192,7 +192,7 @@ class TestRecall:
         metric = Recall()
 
         # Should raise ValueError for mismatched lengths
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="number of predictions"):
             metric.update([detections_50_50], [targets_50_50, targets_50_50])
 
     @pytest.mark.parametrize(

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -50,7 +50,12 @@ def setup_and_teardown_files():
         ("file_2.txt", False, ["   ", "Line 2", "", "Line 4", ""], DoesNotRaise()),
         ("file_3.txt", True, ["Line 2", "Line 4"], DoesNotRaise()),
         ("file_3.txt", False, ["", "Line 2", "", "Line 4", ""], DoesNotRaise()),
-        ("file_4.txt", True, None, pytest.raises(FileNotFoundError)),
+        (
+            "file_4.txt",
+            True,
+            None,
+            pytest.raises(FileNotFoundError, match=r"file_4\.txt"),
+        ),
     ],
 )
 def test_read_txt_file(

--- a/tests/utils/test_internal.py
+++ b/tests/utils/test_internal.py
@@ -80,7 +80,7 @@ class MockDataclass:
             MockClass,
             False,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Only class instances are supported"),
         ),
         (
             MockClass(),
@@ -110,13 +110,13 @@ class MockDataclass:
             Detections,
             False,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Only class instances are supported"),
         ),
         (
             Detections,
             True,
             None,
-            pytest.raises(ValueError),
+            pytest.raises(ValueError, match="Only class instances are supported"),
         ),
         (
             Detections.empty(),


### PR DESCRIPTION
This pull request updates the test suite to add more precise exception matching in `pytest.raises` statements. Instead of only checking for the type of exception, the tests now also verify that the exception message matches an expected string or pattern. This improves the robustness of the tests by ensuring that the correct error is raised for the correct reason.

**Test improvements:**

- Updated all `pytest.raises(Exception)` calls in test files to include a `match` parameter, specifying the expected error message or pattern for more precise exception validation. [[1]](diffhunk://#diff-23cf93fd6da723547be66b0bda66d9f63d8f04817cef4ccc60bbd54abf0d07ecL54-R54) [[2]](diffhunk://#diff-23cf93fd6da723547be66b0bda66d9f63d8f04817cef4ccc60bbd54abf0d07ecL65-R79) [[3]](diffhunk://#diff-23cf93fd6da723547be66b0bda66d9f63d8f04817cef4ccc60bbd54abf0d07ecL93-R93) [[4]](diffhunk://#diff-23cf93fd6da723547be66b0bda66d9f63d8f04817cef4ccc60bbd54abf0d07ecL155-R161) [[5]](diffhunk://#diff-050464f010af55dcb0740090ec10afab21d1b5aa29cae674b1a943ef8e6bbc59L105-R105) [[6]](diffhunk://#diff-0b13e9fad9f3e95e6a8cf6ccc3f98ceb1ad9362374a1eb96628d1a77d4825318L40-R47) [[7]](diffhunk://#diff-a07a142467d55bf80a8be761dc174a4dda54cbca617d9781503a358b92a350b1L171-R171) [[8]](diffhunk://#diff-57e13279d472caa105c9c81a90df8b1470f6682466c26acc7f0709926f914228L139-R139) [[9]](diffhunk://#diff-57e13279d472caa105c9c81a90df8b1470f6682466c26acc7f0709926f914228L163-R163) [[10]](diffhunk://#diff-57e13279d472caa105c9c81a90df8b1470f6682466c26acc7f0709926f914228L187-R187) [[11]](diffhunk://#diff-57e13279d472caa105c9c81a90df8b1470f6682466c26acc7f0709926f914228L217-R217) [[12]](diffhunk://#diff-57e13279d472caa105c9c81a90df8b1470f6682466c26acc7f0709926f914228L282-R287) [[13]](diffhunk://#diff-57e13279d472caa105c9c81a90df8b1470f6682466c26acc7f0709926f914228L352-R354) [[14]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L234-R253) [[15]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L324-R345) [[16]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L380-R390) [[17]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L431-R443) [[18]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L460-R472) [[19]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L472-R484) [[20]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L529-R541) [[21]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L697-R709) [[22]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L707-R719) [[23]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L800-R812) [[24]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L812-R824) [[25]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L821-R833) [[26]](diffhunk://#diff-24bd34292c9b023da8b1f1e19ac238e8f05814ff8fd243773e64856d2512f117L830-R842) [[27]](diffhunk://#diff-c257e4aae08cf2a1c889c62f08144760f75f7cef19bca996ee84b075d260050cL18-R23) [[28]](diffhunk://#diff-fb5617f86d130ce81b40327c4059e616dabf75f1fe17f9ce0d104348535354d5L99-R99) [[29]](diffhunk://#diff-6f06b72f91ec496450d5c369c80fb119021373b9d53e4e3a941f284aaba60995L173-R192) [[30]](diffhunk://#diff-6f06b72f91ec496450d5c369c80fb119021373b9d53e4e3a941f284aaba60995L361-R379) [[31]](diffhunk://#diff-6f06b72f91ec496450d5c369c80fb119021373b9d53e4e3a941f284aaba60995L373-R397)

**Configuration cleanup:**

- Removed the `PT011` per-file ignore from the linter configuration for tests, as all instances of broad exception matching have been addressed.