### PR TITLE
feat: add show_progress option to dataset loaders and savers

### DIFF
--- a/src/supervision/dataset/core.py
+++ b/src/supervision/dataset/core.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 import numpy.typing as npt
+from tqdm.auto import tqdm
 
 from supervision.classification.core import Classifications
 from supervision.config import CLASS_NAME_DATA_FIELD
@@ -368,24 +369,30 @@ class DetectionDataset(BaseDataset):
             )
         if annotations_directory_path:
             Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
-            for image_path, image, annotations in self:
-                annotation_name = Path(image_path).stem
-                annotations_path = os.path.join(
-                    annotations_directory_path, f"{annotation_name}.xml"
-                )
-                image_name = Path(image_path).name
-                pascal_voc_xml = detections_to_pascal_voc(
-                    detections=annotations,
-                    classes=self.classes,
-                    filename=image_name,
-                    image_shape=image.shape,
-                    min_image_area_percentage=min_image_area_percentage,
-                    max_image_area_percentage=max_image_area_percentage,
-                    approximation_percentage=approximation_percentage,
-                )
+            with tqdm(
+                total=len(self),
+                desc="Saving Pascal VOC annotations",
+                disable=not show_progress,
+            ) as progress_bar:
+                for image_path, image, annotations in self:
+                    annotation_name = Path(image_path).stem
+                    annotations_path = os.path.join(
+                        annotations_directory_path, f"{annotation_name}.xml"
+                    )
+                    image_name = Path(image_path).name
+                    pascal_voc_xml = detections_to_pascal_voc(
+                        detections=annotations,
+                        classes=self.classes,
+                        filename=image_name,
+                        image_shape=image.shape,
+                        min_image_area_percentage=min_image_area_percentage,
+                        max_image_area_percentage=max_image_area_percentage,
+                        approximation_percentage=approximation_percentage,
+                    )
 
-                with open(annotations_path, "w") as f:
-                    f.write(pascal_voc_xml)
+                    with open(annotations_path, "w") as f:
+                        f.write(pascal_voc_xml)
+                    progress_bar.update(1)
 
     @classmethod
     def from_pascal_voc(
@@ -583,6 +590,7 @@ class DetectionDataset(BaseDataset):
                 max_image_area_percentage=max_image_area_percentage,
                 approximation_percentage=approximation_percentage,
                 is_obb=is_obb,
+                show_progress=show_progress,
             )
         if data_yaml_path is not None:
             save_data_yaml(data_yaml_path=data_yaml_path, classes=self.classes)
@@ -739,6 +747,7 @@ class DetectionDataset(BaseDataset):
                 approximation_percentage=approximation_percentage,
                 starting_image_id=starting_image_id,
                 starting_annotation_id=starting_annotation_id,
+                show_progress=show_progress,
             )
         return starting_image_id, starting_annotation_id
 

--- a/src/supervision/dataset/core.py
+++ b/src/supervision/dataset/core.py
@@ -334,6 +334,7 @@ class DetectionDataset(BaseDataset):
         min_image_area_percentage: float = 0.0,
         max_image_area_percentage: float = 1.0,
         approximation_percentage: float = 0.0,
+        show_progress: bool = False,
     ) -> None:
         """
         Exports the dataset to PASCAL VOC format. This method saves the images
@@ -357,11 +358,13 @@ class DetectionDataset(BaseDataset):
             approximation_percentage: The percentage of
                 polygon points to be removed from the input polygon,
                 in the range [0, 1). Argument is used only for segmentation datasets.
+            show_progress: If `True`, display a progress bar while saving images.
         """
         if images_directory_path:
             save_dataset_images(
                 dataset=self,
                 images_directory_path=images_directory_path,
+                show_progress=show_progress,
             )
         if annotations_directory_path:
             Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
@@ -390,6 +393,7 @@ class DetectionDataset(BaseDataset):
         images_directory_path: str,
         annotations_directory_path: str,
         force_masks: bool = False,
+        show_progress: bool = False,
     ) -> DetectionDataset:
         """
         Creates a Dataset instance from PASCAL VOC formatted data.
@@ -400,6 +404,7 @@ class DetectionDataset(BaseDataset):
                 containing the PASCAL VOC XML annotations.
             force_masks: If True, forces masks to
                 be loaded for all annotations, regardless of whether they are present.
+            show_progress: If `True`, display a progress bar while loading images.
 
         Returns:
             A DetectionDataset instance containing
@@ -432,6 +437,7 @@ class DetectionDataset(BaseDataset):
             images_directory_path=images_directory_path,
             annotations_directory_path=annotations_directory_path,
             force_masks=force_masks,
+            show_progress=show_progress,
         )
 
         return DetectionDataset(
@@ -446,6 +452,7 @@ class DetectionDataset(BaseDataset):
         data_yaml_path: str,
         force_masks: bool = False,
         is_obb: bool = False,
+        show_progress: bool = False,
     ) -> DetectionDataset:
         """
         Creates a Dataset instance from YOLO formatted data.
@@ -463,6 +470,7 @@ class DetectionDataset(BaseDataset):
             is_obb: If True, loads the annotations in OBB format.
                 OBB annotations are defined as `[class_id, x, y, x, y, x, y, x, y]`,
                 where pairs of [x, y] are box corners.
+            show_progress: If `True`, display a progress bar while loading images.
 
         Returns:
             A DetectionDataset instance
@@ -496,6 +504,7 @@ class DetectionDataset(BaseDataset):
             data_yaml_path=data_yaml_path,
             force_masks=force_masks,
             is_obb=is_obb,
