### PR TITLE
fix: populate class_name in DetectionDataset annotations

### DIFF
--- a/src/supervision/dataset/core.py
+++ b/src/supervision/dataset/core.py
@@ -12,6 +12,7 @@ import numpy as np
 import numpy.typing as npt
 
 from supervision.classification.core import Classifications
+from supervision.config import CLASS_NAME_DATA_FIELD
 from supervision.dataset.formats.coco import (
     load_coco_annotations,
     save_coco_annotations,
@@ -83,6 +84,14 @@ class DetectionDataset(BaseDataset):
                 "The keys of the images and annotations dictionaries must match."
             )
         self.annotations = annotations
+
+        if self.classes:
+            np_classes = np.array(self.classes)
+            for annotation in self.annotations.values():
+                if annotation.class_id is not None:
+                    annotation.data[CLASS_NAME_DATA_FIELD] = np_classes[
+                        annotation.class_id
+                    ]
 
         # Eliminate duplicates while preserving order
         self.image_paths = list(dict.fromkeys(images))

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import ExitStack as DoesNotRaise
+from pathlib import Path
 
 import numpy as np
 import pytest

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -265,7 +265,7 @@ class TestClassNamePopulation:
             ann2.data[CLASS_NAME_DATA_FIELD], np.array(["cat"])
         )
 
