### PR TITLE
docs: replace YOLO with RF-DETR in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Read more about conda, mamba, and installing from source in our [guide](https://
 
 ### models
 
-Supervision was designed to be model agnostic. Just plug in any classification, detection, or segmentation model. For your convenience, we have created [connectors](https://supervision.roboflow.com/latest/detection/core/#detections) for the most popular libraries like Ultralytics, Transformers, or MMDetection.
+Supervision was designed to be model agnostic. Just plug in any classification, detection, or segmentation model. For your convenience, we have created [connectors](https://supervision.roboflow.com/latest/detection/core/#detections) for the most popular libraries like Ultralytics, Transformers, MMDetection, or Inference. Other integrations, like `rfdetr`, already return `sv.Detections` directly.
+
+Install the optional dependencies for this example with `pip install pillow rfdetr`.
 
 ```python
 import supervision as sv

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ len(detections)
 
     image = Image.open(...)
     model = get_model(model_id="rfdetr-small", api_key="ROBOFLOW_API_KEY")
-    result = model.infer(image, confidence=0.5)[0]
+    result = model.infer(image)[0]
     detections = sv.Detections.from_inference(result)
 
     len(detections)

--- a/README.md
+++ b/README.md
@@ -53,14 +53,13 @@ Read more about conda, mamba, and installing from source in our [guide](https://
 Supervision was designed to be model agnostic. Just plug in any classification, detection, or segmentation model. For your convenience, we have created [connectors](https://supervision.roboflow.com/latest/detection/core/#detections) for the most popular libraries like Ultralytics, Transformers, or MMDetection.
 
 ```python
-import cv2
 import supervision as sv
-from ultralytics import YOLO
+from PIL import Image
+from rfdetr import RFDETRSmall
 
-image = cv2.imread(...)
-model = YOLO("yolov8s.pt")
-result = model(image)[0]
-detections = sv.Detections.from_ultralytics(result)
+image = Image.open(...)
+model = RFDETRSmall()
+detections = model.predict(image, threshold=0.5)
 
 len(detections)
 # 5
@@ -74,13 +73,13 @@ len(detections)
     Running with [Inference](https://github.com/roboflow/inference) requires a [Roboflow API KEY](https://docs.roboflow.com/api-reference/authentication#retrieve-an-api-key).
 
     ```python
-    import cv2
     import supervision as sv
+    from PIL import Image
     from inference import get_model
 
-    image = cv2.imread(...)
-    model = get_model(model_id="yolov8s-640", api_key="ROBOFLOW_API_KEY")
-    result = model.infer(image)[0]
+    image = Image.open(...)
+    model = get_model(model_id="rfdetr-small", api_key="ROBOFLOW_API_KEY")
+    result = model.infer(image, confidence=0.5)[0]
     detections = sv.Detections.from_inference(result)
 
     len(detections)


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [ ] Self-reviewed the code
- [ ] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [ ] Added docs entry for autogeneration (if new functions/classes)
- [ ] Added/updated tests
- [ ] All tests pass locally

</details>

## Description

Swap Ultralytics YOLO references for RFDETRSmall (rfdetr package) and rfdetr-small (Roboflow Inference) to showcase RF-DETR as the primary model in the quickstart and connector examples.

## Type of Change

<!-- Mark the relevant option with an "x" and delete the others -->

- 📝 Documentation update

## Additional Notes

<!-- Any additional information that reviewers should know -->
