### PR TITLE
releasing `0.28.0`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,15 +5,47 @@ date_modified: 2026-04-23
 
 # Changelog
 
-### 0.28.0 <small>Unreleased</small>
+### 0.28.0 <small>Apr 17, 2026</small>
 
-- Changed [#2178](https://github.com/roboflow/supervision/pull/2178): [`sv.Detections.from_inference`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.from_inference) now supports compressed COCO RLE masks. Inference responses with `rle` or `rle_mask` fields containing a compressed counts string (as produced by `pycocotools`) are decoded directly into binary masks, avoiding a lossy polygon round-trip.
+- Added [#2159](https://github.com/roboflow/supervision/pull/2159): [`sv.CompactMask`](https://supervision.roboflow.com/develop/detection/compact_mask/#supervision.detection.compact_mask.CompactMask) for memory-efficient mask storage. Masks are stored as crop-region bounding boxes plus RLE-encoded data instead of full-resolution bitmaps, reducing memory by 10–100× for sparse masks. Integrates transparently with `sv.Detections.mask` — filtering, merging, and `area` all work without materialising the full array.
+
+- Added [#2178](https://github.com/roboflow/supervision/pull/2178): [`sv.Detections.from_inference`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.from_inference) now supports compressed COCO RLE masks. Inference responses with `rle` or `rle_mask` fields containing a compressed counts string (as produced by `pycocotools`) are decoded directly into binary masks, avoiding a lossy polygon round-trip.
+
+- Added [#2004](https://github.com/roboflow/supervision/pull/2004): [`sv.Color.from_hex`](https://supervision.roboflow.com/latest/utils/draw/#supervision.draw.color.Color.from_hex) now accepts 8-digit hexadecimal RGBA codes (e.g. `#ff00ff80`). [`Color.as_hex()`](https://supervision.roboflow.com/latest/utils/draw/#supervision.draw.color.Color.as_hex) serialises back, including alpha when not fully opaque. New utility functions `sv.hex_to_rgba`, `sv.rgba_to_hex`, and `sv.is_valid_hex` are exported at the top level.
+
+- Added [#709](https://github.com/roboflow/supervision/pull/709): [`sv.BlurAnnotator`](https://supervision.roboflow.com/latest/detection/annotators/#supervision.annotators.core.BlurAnnotator) and [`sv.PixelateAnnotator`](https://supervision.roboflow.com/latest/detection/annotators/#supervision.annotators.core.PixelateAnnotator) now support dynamic sizing. When `kernel_size=None` or `pixel_size=None` (the new default), the size is computed per detection as a fraction of the shorter bounding-box dimension, producing consistent visual results across objects of different sizes.
+
+- Added [#2186](https://github.com/roboflow/supervision/pull/2186): [`sv.InferenceSlicer`](https://supervision.roboflow.com/latest/detection/tools/inference_slicer/#supervision.detection.tools.inference_slicer.InferenceSlicer) now emits a warning when detections returned by the callback fall outside the tile boundaries, helping catch coordinate-system bugs in custom callbacks.
 
 - Changed [#2178](https://github.com/roboflow/supervision/pull/2178): [`sv.rle_to_mask`](https://supervision.roboflow.com/latest/detection/utils/converters/#supervision.detection.utils.converters.rle_to_mask) and [`sv.mask_to_rle`](https://supervision.roboflow.com/latest/detection/utils/converters/#supervision.detection.utils.converters.mask_to_rle) moved to `supervision.detection.utils.converters`. The old import path `supervision.dataset.utils` continues to work but is deprecated.
 
 - Fixed [#2178](https://github.com/roboflow/supervision/pull/2178): [`sv.rle_to_mask`](https://supervision.roboflow.com/latest/detection/utils/converters/#supervision.detection.utils.converters.rle_to_mask) now returns `NDArray[bool]` as declared in its signature. Previously the implementation returned `uint8` despite the `bool` annotation; code that relied on the undocumented `uint8` output (e.g. `mask * 255` producing `uint8`) should wrap the result with `.astype(np.uint8)`.
 
 - Fixed [#2210](https://github.com/roboflow/supervision/pull/2210): [`sv.VideoInfo.fps`](https://supervision.roboflow.com/latest/utils/video/#supervision.utils.video.VideoInfo) now returns a `float` instead of a truncated `int`. Previously, frame rates like 23.976, 29.97, and 59.94 were silently truncated, causing frame-timing drift that accumulates over long videos. The type of `VideoInfo.fps` has changed from `int` to `float`; callers that pass `fps` to APIs requiring an integer (such as `deque(maxlen=...)` or `TraceAnnotator(trace_length=...)`) should wrap the value with `int()`.
+
+- Fixed [#2209](https://github.com/roboflow/supervision/pull/2209): [`sv.Detections.is_empty()`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.is_empty) now returns `False` for detections with an empty `tracker_id` array, matching the expected behaviour.
+
+- Fixed [#2199](https://github.com/roboflow/supervision/pull/2199): [`sv.CSVSink`](https://supervision.roboflow.com/latest/detection/tools/save_detections/#supervision.detection.tools.csv_sink.CSVSink) now correctly slices numpy array values in `custom_data` per row. Previously the full array was written for every detection.
+
+- Fixed [#2216](https://github.com/roboflow/supervision/pull/2216): [`sv.CSVSink`](https://supervision.roboflow.com/latest/detection/tools/save_detections/#supervision.detection.tools.csv_sink.CSVSink) and [`sv.JSONSink`](https://supervision.roboflow.com/latest/detection/tools/save_detections/#supervision.detection.tools.json_sink.JSONSink) now slice plain Python `list` and `tuple` values in `custom_data` per detection row. Lists and tuples matching the detection count are indexed per row, consistent with `np.ndarray` behavior.
+
+- Fixed [#2217](https://github.com/roboflow/supervision/pull/2217): [`sv.TraceAnnotator`](https://supervision.roboflow.com/latest/detection/annotators/#supervision.annotators.core.TraceAnnotator) no longer crashes in `smooth` mode when a tracker remains stationary. Duplicate consecutive points caused `splprep` to fail; the annotator now deduplicates anchor points and falls back to a raw polyline when fewer than 4 unique points are available.
+
+- Fixed [#2218](https://github.com/roboflow/supervision/pull/2218): [`load_coco_annotations`](https://supervision.roboflow.com/latest/datasets/core/) now rejects COCO annotations whose `file_name` escapes the images directory via `../` traversal or absolute paths, preventing path-traversal attacks from malicious annotation files.
+
+- Fixed [#2187](https://github.com/roboflow/supervision/pull/2187): Extreme memory usage when loading OBB (oriented bounding box) datasets, caused by allocating full-image masks for each rotated box, has been resolved.
+
+- Fixed [#2188](https://github.com/roboflow/supervision/pull/2188): [`sv.KeyPoints`](https://supervision.roboflow.com/latest/keypoint/core/#supervision.key_points.core.KeyPoints) boolean mask indexing now works correctly when all instances have the same keypoint count (uniform-count selection).
+
+- Fixed [#2185](https://github.com/roboflow/supervision/pull/2185): [`sv.DetectionDataset.as_coco()`](https://supervision.roboflow.com/latest/datasets/core/#supervision.dataset.core.DetectionDataset.as_coco) now preserves `area` and `iscrowd` fields instead of silently dropping them in the round-trip.
+
+- Fixed [#1746](https://github.com/roboflow/supervision/pull/1746): Precision loss when converting annotations with `force_mask=True` in dataset format converters.
+
+- Deprecated [#2215](https://github.com/roboflow/supervision/pull/2215): [`sv.ByteTrack`](https://supervision.roboflow.com/latest/trackers/#supervision.tracker.byte_tracker.core.ByteTrack) is deprecated in favour of `ByteTrackTracker` from the external [`trackers`](https://pypi.org/project/trackers/) package (`pip install trackers`). The update method is renamed from `update_with_detections()` to `update()`. Removal planned for `supervision-0.30.0`.
+
+- Deprecated [#2214](https://github.com/roboflow/supervision/pull/2214): `supervision.keypoint` module is deprecated; use `supervision.key_points` instead. `LMM` enum and `from_lmm` method are deprecated in favour of `VLM` and `from_vlm`. `create_tiles` in `supervision.utils.image`, `ensure_cv2_image_for_processing` in `supervision.utils.conversion`, and keypoint validation utilities in `supervision.validators` are deprecated.
+
+- Deprecated: `normalized_xyxy` argument in [`sv.denormalize_boxes`](https://supervision.roboflow.com/latest/detection/utils/boxes/#supervision.detection.utils.boxes.denormalize_boxes) renamed to `xyxy`. Passing `normalized_xyxy=` now emits a `FutureWarning`; support will be removed in `supervision-0.30.0`.
 
 ### 0.27.0 <small>Nov 16, 2025</small>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ date_modified: 2026-04-23
 
 # Changelog
 
-### 0.28.0 <small>Apr 17, 2026</small>
+### 0.28.0 <small>Apr 30, 2026</small>
 
 - Added [#2159](https://github.com/roboflow/supervision/pull/2159): [`sv.CompactMask`](https://supervision.roboflow.com/develop/detection/compact_mask/#supervision.detection.compact_mask.CompactMask) for memory-efficient mask storage. Masks are stored as crop-region bounding boxes plus RLE-encoded data instead of full-resolution bitmaps, reducing memory by 10–100× for sparse masks. Integrates transparently with `sv.Detections.mask` — filtering, merging, and `area` all work without materialising the full array.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,14 @@ date_modified: 2026-04-23
 
 - Added [#2186](https://github.com/roboflow/supervision/pull/2186): [`sv.InferenceSlicer`](https://supervision.roboflow.com/latest/detection/tools/inference_slicer/#supervision.detection.tools.inference_slicer.InferenceSlicer) now emits a warning when detections returned by the callback fall outside the tile boundaries, helping catch coordinate-system bugs in custom callbacks.
 
+- Added [#2103](https://github.com/roboflow/supervision/pull/2103), [#2152](https://github.com/roboflow/supervision/pull/2152): [`sv.Detections.from_inference`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.from_inference) now parses SAM3 detection and PVS (point-video segmentation) outputs, both from the local `inference` package and from Roboflow-hosted server responses.
+
+- Added [#2154](https://github.com/roboflow/supervision/pull/2154): The library now uses Python's `logging` module instead of `print` for diagnostic output. Messages are emitted under the `supervision` logger so applications can capture, filter, or silence them through standard `logging` configuration.
+
+- Added [#932](https://github.com/roboflow/supervision/pull/932): [`sv.ImageAssets`](https://supervision.roboflow.com/latest/assets/) for downloading sample images alongside existing video assets, useful for examples and tutorials.
+
+- Changed [#2169](https://github.com/roboflow/supervision/pull/2169): [`sv.MeanAveragePrecisionResult`](https://supervision.roboflow.com/latest/metrics/mean_average_precision/) and related metric arrays (`mAP_scores`, `ap_per_class`, `iou_thresholds`, precision/recall) are now `float32` instead of `float64`. Reduces memory and speeds up computation; numerical results may differ in the last few digits.
+
 - Changed [#2178](https://github.com/roboflow/supervision/pull/2178): [`sv.rle_to_mask`](https://supervision.roboflow.com/latest/detection/utils/converters/#supervision.detection.utils.converters.rle_to_mask) and [`sv.mask_to_rle`](https://supervision.roboflow.com/latest/detection/utils/converters/#supervision.detection.utils.converters.mask_to_rle) moved to `supervision.detection.utils.converters`. The old import path `supervision.dataset.utils` continues to work but is deprecated.
 
 - Fixed [#2178](https://github.com/roboflow/supervision/pull/2178): [`sv.rle_to_mask`](https://supervision.roboflow.com/latest/detection/utils/converters/#supervision.detection.utils.converters.rle_to_mask) now returns `NDArray[bool]` as declared in its signature. Previously the implementation returned `uint8` despite the `bool` annotation; code that relied on the undocumented `uint8` output (e.g. `mask * 255` producing `uint8`) should wrap the result with `.astype(np.uint8)`.
@@ -40,6 +48,22 @@ date_modified: 2026-04-23
 - Fixed [#2185](https://github.com/roboflow/supervision/pull/2185): [`sv.DetectionDataset.as_coco()`](https://supervision.roboflow.com/latest/datasets/core/#supervision.dataset.core.DetectionDataset.as_coco) now preserves `area` and `iscrowd` fields instead of silently dropping them in the round-trip.
 
 - Fixed [#1746](https://github.com/roboflow/supervision/pull/1746): Precision loss when converting annotations with `force_mask=True` in dataset format converters.
+
+- Fixed [#1991](https://github.com/roboflow/supervision/pull/1991): [`sv.PolygonZone`](https://supervision.roboflow.com/latest/detection/tools/polygon_zone/) no longer double-counts the same object when multiple zones overlap. The bottom-center anchor was previously assigned to every zone whose polygon contained it; trigger now reflects the chosen anchor's containment per zone independently.
+
+- Fixed [#1868](https://github.com/roboflow/supervision/pull/1868): [`sv.LineZone`](https://supervision.roboflow.com/latest/detection/tools/line_zone/) no longer mis-attributes crossings when a tracker reuses the same `tracker_id` across different classes. Class-aware bookkeeping prevents a new object from inheriting another class's prior crossing state.
+
+- Fixed [#2022](https://github.com/roboflow/supervision/pull/2022): [`sv.process_video`](https://supervision.roboflow.com/latest/utils/video/#supervision.utils.video.process_video) now raises immediately when the user callback throws, instead of silently swallowing the exception and hanging until the writer is flushed.
+
+- Fixed [#2156](https://github.com/roboflow/supervision/pull/2156): [`sv.DetectionDataset`](https://supervision.roboflow.com/latest/datasets/core/#supervision.dataset.core.DetectionDataset) now populates `data["class_name"]` on every loaded annotation, matching what model connectors produce. Downstream code can rely on `class_name` being present whether detections come from a dataset or a model.
+
+- Fixed [#1364](https://github.com/roboflow/supervision/pull/1364): [`sv.ByteTrack`](https://supervision.roboflow.com/latest/trackers/#supervision.tracker.byte_tracker.core.ByteTrack) now preserves externally assigned `tracker_id` values instead of overwriting them with internal ids on the first update.
+
+- Fixed [#1853](https://github.com/roboflow/supervision/pull/1853): [`sv.ConfusionMatrix`](https://supervision.roboflow.com/latest/metrics/confusion_matrix/) `evaluate_detection_batch` now matches predictions to ground truth correctly when multiple detections fall on the same target. Previously, double-counting inflated false-positive and false-negative counts.
+
+- Fixed [#2136](https://github.com/roboflow/supervision/pull/2136): [`sv.MeanAverageRecall`](https://supervision.roboflow.com/latest/metrics/mean_average_recall/) now computes mAR@K using the top-K detections per image, matching the COCO definition. Previous values were inflated relative to `pycocotools`.
+
+- Fixed [#1086](https://github.com/roboflow/supervision/pull/1086), [#265](https://github.com/roboflow/supervision/pull/265): COCO export and `force_masks` behaviour are now consistent across dataset formats. Empty polygons no longer raise during `as_coco`, and `force_masks=True` produces masks regardless of source format.
 
 - Deprecated [#2215](https://github.com/roboflow/supervision/pull/2215): [`sv.ByteTrack`](https://supervision.roboflow.com/latest/trackers/#supervision.tracker.byte_tracker.core.ByteTrack) is deprecated in favour of `ByteTrackTracker` from the external [`trackers`](https://pypi.org/project/trackers/) package (`pip install trackers`). The update method is renamed from `update_with_detections()` to `update()`. Removal planned for `supervision-0.30.0`.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,7 +23,7 @@ date_modified: 2026-04-23
 
 - Fixed [#2210](https://github.com/roboflow/supervision/pull/2210): [`sv.VideoInfo.fps`](https://supervision.roboflow.com/latest/utils/video/#supervision.utils.video.VideoInfo) now returns a `float` instead of a truncated `int`. Previously, frame rates like 23.976, 29.97, and 59.94 were silently truncated, causing frame-timing drift that accumulates over long videos. The type of `VideoInfo.fps` has changed from `int` to `float`; callers that pass `fps` to APIs requiring an integer (such as `deque(maxlen=...)` or `TraceAnnotator(trace_length=...)`) should wrap the value with `int()`.
 
-- Fixed [#2209](https://github.com/roboflow/supervision/pull/2209): [`sv.Detections.is_empty()`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.is_empty) now returns `False` for detections with an empty `tracker_id` array, matching the expected behaviour.
+- Fixed [#2209](https://github.com/roboflow/supervision/pull/2209): [`sv.Detections.is_empty()`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.is_empty) now returns `True` for detections filtered down to zero rows, even when `tracker_id` is an empty array. Previously this case incorrectly returned `False`.
 
 - Fixed [#2199](https://github.com/roboflow/supervision/pull/2199): [`sv.CSVSink`](https://supervision.roboflow.com/latest/detection/tools/save_detections/#supervision.detection.tools.csv_sink.CSVSink) now correctly slices numpy array values in `custom_data` per row. Previously the full array was written for every detection.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,9 @@ date_modified: 2026-04-23
 
 ### 0.28.0 <small>Apr 30, 2026</small>
 
-- Added [#2159](https://github.com/roboflow/supervision/pull/2159): [`sv.CompactMask`](https://supervision.roboflow.com/develop/detection/compact_mask/#supervision.detection.compact_mask.CompactMask) for memory-efficient mask storage. Masks are stored as crop-region bounding boxes plus RLE-encoded data instead of full-resolution bitmaps, reducing memory by 10–100× for sparse masks. Integrates transparently with `sv.Detections.mask` — filtering, merging, and `area` all work without materialising the full array.
+- Added [#2159](https://github.com/roboflow/supervision/pull/2159): [`sv.CompactMask`](https://supervision.roboflow.com/develop/detection/compact_mask/#supervision.detection.compact_mask.CompactMask) for memory-efficient mask storage. Masks are stored as crop-region bounding boxes plus RLE-encoded data instead of full-resolution bitmaps, reducing memory by up to 240× for sparse masks. Integrates transparently with `sv.Detections.mask` — filtering, merging, and `area` all work without materialising the full array.
+
+- Added [#2227](https://github.com/roboflow/supervision/pull/2227): [`sv.CompactMask.resize(new_image_shape)`](https://supervision.roboflow.com/develop/detection/compact_mask/#supervision.detection.compact_mask.CompactMask.resize) rescales all stored crops to match a new image resolution, enabling use across frames or after image resizing pipelines.
 
 - Added [#2178](https://github.com/roboflow/supervision/pull/2178): [`sv.Detections.from_inference`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.from_inference) now supports compressed COCO RLE masks. Inference responses with `rle` or `rle_mask` fields containing a compressed counts string (as produced by `pycocotools`) are decoded directly into binary masks, avoiding a lossy polygon round-trip.
 
@@ -17,7 +19,7 @@ date_modified: 2026-04-23
 
 - Added [#2186](https://github.com/roboflow/supervision/pull/2186): [`sv.InferenceSlicer`](https://supervision.roboflow.com/latest/detection/tools/inference_slicer/#supervision.detection.tools.inference_slicer.InferenceSlicer) now emits a warning when detections returned by the callback fall outside the tile boundaries, helping catch coordinate-system bugs in custom callbacks.
 
-- Added [#2103](https://github.com/roboflow/supervision/pull/2103), [#2152](https://github.com/roboflow/supervision/pull/2152): [`sv.Detections.from_inference`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.from_inference) now parses SAM3 detection and PVS (point-video segmentation) outputs, both from the local `inference` package and from Roboflow-hosted server responses.
+- Added [#2103](https://github.com/roboflow/supervision/pull/2103), [#2152](https://github.com/roboflow/supervision/pull/2152): New [`sv.Detections.from_sam3()`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.from_sam3) classmethod parses SAM3 PCS (text-prompted) and PVS (visual-prompted video segmentation) response formats into a standard `sv.Detections`, both from the local `inference` package and from Roboflow-hosted server responses.
 
 - Added [#2154](https://github.com/roboflow/supervision/pull/2154): The library now uses Python's `logging` module instead of `print` for diagnostic output. Messages are emitted under the `supervision` logger so applications can capture, filter, or silence them through standard `logging` configuration.
 
@@ -49,7 +51,7 @@ date_modified: 2026-04-23
 
 - Fixed [#1746](https://github.com/roboflow/supervision/pull/1746): Precision loss when converting annotations with `force_mask=True` in dataset format converters.
 
-- Fixed [#1991](https://github.com/roboflow/supervision/pull/1991): [`sv.PolygonZone`](https://supervision.roboflow.com/latest/detection/tools/polygon_zone/) no longer double-counts the same object when multiple zones overlap. The bottom-center anchor was previously assigned to every zone whose polygon contained it; trigger now reflects the chosen anchor's containment per zone independently.
+- Fixed [#1991](https://github.com/roboflow/supervision/pull/1991): [`sv.PolygonZone`](https://supervision.roboflow.com/latest/detection/tools/polygon_zone/) no longer double-counts the same object when multiple zones overlap. Detection bounding boxes were incorrectly clipped to each zone's ROI before anchor computation, causing the same detection to appear at a different anchor point in each zone; anchor is now computed from the original bounding box so containment is independent per zone.
 
 - Fixed [#1868](https://github.com/roboflow/supervision/pull/1868): [`sv.LineZone`](https://supervision.roboflow.com/latest/detection/tools/line_zone/) no longer mis-attributes crossings when a tracker reuses the same `tracker_id` across different classes. Class-aware bookkeeping prevents a new object from inheriting another class's prior crossing state.
 
@@ -67,7 +69,7 @@ date_modified: 2026-04-23
 
 - Deprecated [#2215](https://github.com/roboflow/supervision/pull/2215): [`sv.ByteTrack`](https://supervision.roboflow.com/latest/trackers/#supervision.tracker.byte_tracker.core.ByteTrack) is deprecated in favour of `ByteTrackTracker` from the external [`trackers`](https://pypi.org/project/trackers/) package (`pip install trackers`). The update method is renamed from `update_with_detections()` to `update()`. Removal planned for `supervision-0.30.0`.
 
-- Deprecated [#2214](https://github.com/roboflow/supervision/pull/2214): `supervision.keypoint` module is deprecated; use `supervision.key_points` instead. `LMM` enum and `from_lmm` method are deprecated in favour of `VLM` and `from_vlm`. `create_tiles` in `supervision.utils.image`, `ensure_cv2_image_for_processing` in `supervision.utils.conversion`, and keypoint validation utilities in `supervision.validators` are deprecated.
+- Deprecated [#2214](https://github.com/roboflow/supervision/pull/2214): `supervision.keypoint` module is deprecated; use `supervision.key_points` instead. `create_tiles` in `supervision.utils.image`, `ensure_cv2_image_for_processing` in `supervision.utils.conversion`, and keypoint validation utilities in `supervision.validators` are deprecated. The `LMM` enum (use `VLM`) and `from_lmm` method (use `from_vlm`) were deprecated in 0.26.0; this release migrates their deprecation mechanism to `pydeprecate`.
 
 - Deprecated: `normalized_xyxy` argument in [`sv.denormalize_boxes`](https://supervision.roboflow.com/latest/detection/utils/boxes/#supervision.detection.utils.boxes.denormalize_boxes) renamed to `xyxy`. Passing `normalized_xyxy=` now emits a `FutureWarning`; support will be removed in `supervision-0.30.0`.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,7 +59,7 @@ date_modified: 2026-04-23
 
 - Fixed [#1364](https://github.com/roboflow/supervision/pull/1364): [`sv.ByteTrack`](https://supervision.roboflow.com/latest/trackers/#supervision.tracker.byte_tracker.core.ByteTrack) now preserves externally assigned `tracker_id` values instead of overwriting them with internal ids on the first update.
 
-- Fixed [#1853](https://github.com/roboflow/supervision/pull/1853): [`sv.ConfusionMatrix`](https://supervision.roboflow.com/latest/metrics/confusion_matrix/) `evaluate_detection_batch` now matches predictions to ground truth correctly when multiple detections fall on the same target. Previously, double-counting inflated false-positive and false-negative counts.
+- Fixed [#1853](https://github.com/roboflow/supervision/pull/1853): [`sv.ConfusionMatrix`](https://supervision.roboflow.com/latest/detection/metrics/#supervision.metrics.detection.ConfusionMatrix) `evaluate_detection_batch` now matches predictions to ground truth correctly when multiple detections fall on the same target. Previously, double-counting inflated false-positive and false-negative counts.
 
 - Fixed [#2136](https://github.com/roboflow/supervision/pull/2136): [`sv.MeanAverageRecall`](https://supervision.roboflow.com/latest/metrics/mean_average_recall/) now computes mAR@K using the top-K detections per image, matching the COCO definition. Previous values were inflated relative to `pycocotools`.
 

--- a/notebooks/convert_to_ipynb.sh
+++ b/notebooks/convert_to_ipynb.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+for py in "$SCRIPT_DIR"/*.py; do
+    echo "Converting: $(basename "$py")"
+    jupytext --to ipynb "$py"
+done

--- a/notebooks/release-demo_0-28.py
+++ b/notebooks/release-demo_0-28.py
@@ -445,7 +445,5 @@ print(f"deque maxlen: {buf.maxlen}  (= int({info.fps}))")
 #   -- PCS and PVS format reference
 # - [RF-DETR docs](https://github.com/roboflow/rf-detr)
 #   -- training, export, and deployment
-# - [Migration guide for 0.28.0](https://github.com/roboflow/supervision/blob/develop/releases/0.28.0/MIGRATION.md)
-#   -- before/after snippets for all breaking changes
 # - [Full changelog](https://supervision.roboflow.com/develop/changelog/)
 #   -- every change in 0.28.0

--- a/notebooks/release-demo_0-28.py
+++ b/notebooks/release-demo_0-28.py
@@ -264,27 +264,28 @@ if isinstance(detections.mask, sv.CompactMask):
 # Annotators call `.to_dense()` internally -- CompactMask is invisible to them.
 
 # %%
-if isinstance(detections.mask, sv.CompactMask) and dense_bytes > 0:
-    annotated_compact = image_bgr.copy()
-    annotated_compact = sv.MaskAnnotator(color=PALETTE, opacity=0.45).annotate(
-        annotated_compact, large
-    )
-    annotated_compact = sv.BoxAnnotator(color=PALETTE, thickness=2).annotate(
-        annotated_compact, large
-    )
-    annotated_compact = sv.LabelAnnotator(
-        color=PALETTE, text_scale=0.5, text_thickness=1
-    ).annotate(annotated_compact, large, labels=large_labels)
+assert isinstance(detections.mask, sv.CompactMask) and dense_bytes > 0
 
-    plt.figure(figsize=(12, 7))
-    plt.imshow(cv2.cvtColor(annotated_compact, cv2.COLOR_BGR2RGB))
-    plt.axis("off")
-    plt.title(
-        f"CompactMask (filtered) -- {len(large)} instance(s)  "
-        f"| {dense_bytes / 1024:.0f} KB dense -> {crop_bytes / 1024:.0f} KB crops"
-    )
-    plt.tight_layout()
-    plt.show()
+annotated_compact = image_bgr.copy()
+annotated_compact = sv.MaskAnnotator(color=PALETTE, opacity=0.45).annotate(
+    annotated_compact, large
+)
+annotated_compact = sv.BoxAnnotator(color=PALETTE, thickness=2).annotate(
+    annotated_compact, large
+)
+annotated_compact = sv.LabelAnnotator(
+    color=PALETTE, text_scale=0.5, text_thickness=1
+).annotate(annotated_compact, large, labels=large_labels)
+
+plt.figure(figsize=(12, 7))
+plt.imshow(cv2.cvtColor(annotated_compact, cv2.COLOR_BGR2RGB))
+plt.axis("off")
+plt.title(
+    f"CompactMask (filtered) -- {len(large)} instance(s)  "
+    f"| {dense_bytes / 1024:.0f} KB dense -> {crop_bytes / 1024:.0f} KB crops"
+)
+plt.tight_layout()
+plt.show()
 
 # %% [markdown]
 # ### 4.5 Per-instance crop
@@ -293,26 +294,27 @@ if isinstance(detections.mask, sv.CompactMask) and dense_bytes > 0:
 # `(H_crop, W_crop)` bool array -- no full mask materialised.
 
 # %%
-if isinstance(detections.mask, sv.CompactMask) and len(detections) > 0:
-    crop = detections.mask.crop(0)
-    bbox = detections.mask.bbox_xyxy[0].astype(int)
+assert isinstance(detections.mask, sv.CompactMask) and len(detections) > 0
 
-    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
-    axes[0].imshow(image_rgb[bbox[1] : bbox[3], bbox[0] : bbox[2]])
-    axes[0].set_title("Image crop  (instance 0)")
-    axes[0].axis("off")
+crop = detections.mask.crop(0)
+bbox = detections.mask.bbox_xyxy[0].astype(int)
 
-    axes[1].imshow(crop, cmap="gray")
-    axes[1].set_title(f"Mask crop  ({crop.shape[1]} x {crop.shape[0]} px)")
-    axes[1].axis("off")
+fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+axes[0].imshow(image_rgb[bbox[1] : bbox[3], bbox[0] : bbox[2]])
+axes[0].set_title("Image crop  (instance 0)")
+axes[0].axis("off")
 
-    plt.tight_layout()
-    plt.show()
+axes[1].imshow(crop, cmap="gray")
+axes[1].set_title(f"Mask crop  ({crop.shape[1]} x {crop.shape[0]} px)")
+axes[1].axis("off")
 
-    full_px = H * W
-    crop_kb = crop.nbytes / 1024
-    print(f"Full-res mask slot: {H} x {W} = {full_px / 1024:.0f} KB")
-    print(f"Compact crop:       {crop.shape[0]} x {crop.shape[1]} = {crop_kb:.1f} KB")
+plt.tight_layout()
+plt.show()
+
+full_px = H * W
+crop_kb = crop.nbytes / 1024
+print(f"Full-res mask slot: {H} x {W} = {full_px / 1024:.0f} KB")
+print(f"Compact crop:       {crop.shape[0]} x {crop.shape[1]} = {crop_kb:.1f} KB")
 
 # %% [markdown]
 # ## 5. SAM3
@@ -326,6 +328,8 @@ if isinstance(detections.mask, sv.CompactMask) and len(detections) > 0:
 
 # %%
 import os
+import base64
+import requests
 from typing import Optional
 
 try:
@@ -338,63 +342,59 @@ except Exception:
 PROMPTS = ["person", "bag"]
 sam3_detections: Optional[sv.Detections] = None
 
-if ROBOFLOW_API_KEY:
-    import base64
+assert ROBOFLOW_API_KEY
 
-    import requests
+with open(image_path, "rb") as _f:
+    _img_b64 = base64.b64encode(_f.read()).decode("utf-8")
 
-    with open(image_path, "rb") as _f:
-        _img_b64 = base64.b64encode(_f.read()).decode("utf-8")
-
-    _response = requests.post(
-        f"https://api.roboflow.com/inferenceproxy/seg-preview?api_key={ROBOFLOW_API_KEY}",
-        json={
-            "image": {"type": "base64", "value": _img_b64},
-            "prompts": [{"type": "text", "text": p} for p in PROMPTS],
-            "output_prob_thresh": 0.3,
-        },
-        headers={"Content-Type": "application/json"},
-        timeout=60,
-    )
-    _response.raise_for_status()
-    sam3_result: dict[str, Any] = _response.json()
-    sam3_detections = sv.Detections.from_sam3(
-        sam3_result=sam3_result, resolution_wh=(W, H)
-    )
-    print(f"SAM3 detections: {len(sam3_detections)}")
-    if sam3_detections.class_id is not None:
-        for idx, prompt in enumerate(PROMPTS):
-            count = int((sam3_detections.class_id == idx).sum())
-            print(f"  [{idx}] '{prompt}': {count} instance(s)")
-else:
-    print("No ROBOFLOW_API_KEY -- skipping SAM3. Set the key to run this section.")
+_response = requests.post(
+    f"https://api.roboflow.com/inferenceproxy/seg-preview?api_key={ROBOFLOW_API_KEY}",
+    json={
+        "image": {"type": "base64", "value": _img_b64},
+        "prompts": [{"type": "text", "text": p} for p in PROMPTS],
+        "output_prob_thresh": 0.3,
+    },
+    headers={"Content-Type": "application/json"},
+    timeout=60,
+)
+_response.raise_for_status()
+sam3_result: dict[str, Any] = _response.json()
+sam3_detections = sv.Detections.from_sam3(
+    sam3_result=sam3_result, resolution_wh=(W, H)
+)
+print(f"SAM3 detections: {len(sam3_detections)}")
+if sam3_detections.class_id is not None:
+    for idx, prompt in enumerate(PROMPTS):
+        count = int((sam3_detections.class_id == idx).sum())
+        print(f"  [{idx}] '{prompt}': {count} instance(s)")
 
 # %%
-if sam3_detections is not None and len(sam3_detections) > 0:
-    sam3_labels = (
-        [PROMPTS[c] for c in sam3_detections.class_id]
-        if sam3_detections.class_id is not None
-        else []
-    )
-    SAM3_PALETTE = sv.ColorPalette.from_hex(["#ff6b6b", "#4ecdc4"])
+assert sam3_detections is not None and len(sam3_detections) > 0
 
-    annotated_sam3 = image_bgr.copy()
-    annotated_sam3 = sv.MaskAnnotator(color=SAM3_PALETTE, opacity=0.45).annotate(
-        annotated_sam3, sam3_detections
-    )
-    annotated_sam3 = sv.BoxAnnotator(color=SAM3_PALETTE, thickness=2).annotate(
-        annotated_sam3, sam3_detections
-    )
-    annotated_sam3 = sv.LabelAnnotator(
-        color=SAM3_PALETTE, text_scale=0.5, text_thickness=1
-    ).annotate(annotated_sam3, sam3_detections, labels=sam3_labels)
+sam3_labels = (
+    [PROMPTS[c] for c in sam3_detections.class_id]
+    if sam3_detections.class_id is not None
+    else []
+)
+SAM3_PALETTE = sv.ColorPalette.from_hex(["#ff6b6b", "#4ecdc4"])
 
-    plt.figure(figsize=(12, 7))
-    plt.imshow(cv2.cvtColor(annotated_sam3, cv2.COLOR_BGR2RGB))
-    plt.axis("off")
-    plt.title(f"SAM3 -- from_sam3() -- {len(sam3_detections)} instance(s)")
-    plt.tight_layout()
-    plt.show()
+annotated_sam3 = image_bgr.copy()
+annotated_sam3 = sv.MaskAnnotator(color=SAM3_PALETTE, opacity=0.45).annotate(
+    annotated_sam3, sam3_detections
+)
+annotated_sam3 = sv.BoxAnnotator(color=SAM3_PALETTE, thickness=2).annotate(
+    annotated_sam3, sam3_detections
+)
+annotated_sam3 = sv.LabelAnnotator(
+    color=SAM3_PALETTE, text_scale=0.5, text_thickness=1
+).annotate(annotated_sam3, sam3_detections, labels=sam3_labels)
+
+plt.figure(figsize=(12, 7))
+plt.imshow(cv2.cvtColor(annotated_sam3, cv2.COLOR_BGR2RGB))
+plt.axis("off")
+plt.title(f"SAM3 -- from_sam3() -- {len(sam3_detections)} instance(s)")
+plt.tight_layout()
+plt.show()
 
 # %% [markdown]
 # ## 6. Other notable changes in 0.28.0

--- a/notebooks/release-demo_0-28.py
+++ b/notebooks/release-demo_0-28.py
@@ -1,0 +1,452 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.1
+# ---
+# ruff: noqa: E402
+
+# %% [markdown]
+# # supervision 0.28.0: Memory-Efficient Instance Segmentation
+#
+# [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow/supervision/blob/develop/notebooks/release-demo_0-28.ipynb)
+#
+# **supervision** is a set of reusable tools for computer vision.
+# Two headlining changes in 0.28.0:
+#
+# 1. **`sv.Detections.from_sam3`** -- first-class support for SAM3 (Segment
+#    Anything Model 3) inference responses. supervision now parses both the
+#    PCS (prompt-controlled segmentation) and PVS (point-video segmentation)
+#    output formats directly into a `sv.Detections` object.
+#
+# 2. **`sv.CompactMask`** -- instance masks stored as RLE-encoded bounding-box
+#    crops instead of full-resolution bitmaps. Any segmentation model --
+#    RF-DETR Seg, SAM3, YOLO-Seg -- can feed into CompactMask. Memory drops
+#    10-100x without changing the API anywhere in supervision.
+#
+# **Story**: run RF-DETR Seg on a real image, visualise the masks, then convert
+# to CompactMask and watch the memory footprint collapse.
+#
+# **Sections:**
+# 1. [Install](#1-install)
+# 2. [Download sample image](#2-download-sample-image)
+# 3. [RF-DETR Seg -- instance segmentation](#3-rf-detr-seg)
+# 4. [CompactMask -- memory-efficient storage](#4-compactmask)
+# 5. [SAM3 -- text-prompted segmentation](#5-sam3)
+# 6. [Other notable changes in 0.28.0](#6-other-notable-changes)
+# 7. [Next steps](#7-next-steps)
+
+# %% [markdown]
+# ## 1. Install
+
+# %%
+# !pip install -q 'supervision==0.28.0' 'rfdetr' 'inference-sdk>=0.9' numpy matplotlib
+
+# %% [markdown]
+# ## 2. Download sample image
+#
+# `sv.ImageAssets` is new in 0.28.0 -- a counterpart to the existing
+# `sv.VideoAssets`. `download_assets` caches locally and returns the path.
+
+# %%
+# %matplotlib inline
+
+import cv2
+import matplotlib.pyplot as plt
+import numpy as np
+
+import supervision as sv
+from supervision.assets import ImageAssets, download_assets
+
+image_path = download_assets(ImageAssets.PEOPLE_WALKING)
+print(f"Image: {image_path}")
+
+image_bgr = cv2.imread(image_path)
+image_rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+H, W = image_bgr.shape[:2]
+print(f"Resolution: {W} x {H}")
+
+plt.figure(figsize=(12, 7))
+plt.imshow(image_rgb)
+plt.axis("off")
+plt.title("people-walking.jpg")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 3. RF-DETR Seg
+#
+# **RF-DETR** is a real-time transformer-based object detection model from Roboflow.
+# The `RFDETRSegSmall` variant adds an instance segmentation head -- it produces
+# one binary mask per detected instance alongside the bounding box.
+#
+# Key facts for this demo:
+#
+# - Pretrained on **COCO** (80 object categories) -- detects people, bags, cars, etc.
+# - Weights download automatically on first `RFDETRSegSmall()` call (~100 MB).
+# - `model.predict()` returns **`sv.Detections`** directly -- no converter needed.
+#   Masks are a `(N, H, W)` bool array attached as `detections.mask`.
+
+# %%
+from rfdetr.detr import RFDETRSegSmall
+
+model = RFDETRSegSmall()
+model.optimize_for_inference()
+
+# predict accepts a file path, PIL Image, or RGB numpy array
+detections = model.predict(image_path, threshold=0.3)
+if not isinstance(detections, sv.Detections):
+    raise TypeError(f"Expected sv.Detections, got {type(detections).__name__}")
+
+n_masks = 0 if detections.mask is None else len(detections.mask)
+print(f"Detections: {len(detections)}  (with masks: {n_masks})")
+
+# %% [markdown]
+# ### 3.1 COCO class names
+#
+# COCO has 90 numeric class IDs; map them to readable names for annotation.
+
+# %%
+# Subset of COCO class names (IDs 0-based after RF-DETR's remapping).
+COCO_NAMES: dict[int, str] = {
+    0: "person",
+    1: "bicycle",
+    2: "car",
+    3: "motorcycle",
+    4: "airplane",
+    5: "bus",
+    6: "train",
+    7: "truck",
+    8: "boat",
+    24: "backpack",
+    25: "umbrella",
+    26: "handbag",
+    28: "suitcase",
+    56: "chair",
+    57: "couch",
+    58: "potted plant",
+    59: "bed",
+    60: "dining table",
+    62: "tv",
+    63: "laptop",
+    67: "cell phone",
+    72: "refrigerator",
+    74: "clock",
+    76: "scissors",
+}
+
+labels = []
+if detections.class_id is not None:
+    for cid, conf in zip(
+        detections.class_id,
+        detections.confidence
+        if detections.confidence is not None
+        else [None] * len(detections),
+    ):
+        name = COCO_NAMES.get(int(cid), f"cls_{cid}")
+        labels.append(f"{name} {conf:.2f}" if conf is not None else name)
+
+# %% [markdown]
+# ### 3.2 Visualise RF-DETR Seg output
+
+# %%
+PALETTE = sv.ColorPalette.DEFAULT
+
+annotated = image_bgr.copy()
+annotated = sv.MaskAnnotator(color=PALETTE, opacity=0.45).annotate(
+    annotated, detections
+)
+annotated = sv.BoxAnnotator(color=PALETTE, thickness=2).annotate(annotated, detections)
+annotated = sv.LabelAnnotator(color=PALETTE, text_scale=0.5, text_thickness=1).annotate(
+    annotated, detections, labels=labels
+)
+
+plt.figure(figsize=(12, 7))
+plt.imshow(cv2.cvtColor(annotated, cv2.COLOR_BGR2RGB))
+plt.axis("off")
+plt.title(f"RF-DETR Seg -- {len(detections)} instance(s)")
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## 4. CompactMask
+#
+# RF-DETR Seg returns one full-resolution binary mask per detected instance.
+# On a 1280 x 720 image with 12 people that is:
+#
+# `12 x 720 x 1280 x 1 byte = 11 MB`
+#
+# Most of those pixels are background. The actual person silhouette fits in a
+# tight bounding box. `sv.CompactMask` stores **only the bounding-box crop**,
+# RLE-encoded:
+#
+# - A 200 x 100 person crop: `~2.5 KB` instead of `900 KB`
+# - Drop-in replacement -- all annotators, filters, and `area` keep working
+
+# %% [markdown]
+# ### 4.1 Measure dense mask footprint
+
+# %%
+from typing import Any
+
+dense_bytes: int = 0
+dense_mask: "np.ndarray[Any, np.dtype[np.bool_]] | None" = None
+
+if detections.mask is not None and isinstance(detections.mask, np.ndarray):
+    dense_mask = detections.mask
+    dense_bytes = dense_mask.nbytes
+    n_inst = len(dense_mask)
+    print(f"Instances:       {n_inst}")
+    print(f"Mask shape:      {dense_mask.shape}  (N x H x W, bool)")
+    print(f"Dense footprint: {dense_bytes / 1024:.1f} KB")
+    print(f"  = {n_inst} masks x {H} x {W} x 1 byte")
+
+# %% [markdown]
+# ### 4.2 Convert to CompactMask
+
+# %%
+compact: "sv.CompactMask | None" = None
+crop_bytes: int = 0
+
+if dense_mask is not None:
+    compact = sv.CompactMask.from_dense(
+        masks=dense_mask,
+        xyxy=detections.xyxy,
+        image_shape=(H, W),
+    )
+
+    # Measure compact size via uncompressed crop booleans (upper bound; RLE < this).
+    crop_bytes = sum(compact.crop(i).nbytes for i in range(len(compact)))
+
+    print(f"Crop size (est.):   {crop_bytes / 1024:.1f} KB  (uncompressed crops)")
+    if crop_bytes > 0 and dense_bytes > 0:
+        ratio = dense_bytes / crop_bytes
+        print(f"Reduction factor:   {ratio:.1f}x  (before RLE compression)")
+
+    # Swap in CompactMask -- supervision uses it transparently from here on.
+    detections.mask = compact
+    print(f"\ndetections.mask type: {type(detections.mask).__name__}")
+
+# %% [markdown]
+# ### 4.3 Filtering by mask area
+#
+# `compact.area` returns the true pixel count of each instance mask.
+# Filter out tiny detections (partial occlusions, image-edge artefacts).
+
+# %%
+large: sv.Detections = detections
+large_labels: list[str] = labels
+
+if isinstance(detections.mask, sv.CompactMask):
+    areas = detections.mask.area
+    print(
+        f"Mask areas (px): min={areas.min():.0f}  "
+        f"mean={areas.mean():.0f}  max={areas.max():.0f}"
+    )
+
+    # Keep instances larger than 0.1% of the image.
+    min_area = 0.001 * H * W
+    keep_idx = np.where(areas > min_area)[0]
+    _filtered = detections[keep_idx]
+    if isinstance(_filtered, sv.Detections):
+        large = _filtered
+        large_labels = [labels[i] for i in keep_idx] if labels else []
+    print(f"\nInstances > {min_area:.0f} px: {len(large)}")
+
+# %% [markdown]
+# ### 4.4 Annotate with CompactMask
+#
+# Annotators call `.to_dense()` internally -- CompactMask is invisible to them.
+
+# %%
+if isinstance(detections.mask, sv.CompactMask) and dense_bytes > 0:
+    annotated_compact = image_bgr.copy()
+    annotated_compact = sv.MaskAnnotator(color=PALETTE, opacity=0.45).annotate(
+        annotated_compact, large
+    )
+    annotated_compact = sv.BoxAnnotator(color=PALETTE, thickness=2).annotate(
+        annotated_compact, large
+    )
+    annotated_compact = sv.LabelAnnotator(
+        color=PALETTE, text_scale=0.5, text_thickness=1
+    ).annotate(annotated_compact, large, labels=large_labels)
+
+    plt.figure(figsize=(12, 7))
+    plt.imshow(cv2.cvtColor(annotated_compact, cv2.COLOR_BGR2RGB))
+    plt.axis("off")
+    plt.title(
+        f"CompactMask (filtered) -- {len(large)} instance(s)  "
+        f"| {dense_bytes / 1024:.0f} KB dense -> {crop_bytes / 1024:.0f} KB crops"
+    )
+    plt.tight_layout()
+    plt.show()
+
+# %% [markdown]
+# ### 4.5 Per-instance crop
+#
+# `compact.crop(i)` decodes only the bounding-box crop for instance `i` as a
+# `(H_crop, W_crop)` bool array -- no full mask materialised.
+
+# %%
+if isinstance(detections.mask, sv.CompactMask) and len(detections) > 0:
+    crop = detections.mask.crop(0)
+    bbox = detections.mask.bbox_xyxy[0].astype(int)
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+    axes[0].imshow(image_rgb[bbox[1] : bbox[3], bbox[0] : bbox[2]])
+    axes[0].set_title("Image crop  (instance 0)")
+    axes[0].axis("off")
+
+    axes[1].imshow(crop, cmap="gray")
+    axes[1].set_title(f"Mask crop  ({crop.shape[1]} x {crop.shape[0]} px)")
+    axes[1].axis("off")
+
+    plt.tight_layout()
+    plt.show()
+
+    full_px = H * W
+    crop_kb = crop.nbytes / 1024
+    print(f"Full-res mask slot: {H} x {W} = {full_px / 1024:.0f} KB")
+    print(f"Compact crop:       {crop.shape[0]} x {crop.shape[1]} = {crop_kb:.1f} KB")
+
+# %% [markdown]
+# ## 5. SAM3
+#
+# `sv.Detections.from_sam3()` is the other headline in 0.28.0.
+# SAM3 segments objects by free-text prompts -- `"person"`, `"bag"`, any phrase.
+# supervision parses both the PCS and PVS response formats into a standard
+# `sv.Detections`, with `class_id` set to the prompt index.
+#
+# This section runs only when `ROBOFLOW_API_KEY` is available.
+
+# %%
+import os
+from typing import Optional
+
+try:
+    from google.colab import userdata  # type: ignore[import, unused-ignore]
+
+    ROBOFLOW_API_KEY: str = userdata.get("ROBOFLOW_API_KEY") or ""
+except Exception:
+    ROBOFLOW_API_KEY = os.environ.get("ROBOFLOW_API_KEY", "")
+
+PROMPTS = ["person", "bag"]
+sam3_detections: Optional[sv.Detections] = None
+
+if ROBOFLOW_API_KEY:
+    import base64
+
+    import requests
+
+    with open(image_path, "rb") as _f:
+        _img_b64 = base64.b64encode(_f.read()).decode("utf-8")
+
+    _response = requests.post(
+        f"https://api.roboflow.com/inferenceproxy/seg-preview?api_key={ROBOFLOW_API_KEY}",
+        json={
+            "image": {"type": "base64", "value": _img_b64},
+            "prompts": [{"type": "text", "text": p} for p in PROMPTS],
+            "output_prob_thresh": 0.3,
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=60,
+    )
+    _response.raise_for_status()
+    sam3_result: dict[str, Any] = _response.json()
+    sam3_detections = sv.Detections.from_sam3(
+        sam3_result=sam3_result, resolution_wh=(W, H)
+    )
+    print(f"SAM3 detections: {len(sam3_detections)}")
+    if sam3_detections.class_id is not None:
+        for idx, prompt in enumerate(PROMPTS):
+            count = int((sam3_detections.class_id == idx).sum())
+            print(f"  [{idx}] '{prompt}': {count} instance(s)")
+else:
+    print("No ROBOFLOW_API_KEY -- skipping SAM3. Set the key to run this section.")
+
+# %%
+if sam3_detections is not None and len(sam3_detections) > 0:
+    sam3_labels = (
+        [PROMPTS[c] for c in sam3_detections.class_id]
+        if sam3_detections.class_id is not None
+        else []
+    )
+    SAM3_PALETTE = sv.ColorPalette.from_hex(["#ff6b6b", "#4ecdc4"])
+
+    annotated_sam3 = image_bgr.copy()
+    annotated_sam3 = sv.MaskAnnotator(color=SAM3_PALETTE, opacity=0.45).annotate(
+        annotated_sam3, sam3_detections
+    )
+    annotated_sam3 = sv.BoxAnnotator(color=SAM3_PALETTE, thickness=2).annotate(
+        annotated_sam3, sam3_detections
+    )
+    annotated_sam3 = sv.LabelAnnotator(
+        color=SAM3_PALETTE, text_scale=0.5, text_thickness=1
+    ).annotate(annotated_sam3, sam3_detections, labels=sam3_labels)
+
+    plt.figure(figsize=(12, 7))
+    plt.imshow(cv2.cvtColor(annotated_sam3, cv2.COLOR_BGR2RGB))
+    plt.axis("off")
+    plt.title(f"SAM3 -- from_sam3() -- {len(sam3_detections)} instance(s)")
+    plt.tight_layout()
+    plt.show()
+
+# %% [markdown]
+# ## 6. Other notable changes in 0.28.0
+#
+# ### `VideoInfo.fps` is now `float`
+#
+# NTSC frame rates (23.976, 29.97, 59.94) were silently truncated to `int`.
+# Wrap with `int()` at call sites that require an integer.
+
+# %%
+import collections
+
+from supervision.assets import VideoAssets
+
+video_path = download_assets(VideoAssets.PEOPLE_WALKING)
+info = sv.VideoInfo.from_video_path(video_path)
+
+print(f"fps: {info.fps}  ({type(info.fps).__name__})  -- was int before 0.28.0")
+
+fps_int = int(info.fps)
+buf: collections.deque[sv.Detections] = collections.deque(maxlen=fps_int)
+trace = sv.TraceAnnotator(trace_length=fps_int)
+print(f"deque maxlen: {buf.maxlen}  (= int({info.fps}))")
+
+# %% [markdown]
+# ### `sv.ByteTrack` deprecated
+#
+# `sv.ByteTrack` still works in 0.28.0 and 0.29.0 but emits a
+# `DeprecationWarning`. Migrate to `ByteTrackTracker` from the external
+# [`trackers`](https://pypi.org/project/trackers/) package before 0.30.0.
+#
+# ```python
+# # Before
+# tracker = sv.ByteTrack()
+# detections = tracker.update_with_detections(detections)
+#
+# # After (pip install trackers)
+# from trackers import ByteTrackTracker
+# tracker = ByteTrackTracker()
+# detections = tracker.update(detections)
+# ```
+
+# %% [markdown]
+# ## 7. Next steps
+#
+# - [`sv.CompactMask` docs](https://supervision.roboflow.com/develop/detection/compact_mask/)
+#   -- full API reference: `resize`, `merge`, `with_offset`
+# - [`sv.Detections.from_sam3` docs](https://supervision.roboflow.com/develop/detection/core/)
+#   -- PCS and PVS format reference
+# - [RF-DETR docs](https://github.com/roboflow/rf-detr)
+#   -- training, export, and deployment
+# - [Migration guide for 0.28.0](https://github.com/roboflow/supervision/blob/develop/releases/0.28.0/MIGRATION.md)
+#   -- before/after snippets for all breaking changes
+# - [Full changelog](https://supervision.roboflow.com/develop/changelog/)
+#   -- every change in 0.28.0

--- a/notebooks/release-demo_0-28.py
+++ b/notebooks/release-demo_0-28.py
@@ -327,10 +327,11 @@ print(f"Compact crop:       {crop.shape[0]} x {crop.shape[1]} = {crop_kb:.1f} KB
 # This section runs only when `ROBOFLOW_API_KEY` is available.
 
 # %%
-import os
 import base64
-import requests
+import os
 from typing import Optional
+
+import requests
 
 try:
     from google.colab import userdata  # type: ignore[import, unused-ignore]
@@ -359,9 +360,7 @@ _response = requests.post(
 )
 _response.raise_for_status()
 sam3_result: dict[str, Any] = _response.json()
-sam3_detections = sv.Detections.from_sam3(
-    sam3_result=sam3_result, resolution_wh=(W, H)
-)
+sam3_detections = sv.Detections.from_sam3(sam3_result=sam3_result, resolution_wh=(W, H))
 print(f"SAM3 detections: {len(sam3_detections)}")
 if sam3_detections.class_id is not None:
     for idx, prompt in enumerate(PROMPTS):

--- a/notebooks/release-demo_0-28.py
+++ b/notebooks/release-demo_0-28.py
@@ -141,15 +141,15 @@ COCO_NAMES: dict[int, str] = {
 }
 
 labels = []
-if detections.class_id is not None:
-    for cid, conf in zip(
-        detections.class_id,
-        detections.confidence
-        if detections.confidence is not None
-        else [None] * len(detections),
-    ):
-        name = COCO_NAMES.get(int(cid), f"cls_{cid}")
-        labels.append(f"{name} {conf:.2f}" if conf is not None else name)
+assert detections.class_id is not None
+for cid, conf in zip(
+    detections.class_id,
+    detections.confidence
+    if detections.confidence is not None
+    else [None] * len(detections),
+):
+    name = COCO_NAMES.get(int(cid), f"cls_{cid}")
+    labels.append(f"{name} {conf:.2f}" if conf is not None else name)
 
 # %% [markdown]
 # ### 3.2 Visualise RF-DETR Seg output
@@ -197,14 +197,15 @@ from typing import Any
 dense_bytes: int = 0
 dense_mask: "np.ndarray[Any, np.dtype[np.bool_]] | None" = None
 
-if detections.mask is not None and isinstance(detections.mask, np.ndarray):
-    dense_mask = detections.mask
-    dense_bytes = dense_mask.nbytes
-    n_inst = len(dense_mask)
-    print(f"Instances:       {n_inst}")
-    print(f"Mask shape:      {dense_mask.shape}  (N x H x W, bool)")
-    print(f"Dense footprint: {dense_bytes / 1024:.1f} KB")
-    print(f"  = {n_inst} masks x {H} x {W} x 1 byte")
+assert detections.mask is not None and isinstance(detections.mask, np.ndarray)
+
+dense_mask = detections.mask
+dense_bytes = dense_mask.nbytes
+n_inst = len(dense_mask)
+print(f"Instances:       {n_inst}")
+print(f"Mask shape:      {dense_mask.shape}  (N x H x W, bool)")
+print(f"Dense footprint: {dense_bytes / 1024:.1f} KB")
+print(f"  = {n_inst} masks x {H} x {W} x 1 byte")
 
 # %% [markdown]
 # ### 4.2 Convert to CompactMask
@@ -213,24 +214,24 @@ if detections.mask is not None and isinstance(detections.mask, np.ndarray):
 compact: "sv.CompactMask | None" = None
 crop_bytes: int = 0
 
-if dense_mask is not None:
-    compact = sv.CompactMask.from_dense(
-        masks=dense_mask,
-        xyxy=detections.xyxy,
-        image_shape=(H, W),
-    )
+assert dense_mask is not None
+compact = sv.CompactMask.from_dense(
+    masks=dense_mask,
+    xyxy=detections.xyxy,
+    image_shape=(H, W),
+)
 
-    # Measure compact size via uncompressed crop booleans (upper bound; RLE < this).
-    crop_bytes = sum(compact.crop(i).nbytes for i in range(len(compact)))
+# Measure compact size via uncompressed crop booleans (upper bound; RLE < this).
+crop_bytes = sum(compact.crop(i).nbytes for i in range(len(compact)))
 
-    print(f"Crop size (est.):   {crop_bytes / 1024:.1f} KB  (uncompressed crops)")
-    if crop_bytes > 0 and dense_bytes > 0:
-        ratio = dense_bytes / crop_bytes
-        print(f"Reduction factor:   {ratio:.1f}x  (before RLE compression)")
+print(f"Crop size (est.):   {crop_bytes / 1024:.1f} KB  (uncompressed crops)")
+if crop_bytes > 0 and dense_bytes > 0:
+    ratio = dense_bytes / crop_bytes
+    print(f"Reduction factor:   {ratio:.1f}x  (before RLE compression)")
 
-    # Swap in CompactMask -- supervision uses it transparently from here on.
-    detections.mask = compact
-    print(f"\ndetections.mask type: {type(detections.mask).__name__}")
+# Swap in CompactMask -- supervision uses it transparently from here on.
+detections.mask = compact
+print(f"\ndetections.mask type: {type(detections.mask).__name__}")
 
 # %% [markdown]
 # ### 4.3 Filtering by mask area
@@ -242,21 +243,21 @@ if dense_mask is not None:
 large: sv.Detections = detections
 large_labels: list[str] = labels
 
-if isinstance(detections.mask, sv.CompactMask):
-    areas = detections.mask.area
-    print(
-        f"Mask areas (px): min={areas.min():.0f}  "
-        f"mean={areas.mean():.0f}  max={areas.max():.0f}"
-    )
+assert isinstance(detections.mask, sv.CompactMask)
+areas = detections.mask.area
+print(
+    f"Mask areas (px): min={areas.min():.0f}  "
+    f"mean={areas.mean():.0f}  max={areas.max():.0f}"
+)
 
-    # Keep instances larger than 0.1% of the image.
-    min_area = 0.001 * H * W
-    keep_idx = np.where(areas > min_area)[0]
-    _filtered = detections[keep_idx]
-    if isinstance(_filtered, sv.Detections):
-        large = _filtered
-        large_labels = [labels[i] for i in keep_idx] if labels else []
-    print(f"\nInstances > {min_area:.0f} px: {len(large)}")
+# Keep instances larger than 0.1% of the image.
+min_area = 0.001 * H * W
+keep_idx = np.where(areas > min_area)[0]
+_filtered = detections[keep_idx]
+if isinstance(_filtered, sv.Detections):
+    large = _filtered
+    large_labels = [labels[i] for i in keep_idx] if labels else []
+print(f"\nInstances > {min_area:.0f} px: {len(large)}")
 
 # %% [markdown]
 # ### 4.4 Annotate with CompactMask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,10 @@ lint.select = [
 ]
 lint.ignore = []
 lint.per-file-ignores."__init__.py" = [ "E402", "F401" ]
+lint.per-file-ignores."notebooks/**" = [
+  "PT018", # Assertion should be broken down into multiple parts
+  "S101",  # Use of `assert` detected
+]
 lint.per-file-ignores."src/**" = [
   "S101", # TODO: Replace asserts with proper error handling
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=61" ]
 
 [project]
 name = "supervision"
-version = "0.28.0rc2"
+version = "0.28.0"
 description = "A set of easy-to-use utils that will come in handy in any Computer Vision project"
 readme = "README.md"
 keywords = [

--- a/src/supervision/detection/utils/boxes.py
+++ b/src/supervision/detection/utils/boxes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import numpy.typing as npt
+from deprecate import deprecated
 
 from supervision.detection.utils.iou_and_nms import box_iou_batch
 
@@ -95,10 +96,17 @@ def pad_boxes(
     return result
 
 
+@deprecated(  # type: ignore[untyped-decorator]
+    target=True,
+    deprecated_in="0.27.0",
+    remove_in="0.30.0",
+    args_mapping={"normalized_xyxy": "xyxy"},
+)
 def denormalize_boxes(
     xyxy: npt.NDArray[np.number],
     resolution_wh: tuple[int, int],
     normalization_factor: float = 1.0,
+    normalized_xyxy: npt.NDArray[np.number] | None = None,
 ) -> npt.NDArray[np.number]:
     """
     Convert normalized bounding box coordinates to absolute pixel coordinates.


### PR DESCRIPTION
# supervision 0.28.0

Release date: 2026-04-30

## 🔦 Spotlight

### Memory-efficient masks with `sv.CompactMask`

Segmentation models produce one full-resolution bitmap per instance. On a 1920×1080 image with 28 detections that is **~55 MB** of mask data. Most pixels are background. `sv.CompactMask` stores only the tight bounding-box crop, RLE-encoded — the same 28 masks drop to **~237 KB** of crops, a **240× reduction** before RLE kicks in.

It's a drop-in replacement: annotators, filters, and `area` all work unchanged.

<!-- IMAGE: demo frame showing RF-DETR Seg masks on people-walking.jpg (dense annotated) -->

<!-- IMAGE: memory bar chart — 55 MB dense vs 237 KB compact -->

```python
import supervision as sv

# any segmentation model — RF-DETR Seg, YOLO-Seg, SAM3
detections = model.predict(image)  # sv.Detections with dense masks

dense_mb = detections.mask.nbytes / 1024 / 1024
compact = sv.CompactMask.from_dense(
    masks=detections.mask,
    xyxy=detections.xyxy,
    image_shape=image.shape[:2],
)
detections.mask = compact  # swap in — API unchanged

# filter by pixel area without materialising dense masks
large = detections[compact.area > 1000]

# annotators call .to_dense() internally
annotated = sv.MaskAnnotator().annotate(image.copy(), detections)
```

---

### SAM3 text-prompted segmentation

SAM3 segments objects by free-text prompt — no class list, no bounding boxes. `sv.Detections.from_sam3()` parses both PCS (multi-prompt) and PVS (video) response formats into a standard `sv.Detections`, with `class_id` set to the prompt index.

<!-- IMAGE: SAM3 output on people-walking.jpg — person masks red, bag masks teal -->

```python
import requests, base64
import supervision as sv

PROMPTS = ["person", "bag"]

with open("image.jpg", "rb") as f:
    img_b64 = base64.b64encode(f.read()).decode()

response = requests.post(
    f"https://api.roboflow.com/inferenceproxy/seg-preview?api_key={API_KEY}",
    json={
        "image": {"type": "base64", "value": img_b64},
        "prompts": [{"type": "text", "text": p} for p in PROMPTS],
    },
    headers={"Content-Type": "application/json"},
)
sam3_result = response.json()

h, w = cv2.imread("image.jpg").shape[:2]
detections = sv.Detections.from_sam3(sam3_result=sam3_result, resolution_wh=(w, h))
# class_id == 0 → "person", class_id == 1 → "bag"
```

---

## 🔄 Migration

### `VideoInfo.fps` is now `float`

NTSC frame rates (23.976, 29.97, 59.94) were silently truncated. `fps` is now the true float — cast at call sites that need an integer.

<details>
<summary>Before</summary>

```python
info = sv.VideoInfo.from_video_path("clip.mp4")
buf = collections.deque(maxlen=info.fps)
trace = sv.TraceAnnotator(trace_length=info.fps)
```

</details>

<details>
<summary>After</summary>

```python
info = sv.VideoInfo.from_video_path("clip.mp4")
buf = collections.deque(maxlen=int(info.fps))
trace = sv.TraceAnnotator(trace_length=int(info.fps))
```

</details>

### `sv.ByteTrack` deprecated — use `ByteTrackTracker`

Tracker implementations now live in the dedicated `trackers` package. `sv.ByteTrack` remains available in 0.28–0.29 with `DeprecationWarning`; removal in 0.30.0.

<details>
<summary>Before</summary>

```python
tracker = sv.ByteTrack()
detections = tracker.update_with_detections(detections)
```

</details>

<details>
<summary>After</summary>

```python
# pip install trackers
from trackers import ByteTrackTracker

tracker = ByteTrackTracker()
detections = tracker.update(detections)
```

</details>

---

## 🚀 Added

- **Memory-efficient masks with `sv.CompactMask`.** Sparse segmentation masks are now stored as a crop region plus RLE-encoded data instead of full-resolution bitmaps, cutting memory use by 10–100× for typical instance-segmentation outputs. It's a drop-in change — `sv.Detections.mask`, filtering, merging, and `area` all keep working without materialising the full array. ([#2159](https://github.com/roboflow/supervision/pull/2159))

- **SAM3 detection and PVS support in `from_inference`.** [`sv.Detections.from_inference`](https://supervision.roboflow.com/latest/detection/core/#supervision.detection.core.Detections.from_inference) now parses SAM3 detection and point-video-segmentation outputs, both from the local `inference` package and from Roboflow-hosted server responses. ([#2103](https://github.com/roboflow/supervision/pull/2103), [#2152](https://github.com/roboflow/supervision/pull/2152))

- **Compressed COCO RLE masks in `from_inference`.** Inference responses with `rle` or `rle_mask` fields containing a compressed counts string (as produced by `pycocotools`) are decoded directly into binary masks, skipping the lossy polygon round-trip. ([#2178](https://github.com/roboflow/supervision/pull/2178))

- **Standard `logging` module instead of `print`.** Diagnostic output is now emitted under the `supervision` logger, so applications can capture, filter, or silence it through standard `logging` configuration. ([#2154](https://github.com/roboflow/supervision/pull/2154))

- **RGBA hex codes in `sv.Color`.** [`sv.Color.from_hex`](https://supervision.roboflow.com/latest/utils/draw/#supervision.draw.color.Color.from_hex) accepts 8-digit hex (`#ff00ff80`), and `Color.as_hex()` round-trips alpha when not fully opaque. New top-level helpers: `sv.hex_to_rgba`, `sv.rgba_to_hex`, and `sv.is_valid_hex`. ([#2004](https://github.com/roboflow/supervision/pull/2004))

- **Dynamic kernel sizing in blur and pixelate annotators.** `BlurAnnotator(kernel_size=None)` and `PixelateAnnotator(pixel_size=None)` (the new default) compute the kernel per detection as a fraction of the shorter bounding-box side, giving visually consistent results across object scales. ([#709](https://github.com/roboflow/supervision/pull/709))

- **`sv.ImageAssets` for sample images.** A counterpart to the existing video assets — downloads sample images for examples and tutorials. ([#932](https://github.com/roboflow/supervision/pull/932))

- **Boundary warnings in `InferenceSlicer`.** Emits a warning when callback detections fall outside tile boundaries, helping you spot coordinate-system bugs in custom callbacks early. ([#2186](https://github.com/roboflow/supervision/pull/2186))

## ⚠️ Breaking Changes

- **`sv.VideoInfo.fps` is now `float`, not `int`.** Frame rates like 23.976, 29.97, and 59.94 are no longer truncated. If you pass `fps` to APIs that require an integer (`deque(maxlen=...)`, `TraceAnnotator(trace_length=...)`), wrap with `int(...)`. ([#2210](https://github.com/roboflow/supervision/pull/2210))

- **`sv.rle_to_mask` returns `bool`, not `uint8`.** This matches the long-declared signature. Code that does `mask * 255` still works via NumPy broadcasting, but explicit casts like `mask.view(np.uint8)` will break. Add `.astype(np.uint8)` if you relied on the undocumented integer output. ([#2178](https://github.com/roboflow/supervision/pull/2178))

See the migration guide below for before/after snippets.

## 🌱 Changed

- **Metric arrays use `float32` instead of `float64`.** `sv.MeanAveragePrecisionResult` and related arrays (`mAP_scores`, `ap_per_class`, `iou_thresholds`, precision/recall) drop to `float32`, reducing memory and speeding up computation. Numerical results may differ in the last few digits. ([#2169](https://github.com/roboflow/supervision/pull/2169))

- **`rle_to_mask` and `mask_to_rle` moved.** New canonical path: `supervision.detection.utils.converters`. The old `supervision.dataset.utils` import still works but is deprecated. ([#2178](https://github.com/roboflow/supervision/pull/2178))

## 🗑️ Deprecated

- **`normalized_xyxy` argument renamed to `xyxy` in `denormalize_boxes`.** `sv.denormalize_boxes(normalized_xyxy=...)` still works but emits a `FutureWarning`; switch to `xyxy=`. Scheduled for removal in 0.30.0.

- **`sv.ByteTrack` → `ByteTrackTracker` (external `trackers` package).** Install with `pip install trackers`; the method renames from `update_with_detections()` to `update()`. Scheduled for removal in 0.30.0. ([#2215](https://github.com/roboflow/supervision/pull/2215))

- **`supervision.keypoint` → `supervision.key_points`.** Also deprecated: the `LMM` enum (use `VLM`), `from_lmm` (use `from_vlm`), `create_tiles` in `supervision.utils.image`, `ensure_cv2_image_for_processing` in `supervision.utils.conversion`, and the keypoint validators in `supervision.validators`. ([#2214](https://github.com/roboflow/supervision/pull/2214))

## 🔧 Fixed

- **`PolygonZone` no longer double-counts overlapping zones.** When two polygons contain the same anchor, each zone now reflects its own containment instead of every zone claiming the detection. ([#1991](https://github.com/roboflow/supervision/pull/1991))

- **`LineZone` respects class identity across reused tracker IDs.** Trackers that recycle `tracker_id` across classes no longer leak crossing state from one object to another. ([#1868](https://github.com/roboflow/supervision/pull/1868))

- **`process_video` raises immediately on callback errors.** Previously the exception was swallowed and the process hung until the writer was flushed. ([#2022](https://github.com/roboflow/supervision/pull/2022))

- **`DetectionDataset` populates `class_name`.** Loaded annotations now carry `data["class_name"]`, matching what model connectors produce. ([#2156](https://github.com/roboflow/supervision/pull/2156))

- **`ByteTrack` preserves externally assigned `tracker_id`.** No longer overwrites caller-assigned IDs on the first update. ([#1364](https://github.com/roboflow/supervision/pull/1364))

- **Confusion matrix double-counting fixed.** `evaluate_detection_batch` now correctly matches multiple predictions to the same target, so FP/FN counts match expectations. ([#1853](https://github.com/roboflow/supervision/pull/1853))

- **`MeanAverageRecall` mAR@K is now COCO-compliant.** Computed using top-K detections per image; previous values were inflated relative to `pycocotools`. ([#2136](https://github.com/roboflow/supervision/pull/2136))

- **`Detections.is_empty()` handles empty `tracker_id`.** Returns `True` for zero-row detections regardless of whether `tracker_id` is `None` or an empty array. ([#2209](https://github.com/roboflow/supervision/pull/2209))

- **`CSVSink` and `JSONSink` slice `custom_data` per row.** NumPy arrays, lists, and tuples whose length matches the detection count are now indexed per row, instead of being written whole for every detection. ([#2199](https://github.com/roboflow/supervision/pull/2199), [#2216](https://github.com/roboflow/supervision/pull/2216))

- **`TraceAnnotator` smooth mode handles stationary tracks.** Deduplicates anchor points and falls back to a raw polyline when `splprep` cannot fit fewer than 4 unique points. ([#2217](https://github.com/roboflow/supervision/pull/2217))

- **`load_coco_annotations` rejects path-traversal annotations.** Refuses `file_name` entries that escape the images directory via `../` or absolute paths. ([#2218](https://github.com/roboflow/supervision/pull/2218))

- **OBB datasets no longer blow up memory.** Loading oriented-bounding-box datasets stopped allocating full-image masks per box. ([#2187](https://github.com/roboflow/supervision/pull/2187))

- **`KeyPoints` boolean mask indexing fixed.** Uniform-count selection now works correctly when all instances share the same keypoint count. ([#2188](https://github.com/roboflow/supervision/pull/2188))

- **`DetectionDataset.as_coco()` preserves `area` and `iscrowd`.** No longer dropped silently in the round-trip. ([#2185](https://github.com/roboflow/supervision/pull/2185))

- **`force_mask=True` precision and COCO empty-polygon export.** Annotation conversion no longer loses precision, and COCO export tolerates empty polygons across formats. ([#1746](https://github.com/roboflow/supervision/pull/1746), [#1086](https://github.com/roboflow/supervision/pull/1086), [#265](https://github.com/roboflow/supervision/pull/265))

---

## 🏆 Contributors

A huge thank you to everyone who shipped this release:

- @Erol444 — SAM3 detection and PVS parsing
- @leeclemnet — compressed COCO RLE masks and `rle_to_mask` correctness
- @abritton2002 — `VideoInfo.fps` as float and `Detections.is_empty()` fix
- @shaun0927 ([LinkedIn](https://www.linkedin.com/in/junghwan-na-ba7228302/)) — sink slicing, trace annotator, COCO path-traversal hardening
- @happyhj ([LinkedIn](https://www.linkedin.com/in/heejaekm/)) — `class_name` in `DetectionDataset`
- @farukalamai ([LinkedIn](https://www.linkedin.com/in/farukalamai/)) — `CSVSink` NumPy slicing
- @stop1one ([LinkedIn](https://www.linkedin.com/in/stop1one/)) — COCO-compliant `MeanAverageRecall`
- @Adithi-Sreenath ([LinkedIn](https://www.linkedin.com/in/adithi-sreenath)) — `PolygonZone` overlap fix
- @JESUSROYETH — `LineZone` class-aware tracker IDs
- @realh4m — `process_video` error propagation
- @rolson24 ([LinkedIn](https://www.linkedin.com/in/raif-olson/)) — `ByteTrack` preserves external tracker IDs
- @panagiotamoraiti — confusion matrix correctness
- @Youho99, @kirilllzaitsev — COCO empty polygons and `force_masks` consistency
- @aza-ali — RGBA hex support in `sv.Color`
- @Clemens-E — dynamic kernel sizing for blur and pixelate annotators
- @NickHerrig ([LinkedIn](https://www.linkedin.com/in/nickherrig/)) — `sv.ImageAssets`
- @0xD4rky — `force_mask=True` precision fix
- @Borda ([LinkedIn](https://linkedin.com/in/jirka-borovec)) — `CompactMask`, metrics float32, deprecations

---

**Full changelog**: https://github.com/roboflow/supervision/compare/0.27.0...0.28.0
