### PR TITLE
ci(docs): skip RC tags, strip .postX, fix latest alias deploy

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mike deploy --push latest
+          mike deploy --push -u latest
 
       - name: 🚀 Deploy Release Docs
         if: github.event_name == 'release' && github.event.action == 'published'
@@ -70,6 +70,13 @@ jobs:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |
           release_tag="${GITHUB_REF_NAME#v}"
+          # Skip RC releases
+          if [[ "$release_tag" == *rc* ]] || [[ "$release_tag" == *RC* ]]; then
+            echo "Skipping RC release: $release_tag"
+            exit 0
+          fi
+          # Strip .postX suffix
+          release_tag="${release_tag%.post*}"
           mike deploy --push "$release_tag"
 
       # IndexNow key: 0d5d9799b1cc4a39825146388c6781eb

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mike deploy --push -u latest
+          mike deploy --push latest
 
       - name: 🏷️ Determine release deployment metadata
         id: release_metadata

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -71,10 +71,10 @@ jobs:
           release_tag=""
           if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
             release_tag="${GITHUB_REF_NAME#v}"
-            if [[ "$release_tag" == *[Rr][Cc]* ]]; then
+            release_tag="${release_tag%.post*}"
+            release_tag_lower="${release_tag,,}"
+            if [[ "$release_tag_lower" =~ (^|[._-])rc[0-9]+$ ]] || [[ "$release_tag_lower" =~ [0-9]rc[0-9]+$ ]]; then
               is_rc=true
-            else
-              release_tag="${release_tag%.post*}"
             fi
           fi
           echo "is_rc=$is_rc" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -73,6 +73,7 @@ jobs:
             release_tag="${GITHUB_REF_NAME#v}"
             release_tag="${release_tag%.post*}"
             release_tag_lower="${release_tag,,}"
+            # Match RC suffixes like 1.0rc1, 1.0-rc1, or 1.0.rc1.
             if [[ "$release_tag_lower" =~ (^|[._-])rc[0-9]+$ ]] || [[ "$release_tag_lower" =~ [0-9]rc[0-9]+$ ]]; then
               is_rc=true
             fi
@@ -100,7 +101,7 @@ jobs:
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref == 'refs/heads/release/latest') ||
           (github.event_name == 'release' && github.event.action == 'published' &&
-          steps.release_metadata.outputs.is_rc != 'true')
+            steps.release_metadata.outputs.is_rc != 'true')
         run: |
           cp docs/robots.txt /tmp/robots.txt
           cp docs/llms.txt /tmp/llms.txt

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -73,7 +73,7 @@ jobs:
             release_tag="${GITHUB_REF_NAME#v}"
             release_tag="${release_tag%.post*}"
             release_tag_lower="${release_tag,,}"
-            # Match RC suffixes like 1.0rc1, 1.0-rc1, or 1.0.rc1.
+            # Match RC suffixes with separators (1.0-rc1, 1.0.rc1) or compact form (1.0rc1).
             if [[ "$release_tag_lower" =~ (^|[._-])rc[0-9]+$ ]] || [[ "$release_tag_lower" =~ [0-9]rc[0-9]+$ ]]; then
               is_rc=true
             fi
@@ -100,8 +100,7 @@ jobs:
           (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref == 'refs/heads/release/latest') ||
-          (github.event_name == 'release' && github.event.action == 'published' &&
-            steps.release_metadata.outputs.is_rc != 'true')
+          (github.event_name == 'release' && github.event.action == 'published' && steps.release_metadata.outputs.is_rc != 'true')
         run: |
           cp docs/robots.txt /tmp/robots.txt
           cp docs/llms.txt /tmp/llms.txt

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -64,20 +64,28 @@ jobs:
         run: |
           mike deploy --push -u latest
 
+      - name: 🏷️ Determine release deployment metadata
+        id: release_metadata
+        run: |
+          is_rc=false
+          release_tag=""
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            release_tag="${GITHUB_REF_NAME#v}"
+            if [[ "$release_tag" == *[Rr][Cc]* ]]; then
+              is_rc=true
+            else
+              release_tag="${release_tag%.post*}"
+            fi
+          fi
+          echo "is_rc=$is_rc" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+
       - name: 🚀 Deploy Release Docs
-        if: github.event_name == 'release' && github.event.action == 'published'
+        if: github.event_name == 'release' && github.event.action == 'published' && steps.release_metadata.outputs.is_rc != 'true'
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          release_tag="${GITHUB_REF_NAME#v}"
-          # Skip RC releases
-          if [[ "$release_tag" == *rc* ]] || [[ "$release_tag" == *RC* ]]; then
-            echo "Skipping RC release: $release_tag"
-            exit 0
-          fi
-          # Strip .postX suffix
-          release_tag="${release_tag%.post*}"
-          mike deploy --push "$release_tag"
+          mike deploy --push "${{ steps.release_metadata.outputs.release_tag }}"
 
       # IndexNow key: 0d5d9799b1cc4a39825146388c6781eb
       # This key must stay in sync across three files:
@@ -91,7 +99,8 @@ jobs:
           (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'push' && github.ref == 'refs/heads/release/latest') ||
-          (github.event_name == 'release' && github.event.action == 'published')
+          (github.event_name == 'release' && github.event.action == 'published' &&
+          steps.release_metadata.outputs.is_rc != 'true')
         run: |
           cp docs/robots.txt /tmp/robots.txt
           cp docs/llms.txt /tmp/llms.txt


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to improve how documentation is published for both the latest and release versions. The most notable changes are the addition of user attribution when deploying the latest docs and enhanced handling for release candidate (RC) and post-release tags.

**Documentation deployment improvements:**

* Added the `-u` flag to the `mike deploy` command for the latest docs to include user attribution when pushing documentation updates.
* Updated the release deployment step to skip publishing documentation for release candidate (RC) versions and to strip any `.postX` suffix from release tags before deploying, ensuring only final releases are published and tagged correctly.

---

- Skip mike deploy for RC releases (tags containing rc/RC)
- Strip .postX suffix before deploying (0.27.0.post1 → 0.27.0)
- Add -u flag to latest deploy to handle existing alias