### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,15 @@ uv run pre-commit run --all-files
 - All tests must pass before opening a PR. Note: some existing tests in the repo may
     already be failing — your changes must not introduce new failures.
 - Fix any issues reported and re-run until clean.
+
+## Cursor Cloud specific instructions
+
+### Quick reference
+
+- Install/sync: `uv sync --group dev`
+- Tests with coverage: `uv run pytest --cov=supervision`
+- Pre-commit: `uv run pre-commit run --all-files`
+
+### Gotchas
+
+- The `pyproject-fmt` pre-commit hook may fail with an `ImportError` due to a `toml_fmt_common` version conflict. This is a pre-existing issue in the hook environment, not in the project code. All other hooks (ruff, mypy, codespell, mdformat, prettier) pass cleanly.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with quick reference commands and a note about the pre-existing `pyproject-fmt` hook compatibility issue.

Verified by running tests (1903 passed, 79% coverage) and pre-commit hooks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac617329-a9ad-4983-9965-75eb99c0961c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac617329-a9ad-4983-9965-75eb99c0961c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

