### PR TITLE
fix: preserve audio stream in process_video

### DIFF
--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+import tempfile
 import threading
 import time
 from collections import deque
@@ -133,6 +137,63 @@ class VideoSink:
             self.__writer.release()
 
 
+def _mux_audio(source_path: str, video_path: str) -> None:
+    """Mux audio from `source_path` into `video_path` in-place using ffmpeg.
+
+    Args:
+        source_path: Path to the original video file containing the audio stream.
+        video_path: Path to the video-only file to be updated with audio.
+    """
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path is None:
+        logger.warning(
+            "ffmpeg not found on PATH. Audio will not be preserved. "
+            "Install ffmpeg to enable audio preservation."
+        )
+        return
+
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=os.path.splitext(video_path)[1])
+    os.close(tmp_fd)
+    try:
+        result = subprocess.run(  # noqa: S603
+            [
+                ffmpeg_path,
+                "-y",
+                "-i",
+                video_path,
+                "-i",
+                source_path,
+                "-c:v",
+                "copy",
+                "-c:a",
+                "copy",
+                "-map",
+                "0:v:0",
+                "-map",
+                "1:a:0",
+                "-shortest",
+                tmp_path,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "ffmpeg failed to mux audio (return code %d). "
+                "The output video will not have audio.",
+                result.returncode,
+            )
+            return
+        shutil.move(tmp_path, video_path)
+    except Exception as exc:
+        logger.warning(
+            "Audio muxing failed: %s. Output video will not have audio.", exc
+        )
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
 def _validate_and_setup_video(
     source_path: str, start: int, end: int | None, iterative_seek: bool = False
 ) -> tuple[cv2.VideoCapture, int, int]:
@@ -219,6 +280,7 @@ def process_video(
     writer_buffer: int = 32,
     show_progress: bool = False,
     progress_message: str = "Processing video",
+    preserve_audio: bool = False,
 ) -> None:
     """
     Process video frames asynchronously using a threaded pipeline.
@@ -252,6 +314,9 @@ def process_video(
         show_progress: Whether to display a tqdm progress bar during processing.
             Default is False.
         progress_message: Description shown in the progress bar.
+        preserve_audio: If True, copy the audio stream from `source_path` into
+            `target_path` after frame processing. Requires `ffmpeg` on PATH.
+            Default is False.
 
     Returns:
         None
@@ -271,6 +336,7 @@ def process_video(
             source_path="source.mp4",
             target_path="target.mp4",
             callback=callback,
+            preserve_audio=True,
         )
         ```
     """
@@ -367,6 +433,9 @@ def process_video(
             progress_bar.close()
             if exception_in_worker is not None:
                 raise exception_in_worker
+
+    if preserve_audio:
+        _mux_audio(source_path=source_path, video_path=target_path)
 
 
 class FPSMonitor:

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -325,8 +325,11 @@ def process_video(
             Default is False.
         progress_message: Description shown in the progress bar.
         preserve_audio: If True, copy the audio stream from `source_path` into
-            `target_path` after frame processing. Requires `ffmpeg` on PATH.
-            Default is False.
+            `target_path` after frame processing. Requires `ffmpeg` on PATH
+            (e.g. `apt install ffmpeg`, `brew install ffmpeg`). If ffmpeg is
+            not found or the mux step fails, a warning is logged and the output
+            video is saved without audio — no exception is raised. Audio is
+            truncated to match the processed video duration. Default is False.
 
     Returns:
         None

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -194,7 +194,7 @@ def _mux_audio(source_path: str, video_path: str) -> None:
                 f": {stderr_msg}" if stderr_msg else "",
             )
             return
-        shutil.move(tmp_path, video_path)
+        os.replace(tmp_path, video_path)
     except Exception as exc:
         logger.warning(
             "Audio muxing failed: %s. Output video will not have audio.", exc

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -163,6 +163,9 @@ def _mux_audio(source_path: str, video_path: str) -> None:
             [
                 ffmpeg_path,
                 "-y",
+                "-loglevel",
+                "error",
+                "-nostats",
                 "-i",
                 video_path,
                 "-i",
@@ -183,10 +186,12 @@ def _mux_audio(source_path: str, video_path: str) -> None:
             timeout=300,
         )
         if result.returncode != 0:
+            stderr_msg = result.stderr.decode(errors="replace").strip()
             logger.warning(
-                "ffmpeg failed to mux audio (return code %d). "
+                "ffmpeg failed to mux audio (return code %d)%s. "
                 "The output video will not have audio.",
                 result.returncode,
+                f": {stderr_msg}" if stderr_msg else "",
             )
             return
         shutil.move(tmp_path, video_path)

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -152,9 +152,13 @@ def _mux_audio(source_path: str, video_path: str) -> None:
         )
         return
 
-    tmp_fd, tmp_path = tempfile.mkstemp(suffix=os.path.splitext(video_path)[1])
-    os.close(tmp_fd)
+    tmp_path = None
     try:
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            suffix=os.path.splitext(video_path)[1],
+            dir=os.path.dirname(os.path.abspath(video_path)),
+        )
+        os.close(tmp_fd)
         result = subprocess.run(  # noqa: S603
             [
                 ffmpeg_path,
@@ -190,7 +194,7 @@ def _mux_audio(source_path: str, video_path: str) -> None:
             "Audio muxing failed: %s. Output video will not have audio.", exc
         )
     finally:
-        if os.path.exists(tmp_path):
+        if tmp_path is not None and os.path.exists(tmp_path):
             os.remove(tmp_path)
 
 

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -447,7 +447,13 @@ def process_video(
                 raise exception_in_worker
 
     if preserve_audio:
-        _mux_audio(source_path=source_path, video_path=target_path)
+        if writer_worker.is_alive():
+            logger.warning(
+                "Writer thread did not finish in time; skipping audio mux "
+                "to avoid reading an incomplete output file."
+            )
+        else:
+            _mux_audio(source_path=source_path, video_path=target_path)
 
 
 class FPSMonitor:

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -333,7 +333,6 @@ def process_video(
 
     Example:
         ```python
-        import cv2
         import supervision as sv
         from rfdetr import RFDETRMedium
 
@@ -342,7 +341,7 @@ def process_video(
         def callback(frame, frame_index):
             return model.predict(frame)
 
-        process_video(
+        sv.process_video(
             source_path="source.mp4",
             target_path="target.mp4",
             callback=callback,

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -174,7 +174,7 @@ def _mux_audio(source_path: str, video_path: str) -> None:
                 "-map",
                 "0:v:0",
                 "-map",
-                "1:a:0",
+                "1:a:0?",
                 "-shortest",
                 tmp_path,
             ],

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -180,6 +180,7 @@ def _mux_audio(source_path: str, video_path: str) -> None:
             ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
+            timeout=300,
         )
         if result.returncode != 0:
             logger.warning(

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -255,33 +255,32 @@ def test_process_video_no_audio_by_default(dummy_video_path, tmp_path):
 
 
 class TestMuxAudio:
-    def test_warns_when_ffmpeg_missing(self, dummy_video_path, tmp_path):
-        """_mux_audio leaves file unchanged and returns when ffmpeg not on PATH."""
-        target_path = str(tmp_path / "video_only.mp4")
+    @pytest.mark.parametrize(
+        ("which_rv", "run_kwargs"),
+        [
+            pytest.param(None, {}, id="ffmpeg_missing"),
+            pytest.param(
+                "/usr/bin/ffmpeg",
+                {"return_value": MagicMock(returncode=1, stderr=b"")},
+                id="ffmpeg_fails",
+            ),
+            pytest.param(
+                "/usr/bin/ffmpeg",
+                {"side_effect": OSError("mux failed")},
+                id="subprocess_raises",
+            ),
+        ],
+    )
+    def test_file_unchanged_on_failure(
+        self, dummy_video_path, tmp_path, which_rv, run_kwargs
+    ):
+        """_mux_audio leaves the output file unchanged when muxing cannot complete."""
+        target_path = str(tmp_path / "video.mp4")
         shutil.copy(dummy_video_path, target_path)
         original_size = os.path.getsize(target_path)
 
-        with patch("supervision.utils.video.shutil.which", return_value=None):
-            _mux_audio(source_path=dummy_video_path, video_path=target_path)
-
-        assert os.path.getsize(target_path) == original_size
-
-    def test_warns_on_ffmpeg_failure(self, dummy_video_path, tmp_path):
-        """_mux_audio leaves file unchanged and raises no exception on non-zero exit."""
-        target_path = str(tmp_path / "video_only.mp4")
-        shutil.copy(dummy_video_path, target_path)
-        original_size = os.path.getsize(target_path)
-
-        failed_result = MagicMock()
-        failed_result.returncode = 1
-        failed_result.stderr = b""
-
-        with patch(
-            "supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"
-        ):
-            with patch(
-                "supervision.utils.video.subprocess.run", return_value=failed_result
-            ):
+        with patch("supervision.utils.video.shutil.which", return_value=which_rv):
+            with patch("supervision.utils.video.subprocess.run", **run_kwargs):
                 _mux_audio(source_path=dummy_video_path, video_path=target_path)
 
         assert os.path.getsize(target_path) == original_size
@@ -306,23 +305,6 @@ class TestMuxAudio:
 
         mock_replace.assert_called_once()
         assert mock_replace.call_args[0][1] == target_path
-
-    def test_swallows_subprocess_exception(self, dummy_video_path, tmp_path):
-        """_mux_audio does not propagate OSError from subprocess.run to the caller."""
-        target_path = str(tmp_path / "video.mp4")
-        shutil.copy(dummy_video_path, target_path)
-        original_size = os.path.getsize(target_path)
-
-        with patch(
-            "supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"
-        ):
-            with patch(
-                "supervision.utils.video.subprocess.run",
-                side_effect=OSError("mux failed"),
-            ):
-                _mux_audio(source_path=dummy_video_path, video_path=target_path)
-
-        assert os.path.getsize(target_path) == original_size
 
 
 def test_get_video_frames_generator_with_start_end(dummy_video_path):

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -266,7 +266,7 @@ def test_mux_audio_warns_when_ffmpeg_missing(dummy_video_path, tmp_path):
     shutil.copy(dummy_video_path, target_path)
     original_size = os.path.getsize(target_path)
 
-    with patch("shutil.which", return_value=None):
+    with patch("supervision.utils.video.shutil.which", return_value=None):
         _mux_audio(source_path=dummy_video_path, video_path=target_path)
 
     assert os.path.getsize(target_path) == original_size
@@ -287,8 +287,10 @@ def test_mux_audio_warns_on_ffmpeg_failure(dummy_video_path, tmp_path):
     failed_result = MagicMock()
     failed_result.returncode = 1
 
-    with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
-        with patch("subprocess.run", return_value=failed_result):
+    with patch("supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"):
+        with patch(
+            "supervision.utils.video.subprocess.run", return_value=failed_result
+        ):
             _mux_audio(source_path=dummy_video_path, video_path=target_path)
 
     assert os.path.getsize(target_path) == original_size

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -254,57 +254,57 @@ def test_process_video_no_audio_by_default(dummy_video_path, tmp_path):
         mock_mux.assert_not_called()
 
 
-class TestMuxAudio:
-    @pytest.mark.parametrize(
-        ("which_rv", "run_kwargs"),
-        [
-            pytest.param(None, {}, id="ffmpeg_missing"),
-            pytest.param(
-                "/usr/bin/ffmpeg",
-                {"return_value": MagicMock(returncode=1, stderr=b"")},
-                id="ffmpeg_fails",
-            ),
-            pytest.param(
-                "/usr/bin/ffmpeg",
-                {"side_effect": OSError("mux failed")},
-                id="subprocess_raises",
-            ),
-        ],
-    )
-    def test_file_unchanged_on_failure(
-        self, dummy_video_path, tmp_path, which_rv, run_kwargs
+@pytest.mark.parametrize(
+    ("which_rv", "run_kwargs"),
+    [
+        pytest.param(None, {}, id="ffmpeg_missing"),
+        pytest.param(
+            "/usr/bin/ffmpeg",
+            {"return_value": MagicMock(returncode=1, stderr=b"")},
+            id="ffmpeg_fails",
+        ),
+        pytest.param(
+            "/usr/bin/ffmpeg",
+            {"side_effect": OSError("mux failed")},
+            id="subprocess_raises",
+        ),
+    ],
+)
+def test_mux_audio_file_unchanged_on_failure(
+    dummy_video_path, tmp_path, which_rv, run_kwargs
+):
+    """_mux_audio leaves the output file unchanged when muxing cannot complete."""
+    target_path = str(tmp_path / "video.mp4")
+    shutil.copy(dummy_video_path, target_path)
+    original_size = os.path.getsize(target_path)
+
+    with (
+        patch("supervision.utils.video.shutil.which", return_value=which_rv),
+        patch("supervision.utils.video.subprocess.run", **run_kwargs),
     ):
-        """_mux_audio leaves the output file unchanged when muxing cannot complete."""
-        target_path = str(tmp_path / "video.mp4")
-        shutil.copy(dummy_video_path, target_path)
-        original_size = os.path.getsize(target_path)
+        _mux_audio(source_path=dummy_video_path, video_path=target_path)
 
-        with patch("supervision.utils.video.shutil.which", return_value=which_rv):
-            with patch("supervision.utils.video.subprocess.run", **run_kwargs):
-                _mux_audio(source_path=dummy_video_path, video_path=target_path)
+    assert os.path.getsize(target_path) == original_size
 
-        assert os.path.getsize(target_path) == original_size
 
-    def test_replaces_file_on_success(self, dummy_video_path, tmp_path):
-        """_mux_audio calls os.replace with video_path as destination on success."""
-        target_path = str(tmp_path / "video.mp4")
-        shutil.copy(dummy_video_path, target_path)
+def test_mux_audio_replaces_file_on_success(dummy_video_path, tmp_path):
+    """_mux_audio calls os.replace with video_path as destination on success."""
+    target_path = str(tmp_path / "video.mp4")
+    shutil.copy(dummy_video_path, target_path)
 
-        success_result = MagicMock()
-        success_result.returncode = 0
-        success_result.stderr = b""
+    success_result = MagicMock()
+    success_result.returncode = 0
+    success_result.stderr = b""
 
-        with patch(
-            "supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"
-        ):
-            with patch(
-                "supervision.utils.video.subprocess.run", return_value=success_result
-            ):
-                with patch("supervision.utils.video.os.replace") as mock_replace:
-                    _mux_audio(source_path=dummy_video_path, video_path=target_path)
+    with (
+        patch("supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"),
+        patch("supervision.utils.video.subprocess.run", return_value=success_result),
+        patch("supervision.utils.video.os.replace") as mock_replace,
+    ):
+        _mux_audio(source_path=dummy_video_path, video_path=target_path)
 
-        mock_replace.assert_called_once()
-        assert mock_replace.call_args[0][1] == target_path
+    mock_replace.assert_called_once()
+    assert mock_replace.call_args[0][1] == target_path
 
 
 def test_get_video_frames_generator_with_start_end(dummy_video_path):

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -254,92 +254,75 @@ def test_process_video_no_audio_by_default(dummy_video_path, tmp_path):
         mock_mux.assert_not_called()
 
 
-def test_mux_audio_warns_when_ffmpeg_missing(dummy_video_path, tmp_path):
-    """
-    Verify that _mux_audio logs a warning and returns without error when ffmpeg absent.
+class TestMuxAudio:
+    def test_warns_when_ffmpeg_missing(self, dummy_video_path, tmp_path):
+        """_mux_audio leaves file unchanged and returns when ffmpeg not on PATH."""
+        target_path = str(tmp_path / "video_only.mp4")
+        shutil.copy(dummy_video_path, target_path)
+        original_size = os.path.getsize(target_path)
 
-    Scenario: ffmpeg is not available on PATH.
-    Expected: A warning is logged and the target video file is left unchanged,
-    so the caller still gets a valid (audio-less) output rather than a crash.
-    """
-    target_path = str(tmp_path / "video_only.mp4")
-    shutil.copy(dummy_video_path, target_path)
-    original_size = os.path.getsize(target_path)
-
-    with patch("supervision.utils.video.shutil.which", return_value=None):
-        _mux_audio(source_path=dummy_video_path, video_path=target_path)
-
-    assert os.path.getsize(target_path) == original_size
-
-
-def test_mux_audio_warns_on_ffmpeg_failure(dummy_video_path, tmp_path):
-    """
-    Verify that _mux_audio logs a warning and leaves the file intact when ffmpeg fails.
-
-    Scenario: ffmpeg is present but exits with a non-zero return code.
-    Expected: The original video-only file is preserved and no exception is raised,
-    so a transient ffmpeg error does not crash the caller's pipeline.
-    """
-    target_path = str(tmp_path / "video_only.mp4")
-    shutil.copy(dummy_video_path, target_path)
-    original_size = os.path.getsize(target_path)
-
-    failed_result = MagicMock()
-    failed_result.returncode = 1
-    failed_result.stderr = b""
-
-    with patch("supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"):
-        with patch(
-            "supervision.utils.video.subprocess.run", return_value=failed_result
-        ):
+        with patch("supervision.utils.video.shutil.which", return_value=None):
             _mux_audio(source_path=dummy_video_path, video_path=target_path)
 
-    assert os.path.getsize(target_path) == original_size
+        assert os.path.getsize(target_path) == original_size
 
+    def test_warns_on_ffmpeg_failure(self, dummy_video_path, tmp_path):
+        """_mux_audio leaves file unchanged and raises no exception on non-zero exit."""
+        target_path = str(tmp_path / "video_only.mp4")
+        shutil.copy(dummy_video_path, target_path)
+        original_size = os.path.getsize(target_path)
 
-def test_mux_audio_moves_file_on_success(dummy_video_path, tmp_path):
-    """Verify that _mux_audio replaces video_path via os.replace when ffmpeg succeeds.
+        failed_result = MagicMock()
+        failed_result.returncode = 1
+        failed_result.stderr = b""
 
-    Scenario: ffmpeg is present and exits with return code 0.
-    Expected: os.replace is called once with video_path as the destination,
-    confirming the muxed output atomically replaces the original video-only file.
-    """
-    target_path = str(tmp_path / "video.mp4")
-    shutil.copy(dummy_video_path, target_path)
-
-    success_result = MagicMock()
-    success_result.returncode = 0
-    success_result.stderr = b""
-
-    with patch("supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"):
         with patch(
-            "supervision.utils.video.subprocess.run", return_value=success_result
+            "supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"
         ):
-            with patch("supervision.utils.video.os.replace") as mock_replace:
+            with patch(
+                "supervision.utils.video.subprocess.run", return_value=failed_result
+            ):
                 _mux_audio(source_path=dummy_video_path, video_path=target_path)
 
-    mock_replace.assert_called_once()
-    assert mock_replace.call_args[0][1] == target_path
+        assert os.path.getsize(target_path) == original_size
 
+    def test_replaces_file_on_success(self, dummy_video_path, tmp_path):
+        """_mux_audio calls os.replace with video_path as destination on success."""
+        target_path = str(tmp_path / "video.mp4")
+        shutil.copy(dummy_video_path, target_path)
 
-def test_mux_audio_swallows_subprocess_exception(dummy_video_path, tmp_path):
-    """Verify that _mux_audio does not propagate subprocess errors to the caller.
+        success_result = MagicMock()
+        success_result.returncode = 0
+        success_result.stderr = b""
 
-    Scenario: subprocess.run raises OSError after ffmpeg is found on PATH.
-    Expected: No exception escapes _mux_audio; the original video file is unchanged.
-    """
-    target_path = str(tmp_path / "video.mp4")
-    shutil.copy(dummy_video_path, target_path)
-    original_size = os.path.getsize(target_path)
-
-    with patch("supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"):
         with patch(
-            "supervision.utils.video.subprocess.run",
-            side_effect=OSError("mux failed"),
+            "supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"
         ):
-            _mux_audio(source_path=dummy_video_path, video_path=target_path)
+            with patch(
+                "supervision.utils.video.subprocess.run", return_value=success_result
+            ):
+                with patch("supervision.utils.video.os.replace") as mock_replace:
+                    _mux_audio(source_path=dummy_video_path, video_path=target_path)
 
-    assert os.path.getsize(target_path) == original_size
+        mock_replace.assert_called_once()
+        assert mock_replace.call_args[0][1] == target_path
+
+    def test_swallows_subprocess_exception(self, dummy_video_path, tmp_path):
+        """_mux_audio does not propagate OSError from subprocess.run to the caller."""
+        target_path = str(tmp_path / "video.mp4")
+        shutil.copy(dummy_video_path, target_path)
+        original_size = os.path.getsize(target_path)
+
+        with patch(
+            "supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"
+        ):
+            with patch(
+                "supervision.utils.video.subprocess.run",
+                side_effect=OSError("mux failed"),
+            ):
+                _mux_audio(source_path=dummy_video_path, video_path=target_path)
+
+        assert os.path.getsize(target_path) == original_size
 
 
 def test_get_video_frames_generator_with_start_end(dummy_video_path):

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -298,11 +298,11 @@ def test_mux_audio_warns_on_ffmpeg_failure(dummy_video_path, tmp_path):
 
 
 def test_mux_audio_moves_file_on_success(dummy_video_path, tmp_path):
-    """Verify that _mux_audio replaces video_path via shutil.move when ffmpeg succeeds.
+    """Verify that _mux_audio replaces video_path via os.replace when ffmpeg succeeds.
 
     Scenario: ffmpeg is present and exits with return code 0.
-    Expected: shutil.move is called once with video_path as the destination,
-    confirming the muxed output replaces the original video-only file.
+    Expected: os.replace is called once with video_path as the destination,
+    confirming the muxed output atomically replaces the original video-only file.
     """
     target_path = str(tmp_path / "video.mp4")
     shutil.copy(dummy_video_path, target_path)
@@ -315,11 +315,11 @@ def test_mux_audio_moves_file_on_success(dummy_video_path, tmp_path):
         with patch(
             "supervision.utils.video.subprocess.run", return_value=success_result
         ):
-            with patch("supervision.utils.video.shutil.move") as mock_move:
+            with patch("supervision.utils.video.os.replace") as mock_replace:
                 _mux_audio(source_path=dummy_video_path, video_path=target_path)
 
-    mock_move.assert_called_once()
-    assert mock_move.call_args[0][1] == target_path
+    mock_replace.assert_called_once()
+    assert mock_replace.call_args[0][1] == target_path
 
 
 def test_mux_audio_swallows_subprocess_exception(dummy_video_path, tmp_path):

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -1,10 +1,17 @@
 import os
+import shutil
+from unittest.mock import MagicMock, patch
 
 import cv2
 import numpy as np
 import pytest
 
-from supervision.utils.video import VideoInfo, get_video_frames_generator, process_video
+from supervision.utils.video import (
+    VideoInfo,
+    _mux_audio,
+    get_video_frames_generator,
+    process_video,
+)
 
 
 @pytest.fixture
@@ -204,6 +211,87 @@ def test_get_video_frames_generator_with_stride(dummy_video_path):
     generator = get_video_frames_generator(dummy_video_path, stride=2)
     frames = list(generator)
     assert len(frames) == 5
+
+
+def test_process_video_preserve_audio_calls_mux(dummy_video_path, tmp_path):
+    """
+    Verify that process_video calls _mux_audio when preserve_audio=True.
+
+    Scenario: Processing a video with preserve_audio=True and ffmpeg available.
+    Expected: _mux_audio is called exactly once with the correct source and target
+    paths, confirming the audio muxing step is triggered after frame writing completes.
+    """
+    target_path = str(tmp_path / "target_audio.mp4")
+
+    with patch("supervision.utils.video._mux_audio") as mock_mux:
+        process_video(
+            source_path=dummy_video_path,
+            target_path=target_path,
+            callback=lambda frame, idx: frame,
+            preserve_audio=True,
+        )
+        mock_mux.assert_called_once_with(
+            source_path=dummy_video_path, video_path=target_path
+        )
+
+
+def test_process_video_no_audio_by_default(dummy_video_path, tmp_path):
+    """
+    Verify that process_video does not call _mux_audio when preserve_audio=False.
+
+    Scenario: Default process_video call without setting preserve_audio.
+    Expected: _mux_audio is never called, preserving existing behavior for callers
+    that do not need audio.
+    """
+    target_path = str(tmp_path / "target_no_audio.mp4")
+
+    with patch("supervision.utils.video._mux_audio") as mock_mux:
+        process_video(
+            source_path=dummy_video_path,
+            target_path=target_path,
+            callback=lambda frame, idx: frame,
+        )
+        mock_mux.assert_not_called()
+
+
+def test_mux_audio_warns_when_ffmpeg_missing(dummy_video_path, tmp_path):
+    """
+    Verify that _mux_audio logs a warning and returns without error when ffmpeg absent.
+
+    Scenario: ffmpeg is not available on PATH.
+    Expected: A warning is logged and the target video file is left unchanged,
+    so the caller still gets a valid (audio-less) output rather than a crash.
+    """
+    target_path = str(tmp_path / "video_only.mp4")
+    shutil.copy(dummy_video_path, target_path)
+    original_size = os.path.getsize(target_path)
+
+    with patch("shutil.which", return_value=None):
+        _mux_audio(source_path=dummy_video_path, video_path=target_path)
+
+    assert os.path.getsize(target_path) == original_size
+
+
+def test_mux_audio_warns_on_ffmpeg_failure(dummy_video_path, tmp_path):
+    """
+    Verify that _mux_audio logs a warning and leaves the file intact when ffmpeg fails.
+
+    Scenario: ffmpeg is present but exits with a non-zero return code.
+    Expected: The original video-only file is preserved and no exception is raised,
+    so a transient ffmpeg error does not crash the caller's pipeline.
+    """
+    target_path = str(tmp_path / "video_only.mp4")
+    shutil.copy(dummy_video_path, target_path)
+    original_size = os.path.getsize(target_path)
+
+    failed_result = MagicMock()
+    failed_result.returncode = 1
+
+    with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+        with patch("subprocess.run", return_value=failed_result):
+            _mux_audio(source_path=dummy_video_path, video_path=target_path)
+
+    assert os.path.getsize(target_path) == original_size
 
 
 def test_get_video_frames_generator_with_start_end(dummy_video_path):

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -286,10 +286,56 @@ def test_mux_audio_warns_on_ffmpeg_failure(dummy_video_path, tmp_path):
 
     failed_result = MagicMock()
     failed_result.returncode = 1
+    failed_result.stderr = b""
 
     with patch("supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"):
         with patch(
             "supervision.utils.video.subprocess.run", return_value=failed_result
+        ):
+            _mux_audio(source_path=dummy_video_path, video_path=target_path)
+
+    assert os.path.getsize(target_path) == original_size
+
+
+def test_mux_audio_moves_file_on_success(dummy_video_path, tmp_path):
+    """Verify that _mux_audio replaces video_path via shutil.move when ffmpeg succeeds.
+
+    Scenario: ffmpeg is present and exits with return code 0.
+    Expected: shutil.move is called once with video_path as the destination,
+    confirming the muxed output replaces the original video-only file.
+    """
+    target_path = str(tmp_path / "video.mp4")
+    shutil.copy(dummy_video_path, target_path)
+
+    success_result = MagicMock()
+    success_result.returncode = 0
+    success_result.stderr = b""
+
+    with patch("supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"):
+        with patch(
+            "supervision.utils.video.subprocess.run", return_value=success_result
+        ):
+            with patch("supervision.utils.video.shutil.move") as mock_move:
+                _mux_audio(source_path=dummy_video_path, video_path=target_path)
+
+    mock_move.assert_called_once()
+    assert mock_move.call_args[0][1] == target_path
+
+
+def test_mux_audio_swallows_subprocess_exception(dummy_video_path, tmp_path):
+    """Verify that _mux_audio does not propagate subprocess errors to the caller.
+
+    Scenario: subprocess.run raises OSError after ffmpeg is found on PATH.
+    Expected: No exception escapes _mux_audio; the original video file is unchanged.
+    """
+    target_path = str(tmp_path / "video.mp4")
+    shutil.copy(dummy_video_path, target_path)
+    original_size = os.path.getsize(target_path)
+
+    with patch("supervision.utils.video.shutil.which", return_value="/usr/bin/ffmpeg"):
+        with patch(
+            "supervision.utils.video.subprocess.run",
+            side_effect=OSError("mux failed"),
         ):
             _mux_audio(source_path=dummy_video_path, video_path=target_path)
 


### PR DESCRIPTION
## Summary

Fixes #1923.

`process_video` writes frames via OpenCV which discards the audio track. This adds a `preserve_audio` parameter (default `False`) that copies the audio stream from `source_path` into `target_path` after frame processing using `ffmpeg`.

- `preserve_audio=False` (default): existing behavior unchanged, no ffmpeg dependency
- `preserve_audio=True`: calls `ffmpeg` to mux audio in-place; warns and skips gracefully if ffmpeg is absent or fails

## Changes

- `src/supervision/utils/video.py`: add `_mux_audio` helper and `preserve_audio` param to `process_video`
- `tests/utils/test_video.py`: 4 new tests covering the mux call, default behavior, missing ffmpeg, and ffmpeg failure

## Test plan

- [ ] `uv run pytest tests/utils/test_video.py -v` - all 14 tests pass
- [ ] `uv run pre-commit run --files src/supervision/utils/video.py tests/utils/test_video.py` - all hooks pass
- [ ] Manual test with a video that has audio: `process_video(..., preserve_audio=True)` output retains audio track