-    def test_class_name_from_yolo(self, tmp_path: str) -> None:
+    def test_class_name_from_yolo(self, tmp_path: Path) -> None:
         """Integration test: from_yolo should produce class_name data."""
         dataset_info = create_yolo_dataset(
             str(tmp_path), num_images=2, classes=["cat", "dog"]

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from contextlib import ExitStack as DoesNotRaise
 
+import numpy as np
 import pytest
 
-from supervision import DetectionDataset
-from tests.helpers import _create_detections
+from supervision import DetectionDataset, Detections
+from supervision.config import CLASS_NAME_DATA_FIELD
+from tests.helpers import _create_detections, create_yolo_dataset
 
 
 @pytest.mark.parametrize(
@@ -187,3 +189,97 @@ def test_dataset_merge(
     with exception:
         result = DetectionDataset.merge(dataset_list=dataset_list)
         assert result == expected_result
+
+
+class TestClassNamePopulation:
+    """Verify that DetectionDataset populates CLASS_NAME_DATA_FIELD on init."""
+
+    def test_class_name_populated_on_init(self) -> None:
+        """Basic case: class_name data field is set from classes and class_id."""
+        dataset = DetectionDataset(
+            classes=["dog", "cat"],
+            images=["img1.png"],
+            annotations={
+                "img1.png": _create_detections(
+                    xyxy=[[0, 0, 10, 10], [20, 20, 30, 30]],
+                    class_id=[0, 1],
+                ),
+            },
+        )
+        annotation = dataset.annotations["img1.png"]
+        assert CLASS_NAME_DATA_FIELD in annotation.data
+        np.testing.assert_array_equal(
+            annotation.data[CLASS_NAME_DATA_FIELD],
+            np.array(["dog", "cat"]),
+        )
+
+    def test_class_name_with_empty_annotations(self) -> None:
+        """Empty Detections should not raise an error."""
+        dataset = DetectionDataset(
+            classes=["dog"],
+            images=["img1.png"],
+            annotations={"img1.png": Detections.empty()},
+        )
+        annotation = dataset.annotations["img1.png"]
+        assert CLASS_NAME_DATA_FIELD in annotation.data
+        assert len(annotation.data[CLASS_NAME_DATA_FIELD]) == 0
+
+    def test_class_name_with_empty_classes(self) -> None:
+        """When classes is empty, class_name should not be populated."""
+        dataset = DetectionDataset(
+            classes=[],
+            images=[],
+            annotations={},
+        )
+        assert len(dataset.annotations) == 0
+
+    def test_class_name_after_merge(self) -> None:
+        """After merging datasets, class_name must match remapped class_id."""
+        ds1 = DetectionDataset(
+            classes=["dog", "person"],
+            images=["img1.png"],
+            annotations={
+                "img1.png": _create_detections(xyxy=[[0, 0, 10, 10]], class_id=[0]),
+            },
+        )
+        ds2 = DetectionDataset(
+            classes=["cat"],
+            images=["img2.png"],
+            annotations={
+                "img2.png": _create_detections(xyxy=[[0, 0, 10, 10]], class_id=[0]),
+            },
+        )
+        merged = DetectionDataset.merge([ds1, ds2])
+
+        # merged.classes is ["cat", "dog", "person"]
+        # ds1's dog (0) -> dog (1), ds2's cat (0) -> cat (0)
+        ann1 = merged.annotations["img1.png"]
+        assert CLASS_NAME_DATA_FIELD in ann1.data
+        np.testing.assert_array_equal(
+            ann1.data[CLASS_NAME_DATA_FIELD], np.array(["dog"])
+        )
+
+        ann2 = merged.annotations["img2.png"]
+        assert CLASS_NAME_DATA_FIELD in ann2.data
+        np.testing.assert_array_equal(
+            ann2.data[CLASS_NAME_DATA_FIELD], np.array(["cat"])
+        )
+
+    def test_class_name_from_yolo(self, tmp_path: str) -> None:
+        """Integration test: from_yolo should produce class_name data."""
+        dataset_info = create_yolo_dataset(
+            str(tmp_path), num_images=2, classes=["cat", "dog"]
+        )
+        dataset = DetectionDataset.from_yolo(
+            images_directory_path=dataset_info["images_dir"],
+            annotations_directory_path=dataset_info["labels_dir"],
+            data_yaml_path=dataset_info["data_yaml_path"],
+        )
+
+        for _, annotation in dataset.annotations.items():
+            if annotation.class_id is not None and len(annotation.class_id) > 0:
+                assert CLASS_NAME_DATA_FIELD in annotation.data
+                expected_names = np.array(dataset.classes)[annotation.class_id]
+                np.testing.assert_array_equal(
+                    annotation.data[CLASS_NAME_DATA_FIELD], expected_names
+                )


### PR DESCRIPTION
DetectionDataset.__init__ now maps class_id to class names using CLASS_NAME_DATA_FIELD so that LabelAnnotator displays human-readable labels instead of raw integer IDs.

Closes #1772

<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [x] Added docs entry for autogeneration (if new functions/classes)
- [x] Added/updated tests
- [x] All tests pass locally

</details>

## Description

`DetectionDataset.__init__` now populates `CLASS_NAME_DATA_FIELD` in each annotation's `data` dict by mapping `class_id` to the dataset's `classes` list. This is done centrally in the constructor so all format loaders (`from_yolo`, `from_coco`, `from_pascal_voc`) benefit without individual changes.

## Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

When loading a dataset via `DetectionDataset.from_yolo(...)` and annotating with `LabelAnnotator`, labels showed raw integer class IDs (e.g. `0`, `1`) instead of human-readable class names (e.g. `dog`, `person`). This is because the `class_name` data field was never populated on dataset-loaded `Detections`, unlike `Detections.from_inference()` which does set it.

Closes #1772

## Changes Made

- Added `CLASS_NAME_DATA_FIELD` import to `src/supervision/dataset/core.py`
- Added 7 lines in `DetectionDataset.__init__` to populate `class_name` from `classes` and `class_id`
- Added 5 test cases in `tests/dataset/test_core.py` covering init, empty detections, empty classes, merge, and YOLO integration

## Testing

- [x] I have tested this code locally
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass

## Google Colab 
Before fix: https://colab.research.google.com/drive/1ycOTk-zxUnjD_ZHcD8LBDlUVc9jij2Iu?usp=sharing
After fix: https://colab.research.google.com/drive/1kkz0YbwJv7X-9o9AVWu6v601sR4Bc5q9?usp=sharing

## Screenshots/Videos
<img width="674" height="592" alt="Screenshot 2026-02-23 at 10 11 00 AM" src="https://github.com/user-attachments/assets/aa67b577-bf4a-4ade-84e9-4c52ccb8235e" />

## Additional Notes

No changes to individual format loaders or annotator logic were needed.