+            show_progress=show_progress,
         )
         return DetectionDataset(
             classes=classes, images=image_paths, annotations=annotations
@@ -510,6 +519,7 @@ class DetectionDataset(BaseDataset):
         max_image_area_percentage: float = 1.0,
         approximation_percentage: float = 0.0,
         is_obb: bool = False,
+        show_progress: bool = False,
     ) -> None:
         """
         Exports the dataset to YOLO format. This method saves the
@@ -543,6 +553,7 @@ class DetectionDataset(BaseDataset):
                 corners stored in `detections.data["xyxyxyxy"]`. Mirrors
                 `from_yolo(..., is_obb=True)`. Masks are ignored when
                 `is_obb=True`.
+            show_progress: If `True`, display a progress bar while saving images.
         """
         if is_obb and (
             min_image_area_percentage != 0.0
@@ -560,7 +571,9 @@ class DetectionDataset(BaseDataset):
             )
         if images_directory_path is not None:
             save_dataset_images(
-                dataset=self, images_directory_path=images_directory_path
+                dataset=self,
+                images_directory_path=images_directory_path,
+                show_progress=show_progress,
             )
         if annotations_directory_path is not None:
             save_yolo_annotations(
@@ -580,6 +593,7 @@ class DetectionDataset(BaseDataset):
         images_directory_path: str,
         annotations_path: str,
         force_masks: bool = False,
+        show_progress: bool = False,
     ) -> DetectionDataset:
         """
         Creates a Dataset instance from COCO formatted data.
@@ -591,6 +605,7 @@ class DetectionDataset(BaseDataset):
             force_masks: If True,
                 forces masks to be loaded for all annotations,
                 regardless of whether they are present.
+            show_progress: If `True`, display a progress bar while loading images.
         Returns:
             A DetectionDataset instance containing
                 the loaded images and annotations.
@@ -620,6 +635,7 @@ class DetectionDataset(BaseDataset):
             images_directory_path=images_directory_path,
             annotations_path=annotations_path,
             force_masks=force_masks,
+            show_progress=show_progress,
         )
         return DetectionDataset(classes=classes, images=images, annotations=annotations)
 
@@ -632,6 +648,7 @@ class DetectionDataset(BaseDataset):
         approximation_percentage: float = 0.0,
         starting_image_id: int = 1,
         starting_annotation_id: int = 1,
+        show_progress: bool = False,
     ) -> tuple[int, int]:
         """
         Exports the dataset to COCO format. This method saves the
@@ -675,6 +692,7 @@ class DetectionDataset(BaseDataset):
             starting_annotation_id: First annotation id to assign in the
                 exported file. Defaults to ``1``. Override for the same
                 multi-split reason as ``starting_image_id``.
+            show_progress: If `True`, display a progress bar while saving images.
 
         Returns:
             A ``(next_image_id, next_annotation_id)`` tuple containing the
@@ -703,12 +721,14 @@ class DetectionDataset(BaseDataset):
                 annotations_path="out/test/annotations.json",
                 starting_image_id=next_image_id,
                 starting_annotation_id=next_annotation_id,
-            )  # return value not needed — no further split
+            )
             ```
         """
         if images_directory_path is not None:
             save_dataset_images(
-                dataset=self, images_directory_path=images_directory_path
+                dataset=self,
+                images_directory_path=images_directory_path,
+                show_progress=show_progress,
             )
         if annotations_path is not None:
             return save_coco_annotations(

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -486,6 +486,7 @@ def save_coco_annotations(
     approximation_percentage: float = 0.0,
     starting_image_id: int = 1,
     starting_annotation_id: int = 1,
+    show_progress: bool = False,
 ) -> tuple[int, int]:
     """Save a DetectionDataset to a COCO-format ``annotations.json`` file.
 
@@ -504,6 +505,7 @@ def save_coco_annotations(
         starting_annotation_id: First annotation id to assign in the exported
             file. Defaults to ``1``. Override for the same multi-split reason
             as ``starting_image_id``.
+        show_progress: If `True`, display a progress bar while saving annotations.
 
     Returns:
         A ``(next_image_id, next_annotation_id)`` tuple. The returned values
@@ -515,7 +517,7 @@ def save_coco_annotations(
 
         .. note::
             This function ensures globally unique integer ``id`` values across
-            splits. It does **not** ensure unique ``file_name`` values — the
+            splits. It does **not** ensure unique ``file_name`` values - the
             ``file_name`` field is set to the bare image basename, so splits
             that share filenames (e.g. ``000001.jpg`` in both train and valid)
             will have duplicate ``file_name`` values when their COCO files are
@@ -535,7 +537,7 @@ def save_coco_annotations(
         next_img_id, next_ann_id = save_coco_annotations(
             dataset=ds, annotation_path="out/train/annotations.json"
         )
-        # next_img_id and next_ann_id are the first unused ids — pass them
+        # next_img_id and next_ann_id are the first unused ids - pass them
         # to the next split to keep ids globally unique across files.
         ```
     """
@@ -559,30 +561,36 @@ def save_coco_annotations(
     coco_categories = classes_to_coco_categories(classes=dataset.classes)
 
     image_id, annotation_id = starting_image_id, starting_annotation_id
-    for image_path, image, annotation in dataset:
-        image_height, image_width, _ = image.shape
-        image_name = f"{Path(image_path).stem}{Path(image_path).suffix}"
-        coco_image = {
-            "id": image_id,
-            "license": 1,
-            "file_name": image_name,
-            "height": image_height,
-            "width": image_width,
-            "date_captured": datetime.now().strftime("%m/%d/%Y,%H:%M:%S"),
-        }
+    with tqdm(
+        total=len(dataset),
+        desc="Saving COCO annotations",
+        disable=not show_progress,
+    ) as progress_bar:
+        for image_path, image, annotation in dataset:
+            image_height, image_width, _ = image.shape
+            image_name = f"{Path(image_path).stem}{Path(image_path).suffix}"
+            coco_image = {
+                "id": image_id,
+                "license": 1,
+                "file_name": image_name,
+                "height": image_height,
+                "width": image_width,
+                "date_captured": datetime.now().strftime("%m/%d/%Y,%H:%M:%S"),
+            }
 
-        coco_images.append(coco_image)
-        coco_annotation, annotation_id = detections_to_coco_annotations(
-            detections=annotation,
-            image_id=image_id,
-            annotation_id=annotation_id,
-            min_image_area_percentage=min_image_area_percentage,
-            max_image_area_percentage=max_image_area_percentage,
-            approximation_percentage=approximation_percentage,
-        )
+            coco_images.append(coco_image)
+            coco_annotation, annotation_id = detections_to_coco_annotations(
+                detections=annotation,
+                image_id=image_id,
+                annotation_id=annotation_id,
+                min_image_area_percentage=min_image_area_percentage,
+                max_image_area_percentage=max_image_area_percentage,
+                approximation_percentage=approximation_percentage,
+            )
 
-        coco_annotations.extend(coco_annotation)
-        image_id += 1
+            coco_annotations.extend(coco_annotation)
+            image_id += 1
+            progress_bar.update(1)
 
     annotation_dict = {
         "info": {},

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Union, cast
 
 import numpy as np
 import numpy.typing as npt
+from tqdm.auto import tqdm
 
 from supervision.dataset.utils import (
     approximate_mask_with_polygons,
@@ -352,6 +353,7 @@ def load_coco_annotations(
     annotations_path: str,
     force_masks: bool = False,
     use_iscrowd: bool = True,
+    show_progress: bool = False,
 ) -> tuple[list[str], list[str], dict[str, Detections]]:
     """
     Load COCO annotations and convert them to `Detections`.
