### PR TITLE
fix(L100-003): remove `frame_rate` param from `ByteTrack`, simplify `max_time_lost`

### DIFF
--- a/src/supervision/tracker/byte_tracker/core.py
+++ b/src/supervision/tracker/byte_tracker/core.py
@@ -33,7 +33,6 @@ class ByteTrack:
         minimum_matching_threshold: Threshold for matching tracks with detections.
             Decreasing minimum_matching_threshold improves accuracy but risks fragmentation.
             Increasing it improves completeness but risks false positives and drift.
-        frame_rate: The frame rate of the video.
         minimum_consecutive_frames: Number of consecutive frames that an object must
             be tracked before it is considered a 'valid' track.
             Increasing minimum_consecutive_frames prevents the creation of accidental tracks from
@@ -45,7 +44,6 @@ class ByteTrack:
         track_activation_threshold: float = 0.25,
         lost_track_buffer: int = 30,
         minimum_matching_threshold: float = 0.8,
-        frame_rate: int = 30,
         minimum_consecutive_frames: int = 1,
     ):
         self.track_activation_threshold = track_activation_threshold
@@ -53,7 +51,7 @@ class ByteTrack:
 
         self.frame_id = 0
         self.det_thresh = self.track_activation_threshold + 0.1
-        self.max_time_lost = int(frame_rate / 30.0 * lost_track_buffer)
+        self.max_time_lost = lost_track_buffer
         self.minimum_consecutive_frames = minimum_consecutive_frames
         self.kalman_filter = KalmanFilter()
         self.shared_kalman = KalmanFilter()


### PR DESCRIPTION
## Description

Fixes #2202

The `frame_rate` parameter in `ByteTrack.__init__` was only ever used in one place:

```python
self.max_time_lost = int(frame_rate / 30.0 * lost_track_buffer)
```

This was confusing for two reasons:
1. The hardcoded `30.0` divisor means the parameter doesn't behave as its name implies — changing `frame_rate` silently scales `max_time_lost` in a non-obvious way.
2. The docstring for `lost_track_buffer` says *"Number of frames to buffer when a track is lost"*, which is inconsistent with the scaled formula.

With the default `frame_rate=30`, the formula resolves to `int(30 / 30.0 * 30) = 30`, so `max_time_lost` was always equal to `lost_track_buffer` for the vast majority of users.

## Changes

- Removed `frame_rate` parameter from `ByteTrack.__init__`.
- Simplified to `self.max_time_lost = lost_track_buffer` (same pattern as `minimum_consecutive_frames`).
- Updated the class docstring to remove the `frame_rate` argument entry.

## Backward Compatibility

- **Users using defaults** (`frame_rate=30`, `lost_track_buffer=30`): no behaviour change — `max_time_lost` stays `30`.
- **Users who passed a custom `frame_rate`**: they should now pass the desired frame count directly via `lost_track_buffer`. This is a breaking change for that subset, but the old API was semantically misleading.

## Type of change

- [x] Bug fix (non-breaking fix for incorrect/misleading behaviour)
- [x] Breaking change (removes `frame_rate` parameter)

## How Has This Been Tested?

- Verified that all existing usages in the codebase pass `frame_rate=30` (the default) or omit it entirely, meaning `max_time_lost` is unchanged.
- No existing tests reference the `frame_rate` parameter.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the docstring accordingly
- [x] My changes generate no new warnings