### PR TITLE
ci(tests): disable matplotlib GUI and exclude non-test dirs from collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ ini_options.addopts = [
   "--color=yes",
 ]
 ini_options.doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"
+ini_options.norecursedirs = [ "examples", "docs", "notebooks", ".venv", ".git", "dist", "build" ]
 
 [tool.autoflake]
 check = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
+import matplotlib
 import numpy as np
 import pytest
+
+matplotlib.use("Agg")
 
 import supervision as sv
 from tests.helpers import _create_key_points

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ import pytest
 
 matplotlib.use("Agg")
 
-import supervision as sv
-from tests.helpers import _create_key_points
+import supervision as sv  # noqa: E402
+from tests.helpers import _create_key_points  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ import pytest
 
 matplotlib.use("Agg")
 
-import supervision as sv  # noqa: E402
-from tests.helpers import _create_key_points  # noqa: E402
+import supervision as sv
+from tests.helpers import _create_key_points
 
 
 @pytest.fixture


### PR DESCRIPTION
This pull request introduces improvements to the testing configuration to ensure more reliable and isolated test runs. The main changes are:

Testing environment configuration:

* Set the Matplotlib backend to `"Agg"` in `tests/conftest.py` to prevent GUI windows from opening during tests and to ensure compatibility with headless environments.
* Added `norecursedirs` to the pytest configuration in `pyproject.toml` to exclude directories like `examples`, `docs`, `notebooks`, `.venv`, `.git`, `dist`, and `build` from test discovery, reducing noise and improving test performance.