### PR TITLE
docs: clarify MaskAnnotator mask requirements

### DIFF
--- a/docs/detection/annotators.md
+++ b/docs/detection/annotators.md
@@ -197,10 +197,11 @@ Annotators accept detections and apply box or mask visualizations to the detecti
         !!! note
 
             `MaskAnnotator` expects `detections.mask` to contain instance segmentation
-            masks. Each mask should match the height and width of the image passed
-            to `annotate`. If your model returns framework-specific results, convert
-            them to `sv.Detections` first, for example with
-            `sv.Detections.from_ultralytics(...)` or
+            masks aligned to the image passed to `annotate`. For dense masks, provide a
+            boolean array of shape `(N, H, W)` where `(H, W)` matches the image height
+            and width (it also accepts `sv.CompactMask`). If your model returns
+            framework-specific results, convert them to `sv.Detections` first, for
+            example with `sv.Detections.from_ultralytics(...)` or
             `sv.Detections.from_inference(...)`.
 
         <div class="result" markdown>

--- a/docs/detection/annotators.md
+++ b/docs/detection/annotators.md
@@ -194,6 +194,15 @@ Annotators accept detections and apply box or mask visualizations to the detecti
         )
         ```
 
+        !!! note
+
+            `MaskAnnotator` expects `detections.mask` to contain instance segmentation
+            masks. Each mask should match the height and width of the image passed
+            to `annotate`. If your model returns framework-specific results, convert
+            them to `sv.Detections` first, for example with
+            `sv.Detections.from_ultralytics(...)` or
+            `sv.Detections.from_inference(...)`.
+
         <div class="result" markdown>
 
         ![mask-annotator-example](https://media.roboflow.com/supervision-annotator-examples/mask-annotator-example-purple.png){ align=center width="800" }


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

* [x] Self-reviewed the code
* [x] Updated documentation, follow [[Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
* [ ] Added docs entry for autogeneration (if new functions/classes)
* [ ] Added/updated tests
* [x] All tests pass locally

</details>

## Description

Clarifies the expected input format for `MaskAnnotator` in the annotators documentation.

This PR adds a short note explaining that `MaskAnnotator` expects instance segmentation masks in `detections.mask`, and that each mask should match the height and width of the image passed to `annotate`.

## Type of Change

* 📝 Documentation update

## Motivation and Context

The existing `MaskAnnotator` example shows how to annotate detections, but it does not explicitly explain what mask format is expected. This can be confusing for new users, especially when converting predictions from model-specific outputs.

This documentation update makes the expected `detections.mask` input clearer and points users toward common conversion methods such as `sv.Detections.from_ultralytics(...)` and `sv.Detections.from_inference(...)`.

No linked issue.

## Changes Made

* Added a note under the `MaskAnnotator` example
* Clarified that `detections.mask` should contain instance segmentation masks
* Mentioned common conversion paths for framework-specific model outputs

## Testing

* [x] I have tested this code locally
* [ ] I have added unit tests that prove my fix is effective or that my feature works
* [x] All new and existing tests pass

Commands run:

```bash
uv run pre-commit run --files docs/detection/annotators.md
python - <<'PY'
import supervision as sv
print("supervision import OK:", sv.__version__)
PY
```

Also ran the full test suite locally earlier:

```bash
uv run pytest tests -q --maxfail=1
```

Result:

```text
1751 passed
```

## Google Colab (optional)

Not applicable for this documentation-only change.

## Screenshots/Videos (optional)

Not applicable.

## Additional Notes

This is a small documentation-only contribution intended to improve clarity for users working with segmentation masks.