### PR TITLE
fix: add area column to CSVSink BASE_HEADER

### DIFF
--- a/src/supervision/detection/tools/csv_sink.py
+++ b/src/supervision/detection/tools/csv_sink.py
@@ -21,6 +21,7 @@ BASE_HEADER = [
     "class_id",
     "confidence",
     "tracker_id",
+    "area",
 ]
 
 
@@ -33,7 +34,7 @@ class CSVSink:
     A utility class for saving detection data to a CSV file. This class is designed to
     efficiently serialize detection objects into a CSV format, allowing for the
     inclusion of bounding box coordinates and additional attributes like `confidence`,
-    `class_id`, and `tracker_id`.
+    `class_id`, `tracker_id`, and `area`.
 
     !!! tip
 
@@ -117,6 +118,7 @@ class CSVSink:
         detections: Detections, custom_data: dict[str, Any] | None = None
     ) -> list[dict[str, Any]]:
         parsed_rows = []
+        areas = detections.area
         for i in range(len(detections.xyxy)):
             row = {
                 "x_min": detections.xyxy[i][0],
@@ -132,6 +134,7 @@ class CSVSink:
                 "tracker_id": ""
                 if detections.tracker_id is None
                 else str(detections.tracker_id[i]),
+                "area": str(areas[i]),
             }
 
             if hasattr(detections, "data"):


### PR DESCRIPTION
## Problem

`CSVSink` writes bounding-box coordinates, `confidence`, `class_id`, and `tracker_id` to CSV but silently omits the `area` of each detection, even though `Detections.area` is a standard computed property. Users trying to log area either get an empty column or an `AttributeError` when passing it via `custom_data`.

Reported in #1397.

---

## Root Cause

`BASE_HEADER` (the static list of always-written columns) never included `"area"`:

```python
# before
BASE_HEADER = [
    "x_min", "y_min", "x_max", "y_max",
    "class_id", "confidence", "tracker_id",
    # ← area missing
]
```

`parse_detection_data()` built each row from the `xyxy` array + optional fields, but never called `detections.area`.

---

## Fix

Two small, self-contained changes to `csv_sink.py`:

### 1. `BASE_HEADER` — add `"area"`
```python
BASE_HEADER = [
    "x_min", "y_min", "x_max", "y_max",
    "class_id", "confidence", "tracker_id",
    "area",   # ← added
]
```

### 2. `parse_detection_data()` — compute and include area per row
```python
areas = detections.area          # computed once outside the loop
for i in range(len(detections.xyxy)):
    row = {
        ...,
        "area": str(areas[i]),   # ← added
    }
```

`detections.area` is computed once before the loop (not per-iteration) to avoid redundant work on large batches.

---

## Verification

```python
import supervision as sv
import numpy as np

detections = sv.Detections(
    xyxy=np.array([[10, 20, 110, 120]]),  # area = 100*100 = 10000
    confidence=np.array([0.95]),
    class_id=np.array([0]),
)

with sv.CSVSink("out.csv") as sink:
    sink.append(detections)

# out.csv now contains an 'area' column with value 10000.0
```

Fixes #1397