### PR TITLE
docs(examples): fix outdated CLI flag names in `heatmap_and_track` README

### DIFF
--- a/examples/heatmap_and_track/README.md
+++ b/examples/heatmap_and_track/README.md
@@ -44,9 +44,9 @@ supervision package for multiple tasks such as drawing heatmap annotations, trac
     particularly in distinguishing between different objects.
 - `--heatmap_alpha` (optional): Opacity of the overlay mask, between 0 and 1.
 - `--radius` (optional): Radius of the heat circle.
-- `--track_threshold` (optional): Detection confidence threshold for track activation.
+- `--track_activation_threshold` (optional): Detection confidence threshold for track activation.
 - `--track_seconds` (optional): Number of seconds to buffer when a track is lost.
-- `--match_threshold` (optional): Threshold for matching tracks with detections.
+- `--minimum_matching_threshold` (optional): Threshold for matching tracks with detections.
 
 ## ⚙️ run
 


### PR DESCRIPTION
## What

The `examples/heatmap_and_track/README.md` listed two CLI flags that don't exist on the actual script:

| README claimed | Actual flag from `script.py` |
|---|---|
| `--track_threshold` | `--track_activation_threshold` |
| `--match_threshold` | `--minimum_matching_threshold` |

The CLI surface is generated from the `main()` signature by `jsonargparse.auto_cli` (script.py:120-123), so the function parameter names (`track_activation_threshold`, `minimum_matching_threshold`) are the actual accepted flags. Following the README as written produced "unknown argument" errors.

## Change

Two-line rename in the "script arguments" section to match the real flag names.

## Scope

Documentation-only. No code changes, no behavior change.