@@ -365,6 +367,7 @@ def load_coco_annotations(
         annotations_path: Path to COCO JSON annotations.
         force_masks: If `True`, always attempt to load masks.
         use_iscrowd: If `True`, include `iscrowd` and `area` in detection data.
+        show_progress: If `True`, display a progress bar while loading images.
 
     Returns:
         A tuple of `(classes, image_paths, annotations)`.
@@ -381,6 +384,17 @@ def load_coco_annotations(
         paths outside the directory are rejected to prevent path-traversal
         attacks when loading user-supplied annotation files. Symlinked images
         pointing outside the resolved images directory are also rejected.
+
+    Examples:
+        ```python
+        import supervision as sv
+
+        ds = sv.DetectionDataset.from_coco(
+            images_directory_path="images/train",
+            annotations_path="images/train/_annotations.coco.json",
+            show_progress=True,
+        )
+        ```
     """
     coco_data = read_json_file(file_path=annotations_path)
     classes = coco_categories_to_classes(coco_categories=coco_data["categories"])
@@ -398,58 +412,64 @@ def load_coco_annotations(
     annotations = {}
     images_directory_resolved = Path(images_directory_path).resolve()
 
-    for coco_image in coco_images:
-        image_name, image_width, image_height = (
-            coco_image["file_name"],
-            coco_image["width"],
-            coco_image["height"],
-        )
-        image_annotations = coco_annotations_groups.get(coco_image["id"], [])
-        image_path = str(Path(images_directory_path) / Path(image_name))
-        try:
-            resolved_image_path = Path(image_path).resolve()
-        except (OSError, ValueError) as exc:
-            raise ValueError(
-                f"COCO annotation refers to image {image_name!r}, which "
-                f"produces an invalid path: {exc}"
-            ) from exc
-        if resolved_image_path == images_directory_resolved:
-            raise ValueError(
-                f"COCO annotation refers to image {image_name!r}, which "
-                f"resolves to the images directory itself "
-                f"({images_directory_resolved}). Expected a path to an "
-                "image file."
+    with tqdm(
+        total=len(coco_images),
+        desc="Loading COCO annotations",
+        disable=not show_progress,
+    ) as progress_bar:
+        for coco_image in coco_images:
+            image_name, image_width, image_height = (
+                coco_image["file_name"],
+                coco_image["width"],
+                coco_image["height"],
             )
-        if images_directory_resolved not in resolved_image_path.parents:
-            raise ValueError(
-                f"COCO annotation refers to image {image_name!r}, which "
-                f"resolves to {resolved_image_path} — outside the images "
-                f"directory {images_directory_resolved}."
+            image_annotations = coco_annotations_groups.get(coco_image["id"], [])
+            image_path = str(Path(images_directory_path) / Path(image_name))
+            try:
+                resolved_image_path = Path(image_path).resolve()
+            except (OSError, ValueError) as exc:
+                raise ValueError(
+                    f"COCO annotation refers to image {image_name!r}, which "
+                    f"produces an invalid path: {exc}"
+                ) from exc
+            if resolved_image_path == images_directory_resolved:
+                raise ValueError(
+                    f"COCO annotation refers to image {image_name!r}, which "
+                    f"resolves to the images directory itself "
+                    f"({images_directory_resolved}). Expected a path to an "
+                    "image file."
+                )
+            if images_directory_resolved not in resolved_image_path.parents:
+                raise ValueError(
+                    f"COCO annotation refers to image {image_name!r}, which "
+                    f"resolves to {resolved_image_path} - outside the images "
+                    f"directory {images_directory_resolved}."
+                )
+            if resolved_image_path.is_dir():
+                raise ValueError(
+                    f"COCO annotation refers to image {image_name!r}, which "
+                    f"resolves to directory {resolved_image_path}. Expected a "
+                    "path to an image file."
+                )
+
+            with_masks = force_masks or any(
+                _with_seg_mask(annotation) for annotation in image_annotations
             )
-        if resolved_image_path.is_dir():
-            raise ValueError(
-                f"COCO annotation refers to image {image_name!r}, which "
-                f"resolves to directory {resolved_image_path}. Expected a "
-                "path to an image file."
+            annotation = coco_annotations_to_detections(
+                image_annotations=image_annotations,
+                resolution_wh=(image_width, image_height),
+                with_masks=with_masks,
+                use_iscrowd=use_iscrowd,
             )
 
-        with_masks = force_masks or any(
-            _with_seg_mask(annotation) for annotation in image_annotations
-        )
-        annotation = coco_annotations_to_detections(
-            image_annotations=image_annotations,
-            resolution_wh=(image_width, image_height),
-            with_masks=with_masks,
-            use_iscrowd=use_iscrowd,
-        )
+            annotation = map_detections_class_id(
+                source_to_target_mapping=class_index_mapping,
+                detections=annotation,
+            )
 
-        annotation = map_detections_class_id(
-            source_to_target_mapping=class_index_mapping,
-            detections=annotation,
-        )
-
-        images.append(image_path)
-        annotations[image_path] = annotation
+            images.append(image_path)
+            annotations[image_path] = annotation
+            progress_bar.update(1)
 
     return classes, images, annotations
 

--- a/src/supervision/dataset/formats/pascal_voc.py
+++ b/src/supervision/dataset/formats/pascal_voc.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.typing as npt
 from defusedxml.ElementTree import parse, tostring
 from defusedxml.minidom import parseString
+from tqdm.auto import tqdm
 
 from supervision.dataset.utils import approximate_mask_with_polygons
 from supervision.detection.core import Detections
@@ -149,6 +150,7 @@ def load_pascal_voc_annotations(
     images_directory_path: str,
     annotations_directory_path: str,
     force_masks: bool = False,
+    show_progress: bool = False,
 ) -> tuple[list[str], list[str], dict[str, Detections]]:
     """
     Loads PASCAL VOC XML annotations and returns the image name,
@@ -160,11 +162,23 @@ def load_pascal_voc_annotations(
             PASCAL VOC annotation files.
         force_masks: If True, forces masks to be loaded for all
             annotations, regardless of whether they are present.
+        show_progress: If `True`, display a progress bar while loading images.
 
     Returns:
         A tuple with a list
             of class names, a list of paths to images, and a dictionary with image
             paths as keys and corresponding Detections instances as values.
+
+    Examples:
+        ```python
+        import supervision as sv
+
+        ds = sv.DetectionDataset.from_pascal_voc(
+            images_directory_path="images/train",
+            annotations_directory_path="images/train/labels",
+            show_progress=True,
+        )
+        ```
     """
 
     image_paths = [
@@ -177,24 +191,33 @@ def load_pascal_voc_annotations(
     classes: list[str] = []
     annotations = {}
 
-    for image_path in image_paths:
-        image_stem = Path(image_path).stem
-        annotation_path = os.path.join(annotations_directory_path, f"{image_stem}.xml")
-        if not os.path.exists(annotation_path):
-            annotations[image_path] = Detections.empty()
-            continue
+    with tqdm(
+        total=len(image_paths),
+        desc="Loading Pascal VOC annotations",
+        disable=not show_progress,
+    ) as progress_bar:
+        for image_path in image_paths:
+            image_stem = Path(image_path).stem
+            annotation_path = os.path.join(
+                annotations_directory_path, f"{image_stem}.xml"
+            )
+            if not os.path.exists(annotation_path):
+                annotations[image_path] = Detections.empty()
+                progress_bar.update(1)
+                continue
 
-        tree = parse(annotation_path)
-        root = tree.getroot()
+            tree = parse(annotation_path)
+            root = tree.getroot()
 
-        image = cv2.imread(image_path)
-        if image is None:
-            raise ValueError(f"Could not read image from path: {image_path}")
-        resolution_wh = (image.shape[1], image.shape[0])
-        annotation, classes = detections_from_xml_obj(
-            root, classes, resolution_wh, force_masks
-        )
-        annotations[image_path] = annotation
+            image = cv2.imread(image_path)
+            if image is None:
+                raise ValueError(f"Could not read image from path: {image_path}")
+            resolution_wh = (image.shape[1], image.shape[0])
+            annotation, classes = detections_from_xml_obj(
+                root, classes, resolution_wh, force_masks
+            )
+            annotations[image_path] = annotation
+            progress_bar.update(1)
 
     return classes, image_paths, annotations
 

--- a/src/supervision/dataset/formats/yolo.py
+++ b/src/supervision/dataset/formats/yolo.py
@@ -451,6 +451,7 @@ def save_yolo_annotations(
     max_image_area_percentage: float = 1.0,
     approximation_percentage: float = 0.75,
     is_obb: bool = False,
+    show_progress: bool = False,
 ) -> None:
     """Save dataset annotations in YOLO format.
 
@@ -479,21 +480,29 @@ def save_yolo_annotations(
         >>> save_yolo_annotations(dataset, "/tmp/labels")
     """
     Path(annotations_directory_path).mkdir(parents=True, exist_ok=True)
-    for image_path, image, annotation in dataset:
-        image_name = Path(image_path).name
-        yolo_annotations_name = _image_name_to_annotation_name(image_name=image_name)
-        yolo_annotations_path = os.path.join(
-            annotations_directory_path, yolo_annotations_name
-        )
-        lines = detections_to_yolo_annotations(
-            detections=annotation,
-            image_shape=image.shape,
-            min_image_area_percentage=min_image_area_percentage,
-            max_image_area_percentage=max_image_area_percentage,
-            approximation_percentage=approximation_percentage,
-            is_obb=is_obb,
-        )
-        save_text_file(lines=lines, file_path=yolo_annotations_path)
+    with tqdm(
+        total=len(dataset),
+        desc="Saving YOLO annotations",
+        disable=not show_progress,
+    ) as progress_bar:
+        for image_path, image, annotation in dataset:
+            image_name = Path(image_path).name
+            yolo_annotations_name = _image_name_to_annotation_name(
+                image_name=image_name
+            )
+            yolo_annotations_path = os.path.join(
+                annotations_directory_path, yolo_annotations_name
+            )
+            lines = detections_to_yolo_annotations(
+                detections=annotation,
+                image_shape=image.shape,
+                min_image_area_percentage=min_image_area_percentage,
+                max_image_area_percentage=max_image_area_percentage,
+                approximation_percentage=approximation_percentage,
+                is_obb=is_obb,
+            )
+            save_text_file(lines=lines, file_path=yolo_annotations_path)
+            progress_bar.update(1)
 
 
 def save_data_yaml(data_yaml_path: str, classes: list[str]) -> None:

--- a/src/supervision/dataset/formats/yolo.py
+++ b/src/supervision/dataset/formats/yolo.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import numpy.typing as npt
 from PIL import Image
+from tqdm.auto import tqdm
 
 from supervision.config import ORIENTED_BOX_COORDINATES
 from supervision.dataset.utils import approximate_mask_with_polygons
@@ -190,6 +191,7 @@ def load_yolo_annotations(
     data_yaml_path: str,
     force_masks: bool = False,
     is_obb: bool = False,
+    show_progress: bool = False,
 ) -> tuple[list[str], list[str], dict[str, Detections]]:
     """
     Loads YOLO annotations and returns class names, images,
@@ -208,11 +210,24 @@ def load_yolo_annotations(
         is_obb: If True, loads the annotations in OBB format.
             OBB annotations are defined as `[class_id, x, y, x, y, x, y, x, y]`,
             where pairs of [x, y] are box corners.
+        show_progress: If `True`, display a progress bar while loading images.
 
     Returns:
         A tuple containing a list of class names, a dictionary with
             image names as keys and images as values, and a dictionary
             with image names as keys and corresponding Detections instances as values.
+
+    Examples:
+        ```python
+        import supervision as sv
+
+        ds = sv.DetectionDataset.from_yolo(
+            images_directory_path="images/train",
+            annotations_directory_path="labels/train",
+            data_yaml_path="data.yaml",
+            show_progress=True,
+        )
+        ```
     """
     if is_obb and force_masks:
         warnings.warn(
@@ -242,32 +257,42 @@ def load_yolo_annotations(
     classes = _extract_class_names(file_path=data_yaml_path)
     annotations = {}
 
-    for image_path in image_paths:
-        image_stem = Path(image_path).stem
-        annotation_path = os.path.join(annotations_directory_path, f"{image_stem}.txt")
-        if not os.path.exists(annotation_path):
-            annotations[image_path] = Detections.empty()
-            continue
-
-        # PIL is much faster than cv2 for checking image shape and mode: https://github.com/roboflow/supervision/issues/1554
-        image = Image.open(image_path)
-        lines = read_txt_file(file_path=annotation_path, skip_empty=True)
-        w, h = image.size
-        resolution_wh = (w, h)
-        if image.mode not in ("RGB", "L"):
-            raise ValueError(
-                f"Images must be 'RGB' or 'grayscale', \
-                but {image_path} mode is '{image.mode}'."
+    with tqdm(
+        total=len(image_paths),
+        desc="Loading YOLO annotations",
+        disable=not show_progress,
+    ) as progress_bar:
+        for image_path in image_paths:
+            image_stem = Path(image_path).stem
+            annotation_path = os.path.join(
+                annotations_directory_path, f"{image_stem}.txt"
             )
+            if not os.path.exists(annotation_path):
+                annotations[image_path] = Detections.empty()
+                progress_bar.update(1)
+                continue
 
-        with_masks = not is_obb and (force_masks or _with_seg_mask(lines=lines))
-        annotation = yolo_annotations_to_detections(
-            lines=lines,
-            resolution_wh=resolution_wh,
-            with_masks=with_masks,
-            is_obb=is_obb,
-        )
-        annotations[image_path] = annotation
+            # PIL is much faster than cv2 for checking image shape and mode: https://github.com/roboflow/supervision/issues/1554
+            image = Image.open(image_path)
+            lines = read_txt_file(file_path=annotation_path, skip_empty=True)
+            w, h = image.size
+            resolution_wh = (w, h)
+            if image.mode not in ("RGB", "L"):
+                raise ValueError(
+                    f"Images must be 'RGB' or 'grayscale', \
+                but {image_path} mode is '{image.mode}'."
+                )
+
+            with_masks = force_masks or _with_seg_mask(lines=lines)
+            annotation = yolo_annotations_to_detections(
+                lines=lines,
+                resolution_wh=resolution_wh,
+                with_masks=with_masks,
+                is_obb=is_obb,
+            )
+            annotations[image_path] = annotation
+            progress_bar.update(1)
+
     return classes, image_paths, annotations
 
 

--- a/src/supervision/dataset/formats/yolo.py
+++ b/src/supervision/dataset/formats/yolo.py
@@ -273,14 +273,15 @@ def load_yolo_annotations(
                 continue
 
             # PIL is much faster than cv2 for checking image shape and mode: https://github.com/roboflow/supervision/issues/1554
-            image = Image.open(image_path)
+            with Image.open(image_path) as image:
+                w, h = image.size
+                mode = image.mode
             lines = read_txt_file(file_path=annotation_path, skip_empty=True)
-            w, h = image.size
             resolution_wh = (w, h)
-            if image.mode not in ("RGB", "L"):
+            if mode not in ("RGB", "L"):
                 raise ValueError(
-                    f"Images must be 'RGB' or 'grayscale', \
-                but {image_path} mode is '{image.mode}'."
+                    f"Images must be 'RGB' or 'grayscale',"
+                    f" but {image_path} mode is '{mode}'."
                 )
 
             with_masks = force_masks or _with_seg_mask(lines=lines)

--- a/src/supervision/dataset/formats/yolo.py
+++ b/src/supervision/dataset/formats/yolo.py
@@ -284,7 +284,7 @@ def load_yolo_annotations(
                     f" but {image_path} mode is '{mode}'."
                 )
 
-            with_masks = force_masks or _with_seg_mask(lines=lines)
+            with_masks = (not is_obb) and (force_masks or _with_seg_mask(lines=lines))
             annotation = yolo_annotations_to_detections(
                 lines=lines,
                 resolution_wh=resolution_wh,

--- a/src/supervision/dataset/utils.py
+++ b/src/supervision/dataset/utils.py
@@ -11,6 +11,7 @@ import cv2
 import numpy as np
 import numpy.typing as npt
 from deprecate import deprecated, void
+from tqdm.auto import tqdm
 
 from supervision.detection.core import Detections
 from supervision.detection.utils.converters import mask_to_polygons
@@ -125,15 +126,48 @@ def map_detections_class_id(
     return detections_copy
 
 
-def save_dataset_images(dataset: DetectionDataset, images_directory_path: str) -> None:
+def save_dataset_images(
+    dataset: DetectionDataset,
+    images_directory_path: str,
+    show_progress: bool = False,
+) -> None:
+    """
+    Saves all images from a dataset to the specified directory.
+
+    Args:
+        dataset: The dataset whose images should be saved.
+        images_directory_path: Path to the directory where images will be saved.
+        show_progress: If `True`, display a progress bar while saving images.
+
+    Examples:
+        ```python
+        import supervision as sv
+
+        ds = sv.DetectionDataset.from_coco(
+            images_directory_path="images/train",
+            annotations_path="images/train/_annotations.coco.json",
+        )
+        sv.dataset.utils.save_dataset_images(
+            dataset=ds,
+            images_directory_path="output/images",
+            show_progress=True,
+        )
+        ```
+    """
     Path(images_directory_path).mkdir(parents=True, exist_ok=True)
-    for image_path in dataset.image_paths:
-        final_path = os.path.join(images_directory_path, Path(image_path).name)
-        if image_path in dataset._images_in_memory:
-            image = dataset._images_in_memory[image_path]
-            cv2.imwrite(final_path, image)
-        else:
-            shutil.copyfile(image_path, final_path)
+    with tqdm(
+        total=len(dataset.image_paths),
+        desc="Saving images",
+        disable=not show_progress,
+    ) as progress_bar:
+        for image_path in dataset.image_paths:
+            final_path = os.path.join(images_directory_path, Path(image_path).name)
+            if image_path in dataset._images_in_memory:
+                image = dataset._images_in_memory[image_path]
+                cv2.imwrite(final_path, image)
+            else:
+                shutil.copyfile(image_path, final_path)
+            progress_bar.update(1)
 
 
 def train_test_split(

--- a/tests/dataset/test_show_progress.py
+++ b/tests/dataset/test_show_progress.py
@@ -2,23 +2,28 @@
 Tests that show_progress parameter works correctly for all dataset
 loaders and savers, and that output is identical regardless of its value.
 """
+
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import cv2
 import numpy as np
 import pytest
 
-from supervision import DetectionDataset, Detections
-from supervision.dataset.formats.coco import load_coco_annotations, save_coco_annotations
+from supervision import DetectionDataset
+from supervision.dataset.formats.coco import (
+    load_coco_annotations,
+    save_coco_annotations,
+)
 from supervision.dataset.formats.pascal_voc import load_pascal_voc_annotations
-from supervision.dataset.formats.yolo import load_yolo_annotations, save_yolo_annotations
+from supervision.dataset.formats.yolo import (
+    load_yolo_annotations,
+    save_yolo_annotations,
+)
 from supervision.dataset.utils import save_dataset_images
 from tests.helpers import create_yolo_dataset
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -290,9 +295,7 @@ def test_save_coco_annotations_show_progress_consistent(
     out_off = tmp_path / "coco_off" / "annotations.json"
     out_on = tmp_path / "coco_on" / "annotations.json"
     save_coco_annotations(dataset=ds, annotation_path=str(out_off))
-    save_coco_annotations(
-        dataset=ds, annotation_path=str(out_on), show_progress=True
-    )
+    save_coco_annotations(dataset=ds, annotation_path=str(out_on), show_progress=True)
     data_off = json.loads(out_off.read_text())
     data_on = json.loads(out_on.read_text())
     assert len(data_off["images"]) == len(data_on["images"])
@@ -334,9 +337,7 @@ def test_as_pascal_voc_show_progress_consistent(
     out_off = tmp_path / "voc_off"
     out_on = tmp_path / "voc_on"
     ds.as_pascal_voc(annotations_directory_path=str(out_off))
-    ds.as_pascal_voc(
-        annotations_directory_path=str(out_on), show_progress=True
-    )
+    ds.as_pascal_voc(annotations_directory_path=str(out_on), show_progress=True)
     files_off = sorted(f.name for f in out_off.glob("*.xml"))
     files_on = sorted(f.name for f in out_on.glob("*.xml"))
     assert files_off == files_on

--- a/tests/dataset/test_show_progress.py
+++ b/tests/dataset/test_show_progress.py
@@ -166,12 +166,12 @@ def test_load_coco_show_progress(coco_dataset: dict, show_progress: bool) -> Non
 
 
 def test_load_coco_show_progress_consistent(coco_dataset: dict) -> None:
-    classes_off, paths_off, ann_off = load_coco_annotations(
+    classes_off, paths_off, _ann_off = load_coco_annotations(
         images_directory_path=coco_dataset["images_dir"],
         annotations_path=coco_dataset["annotations_path"],
         show_progress=False,
     )
-    classes_on, paths_on, ann_on = load_coco_annotations(
+    classes_on, paths_on, _ann_on = load_coco_annotations(
         images_directory_path=coco_dataset["images_dir"],
         annotations_path=coco_dataset["annotations_path"],
         show_progress=True,

--- a/tests/dataset/test_show_progress.py
+++ b/tests/dataset/test_show_progress.py
@@ -1,0 +1,366 @@
+"""
+Tests that show_progress parameter works correctly for all dataset
+loaders and savers, and that output is identical regardless of its value.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from supervision import DetectionDataset, Detections
+from supervision.dataset.formats.coco import load_coco_annotations, save_coco_annotations
+from supervision.dataset.formats.pascal_voc import load_pascal_voc_annotations
+from supervision.dataset.formats.yolo import load_yolo_annotations, save_yolo_annotations
+from supervision.dataset.utils import save_dataset_images
+from tests.helpers import create_yolo_dataset
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def yolo_dataset(tmp_path: Path) -> dict:
+    return create_yolo_dataset(str(tmp_path / "yolo"), num_images=3)
+
+
+@pytest.fixture
+def coco_dataset(tmp_path: Path) -> dict:
+    """Create a minimal COCO dataset on disk (JSON only; no real images needed)."""
+    images_dir = tmp_path / "coco" / "images"
+    images_dir.mkdir(parents=True)
+    annotations_path = tmp_path / "coco" / "annotations.json"
+
+    coco_data = {
+        "categories": [
+            {"id": 1, "name": "dog", "supercategory": "animal"},
+            {"id": 2, "name": "cat", "supercategory": "animal"},
+        ],
+        "images": [
+            {"id": 1, "file_name": "img1.jpg", "width": 100, "height": 100},
+            {"id": 2, "file_name": "img2.jpg", "width": 100, "height": 100},
+        ],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [10, 10, 30, 30],
+                "area": 900,
+                "segmentation": [],
+                "iscrowd": 0,
+            },
+            {
+                "id": 2,
+                "image_id": 2,
+                "category_id": 2,
+                "bbox": [5, 5, 20, 20],
+                "area": 400,
+                "segmentation": [],
+                "iscrowd": 0,
+            },
+        ],
+    }
+    annotations_path.write_text(json.dumps(coco_data))
+
+    return {
+        "images_dir": str(images_dir),
+        "annotations_path": str(annotations_path),
+    }
+
+
+@pytest.fixture
+def pascal_voc_dataset(tmp_path: Path) -> dict:
+    """Create a minimal Pascal VOC dataset on disk with real images and XML files."""
+    images_dir = tmp_path / "voc" / "images"
+    annotations_dir = tmp_path / "voc" / "annotations"
+    images_dir.mkdir(parents=True)
+    annotations_dir.mkdir(parents=True)
+
+    for i in range(1, 3):
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        cv2.imwrite(str(images_dir / f"img{i}.jpg"), img)
+
+        xml = f"""<?xml version="1.0" ?>
+<annotation>
+  <folder>VOC</folder>
+  <filename>img{i}.jpg</filename>
+  <size><width>100</width><height>100</height><depth>3</depth></size>
+  <object>
+    <name>dog</name>
+    <bndbox>
+      <xmin>{10 + i}</xmin><ymin>{10 + i}</ymin>
+      <xmax>{40 + i}</xmax><ymax>{40 + i}</ymax>
+    </bndbox>
+  </object>
+</annotation>"""
+        (annotations_dir / f"img{i}.xml").write_text(xml)
+
+    return {
+        "images_dir": str(images_dir),
+        "annotations_dir": str(annotations_dir),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_yolo(info: dict, show_progress: bool) -> tuple:
+    return load_yolo_annotations(
+        images_directory_path=info["images_dir"],
+        annotations_directory_path=info["labels_dir"],
+        data_yaml_path=info["data_yaml_path"],
+        show_progress=show_progress,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Load: YOLO
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("show_progress", [False, True])
+def test_load_yolo_show_progress(yolo_dataset: dict, show_progress: bool) -> None:
+    classes, image_paths, annotations = _load_yolo(yolo_dataset, show_progress)
+    assert len(image_paths) == yolo_dataset["num_images"]
+    assert len(annotations) == yolo_dataset["num_images"]
+    assert isinstance(classes, list)
+
+
+def test_load_yolo_show_progress_consistent(yolo_dataset: dict) -> None:
+    classes_off, paths_off, ann_off = _load_yolo(yolo_dataset, show_progress=False)
+    classes_on, paths_on, ann_on = _load_yolo(yolo_dataset, show_progress=True)
+    assert classes_off == classes_on
+    assert paths_off == paths_on
+    assert set(ann_off.keys()) == set(ann_on.keys())
+
+
+# ---------------------------------------------------------------------------
+# Load: COCO
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("show_progress", [False, True])
+def test_load_coco_show_progress(coco_dataset: dict, show_progress: bool) -> None:
+    classes, image_paths, annotations = load_coco_annotations(
+        images_directory_path=coco_dataset["images_dir"],
+        annotations_path=coco_dataset["annotations_path"],
+        show_progress=show_progress,
+    )
+    assert classes == ["dog", "cat"]
+    assert len(image_paths) == 2
+    assert len(annotations) == 2
+
+
+def test_load_coco_show_progress_consistent(coco_dataset: dict) -> None:
+    classes_off, paths_off, ann_off = load_coco_annotations(
+        images_directory_path=coco_dataset["images_dir"],
+        annotations_path=coco_dataset["annotations_path"],
+        show_progress=False,
+    )
+    classes_on, paths_on, ann_on = load_coco_annotations(
+        images_directory_path=coco_dataset["images_dir"],
+        annotations_path=coco_dataset["annotations_path"],
+        show_progress=True,
+    )
+    assert classes_off == classes_on
+    assert paths_off == paths_on
+
+
+# ---------------------------------------------------------------------------
+# Load: Pascal VOC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("show_progress", [False, True])
+def test_load_pascal_voc_show_progress(
+    pascal_voc_dataset: dict, show_progress: bool
+) -> None:
+    classes, image_paths, annotations = load_pascal_voc_annotations(
+        images_directory_path=pascal_voc_dataset["images_dir"],
+        annotations_directory_path=pascal_voc_dataset["annotations_dir"],
+        show_progress=show_progress,
+    )
+    assert "dog" in classes
+    assert len(image_paths) == 2
+    assert len(annotations) == 2
+
+
+def test_load_pascal_voc_show_progress_consistent(
+    pascal_voc_dataset: dict,
+) -> None:
+    classes_off, paths_off, _ = load_pascal_voc_annotations(
+        images_directory_path=pascal_voc_dataset["images_dir"],
+        annotations_directory_path=pascal_voc_dataset["annotations_dir"],
+        show_progress=False,
+    )
+    classes_on, paths_on, _ = load_pascal_voc_annotations(
+        images_directory_path=pascal_voc_dataset["images_dir"],
+        annotations_directory_path=pascal_voc_dataset["annotations_dir"],
+        show_progress=True,
+    )
+    assert classes_off == classes_on
+    assert set(paths_off) == set(paths_on)
+
+
+# ---------------------------------------------------------------------------
+# Save: YOLO
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("show_progress", [False, True])
+def test_save_yolo_annotations_show_progress(
+    yolo_dataset: dict, tmp_path: Path, show_progress: bool
+) -> None:
+    ds = DetectionDataset.from_yolo(
+        images_directory_path=yolo_dataset["images_dir"],
+        annotations_directory_path=yolo_dataset["labels_dir"],
+        data_yaml_path=yolo_dataset["data_yaml_path"],
+    )
+    out_dir = tmp_path / f"yolo_out_{show_progress}"
+    save_yolo_annotations(
+        dataset=ds,
+        annotations_directory_path=str(out_dir),
+        show_progress=show_progress,
+    )
+    written = list(out_dir.glob("*.txt"))
+    assert len(written) == yolo_dataset["num_images"]
+
+
+def test_save_yolo_annotations_show_progress_consistent(
+    yolo_dataset: dict, tmp_path: Path
+) -> None:
+    ds = DetectionDataset.from_yolo(
+        images_directory_path=yolo_dataset["images_dir"],
+        annotations_directory_path=yolo_dataset["labels_dir"],
+        data_yaml_path=yolo_dataset["data_yaml_path"],
+    )
+    out_off = tmp_path / "yolo_off"
+    out_on = tmp_path / "yolo_on"
+    save_yolo_annotations(dataset=ds, annotations_directory_path=str(out_off))
+    save_yolo_annotations(
+        dataset=ds, annotations_directory_path=str(out_on), show_progress=True
+    )
+    files_off = sorted(f.name for f in out_off.glob("*.txt"))
+    files_on = sorted(f.name for f in out_on.glob("*.txt"))
+    assert files_off == files_on
+
+
+# ---------------------------------------------------------------------------
+# Save: COCO
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("show_progress", [False, True])
+def test_save_coco_annotations_show_progress(
+    yolo_dataset: dict, tmp_path: Path, show_progress: bool
+) -> None:
+    ds = DetectionDataset.from_yolo(
+        images_directory_path=yolo_dataset["images_dir"],
+        annotations_directory_path=yolo_dataset["labels_dir"],
+        data_yaml_path=yolo_dataset["data_yaml_path"],
+    )
+    out_path = tmp_path / f"coco_{show_progress}" / "annotations.json"
+    save_coco_annotations(
+        dataset=ds,
+        annotation_path=str(out_path),
+        show_progress=show_progress,
+    )
+    assert out_path.exists()
+    data = json.loads(out_path.read_text())
+    assert len(data["images"]) == yolo_dataset["num_images"]
+
+
+def test_save_coco_annotations_show_progress_consistent(
+    yolo_dataset: dict, tmp_path: Path
+) -> None:
+    ds = DetectionDataset.from_yolo(
+        images_directory_path=yolo_dataset["images_dir"],
+        annotations_directory_path=yolo_dataset["labels_dir"],
+        data_yaml_path=yolo_dataset["data_yaml_path"],
+    )
+    out_off = tmp_path / "coco_off" / "annotations.json"
+    out_on = tmp_path / "coco_on" / "annotations.json"
+    save_coco_annotations(dataset=ds, annotation_path=str(out_off))
+    save_coco_annotations(
+        dataset=ds, annotation_path=str(out_on), show_progress=True
+    )
+    data_off = json.loads(out_off.read_text())
+    data_on = json.loads(out_on.read_text())
+    assert len(data_off["images"]) == len(data_on["images"])
+    assert len(data_off["annotations"]) == len(data_on["annotations"])
+    assert data_off["categories"] == data_on["categories"]
+
+
+# ---------------------------------------------------------------------------
+# Save: Pascal VOC (via DetectionDataset.as_pascal_voc)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("show_progress", [False, True])
+def test_as_pascal_voc_show_progress(
+    yolo_dataset: dict, tmp_path: Path, show_progress: bool
+) -> None:
+    ds = DetectionDataset.from_yolo(
+        images_directory_path=yolo_dataset["images_dir"],
+        annotations_directory_path=yolo_dataset["labels_dir"],
+        data_yaml_path=yolo_dataset["data_yaml_path"],
+    )
+    out_dir = tmp_path / f"voc_{show_progress}"
+    ds.as_pascal_voc(
+        annotations_directory_path=str(out_dir),
+        show_progress=show_progress,
+    )
+    written = list(out_dir.glob("*.xml"))
+    assert len(written) == yolo_dataset["num_images"]
+
+
+def test_as_pascal_voc_show_progress_consistent(
+    yolo_dataset: dict, tmp_path: Path
+) -> None:
+    ds = DetectionDataset.from_yolo(
+        images_directory_path=yolo_dataset["images_dir"],
+        annotations_directory_path=yolo_dataset["labels_dir"],
+        data_yaml_path=yolo_dataset["data_yaml_path"],
+    )
+    out_off = tmp_path / "voc_off"
+    out_on = tmp_path / "voc_on"
+    ds.as_pascal_voc(annotations_directory_path=str(out_off))
+    ds.as_pascal_voc(
+        annotations_directory_path=str(out_on), show_progress=True
+    )
+    files_off = sorted(f.name for f in out_off.glob("*.xml"))
+    files_on = sorted(f.name for f in out_on.glob("*.xml"))
+    assert files_off == files_on
+
+
+# ---------------------------------------------------------------------------
+# Save: images (save_dataset_images)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("show_progress", [False, True])
+def test_save_dataset_images_show_progress(
+    yolo_dataset: dict, tmp_path: Path, show_progress: bool
+) -> None:
+    ds = DetectionDataset.from_yolo(
+        images_directory_path=yolo_dataset["images_dir"],
+        annotations_directory_path=yolo_dataset["labels_dir"],
+        data_yaml_path=yolo_dataset["data_yaml_path"],
+    )
+    out_dir = tmp_path / f"images_{show_progress}"
+    save_dataset_images(
+        dataset=ds,
+        images_directory_path=str(out_dir),
+        show_progress=show_progress,
+    )
+    written = list(out_dir.glob("*.jpg"))
+    assert len(written) == yolo_dataset["num_images"]


### PR DESCRIPTION
## Summary

Closes #183

Adds an optional `show_progress` parameter to all time-consuming dataset operations so users can see loading/saving progress via a `tqdm` progress bar.

- `DetectionDataset.from_coco(show_progress=True)`
- `DetectionDataset.from_pascal_voc(show_progress=True)`
- `DetectionDataset.from_yolo(show_progress=True)`
- `DetectionDataset.as_coco(show_progress=True)`
- `DetectionDataset.as_yolo(show_progress=True)`
- `DetectionDataset.as_pascal_voc(show_progress=True)`

## Details

- Defaults to `False` - fully backward compatible, no existing code breaks
- Uses `tqdm.auto` (already a project dependency) so progress bars work correctly in both terminal and Jupyter notebook environments
- The parameter is propagated from the public `DetectionDataset` methods down to the internal format loader/saver functions

## Test plan

- [ ] Load a COCO dataset with `show_progress=True` and confirm the bar renders
- [ ] Load a YOLO dataset with `show_progress=True` and confirm the bar renders
- [ ] Load a Pascal VOC dataset with `show_progress=True` and confirm the bar renders
- [ ] Confirm existing tests pass with no changes (default `show_progress=False`)