### PR TITLE
chore: use `python3` as default pre-commit language version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.10
+  python: python3
 
 ci:
   autofix_prs: true

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -70,7 +70,7 @@ def coco_annotations_to_masks(
     image_annotations: list[CocoDict], resolution_wh: tuple[int, int]
 ) -> npt.NDArray[np.bool_]:
     height, width = resolution_wh[1], resolution_wh[0]
-    empty_mask = np.zeros((height, width), dtype=bool)
+    empty_mask: npt.NDArray[np.bool_] = np.zeros((height, width), dtype=bool)
     masks = []
 
     for image_annotation in image_annotations:

--- a/src/supervision/dataset/formats/pascal_voc.py
+++ b/src/supervision/dataset/formats/pascal_voc.py
@@ -252,7 +252,9 @@ def detections_from_xml_obj(
 
         xyxy.append([x1, y1, x2, y2])
 
-        object_mask = np.zeros((resolution_wh[1], resolution_wh[0]), dtype=bool)
+        object_mask: npt.NDArray[np.bool_] = np.zeros(
+            (resolution_wh[1], resolution_wh[0]), dtype=bool
+        )
         for polygon_element in obj.findall("polygon"):
             polygon = parse_polygon_points(polygon_element)
             # https://github.com/roboflow/supervision/issues/144

--- a/src/supervision/metrics/mean_average_precision.py
+++ b/src/supervision/metrics/mean_average_precision.py
@@ -984,15 +984,15 @@ class COCOEvaluator:
             precision_slice: npt.NDArray[np.float64],
         ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
             """Compute average precision while handling -1 sentinel values."""
-            masked = np.ma.masked_equal(precision_slice, -1)  # type: ignore
+            masked = np.ma.masked_equal(precision_slice, -1)
             if masked.count() == 0:
                 # All values are -1 (no data)
                 return np.full(num_iou_thresholds, -1, dtype=np.float64), np.full(
                     (num_categories, num_iou_thresholds), -1, dtype=np.float64
                 )
             else:
-                mAP_scores = np.ma.filled(masked.mean(axis=(1, 2)), -1)  # type: ignore
-                ap_per_class = np.ma.filled(masked.mean(axis=1), -1).transpose(1, 0)  # type: ignore
+                mAP_scores = np.ma.filled(masked.mean(axis=(1, 2)), -1)
+                ap_per_class = np.ma.filled(masked.mean(axis=1), -1).transpose(1, 0)
                 return mAP_scores, ap_per_class
 
         # Average precision over all sizes, 100 max detections


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [ ] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [ ] Added docs entry for autogeneration (if new functions/classes)
- [ ] Added/updated tests
- [ ] All tests pass locally

</details>

## Description

<!-- Provide a clear and concise description of your changes -->
Use `python3` instead of pinning `python3.10` for pre-commit hooks to avoid requiring a specific interpreter while remaining compatible with CI.

## Type of Change

<!-- Mark the relevant option with an "x" and delete the others -->

- 🔧 Chore (dependencies, configs, etc.)

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here -->

The pre-commit configuration currently pins the Python interpreter to python3.10. This requires contributors to have that specific version installed locally, otherwise pre-commit fails when creating hook environments.

This change updates the configuration to use python3 instead of a pinned version. This allows pre-commit to use the system's default Python interpreter while remaining compatible with CI and modern development environments.

## Changes Made

<!-- List the main changes made in this PR -->

-

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] I have tested this code locally
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests pass

## Google Colab (optional)

<!-- If applicable, provide a link to a Google Colab notebook demonstrating the feature/fix -->

<!-- Ensure the notebook is publicly accessible -->

Colab link:

## Screenshots/Videos (optional)

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
