### PR TITLE
fix: support grayscale letterbox images

### DIFF
--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -263,7 +263,7 @@ def letterbox_image(
         value=color,
     )
 
-    if image.shape[2] == 4:
+    if image.ndim == 3 and image.shape[2] == 4:
         image[:padding_top, :, 3] = 0
         image[height_new - padding_bottom :, :, 3] = 0
         image[:, :padding_left, 3] = 0

--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -217,14 +217,20 @@ def letterbox_image(
     maintaining aspect ratio.
 
     Args:
-        image: The image to resize and pad.
+        image: The image to resize and pad. Accepts BGR arrays of shape
+            ``(H, W, 3)``, BGRA arrays of shape ``(H, W, 4)``, grayscale
+            arrays of shape ``(H, W)``, or a PIL ``Image``.
         resolution_wh: Target resolution as `(width, height)`.
-        color: Padding color. If tuple, should
-            be in BGR format. Defaults to `Color.BLACK`.
+        color: Padding color. If tuple, should be in BGR format.
+            Defaults to `Color.BLACK`.
 
     Returns:
-        Letterboxed image matching input
-            type.
+        Letterboxed image matching input type.
+
+    Note:
+        For BGRA inputs, the alpha channel in the padding region is set to
+        0 (fully transparent). Grayscale inputs receive scalar padding
+        from ``color[0]``.
 
     Examples:
         ```pycon
@@ -238,6 +244,9 @@ def letterbox_image(
         ... )
         >>> letterboxed_image.shape
         (1000, 1000, 3)
+        >>> gray = np.zeros((4, 6), dtype=np.uint8)
+        >>> sv.letterbox_image(image=gray, resolution_wh=(10, 10)).shape
+        (10, 10)
 
         ```
 
@@ -262,12 +271,6 @@ def letterbox_image(
         cv2.BORDER_CONSTANT,
         value=color,
     )
-
-    if image.ndim == 3 and image.shape[2] == 4:
-        image[:padding_top, :, 3] = 0
-        image[height_new - padding_bottom :, :, 3] = 0
-        image[:, :padding_left, 3] = 0
-        image[:, width_new - padding_right :, 3] = 0
 
     return image_with_borders
 

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -72,6 +72,23 @@ def test_letterbox_image_for_opencv_image() -> None:
     )
 
 
+def test_letterbox_image_for_grayscale_opencv_image() -> None:
+    image = np.zeros((4, 6), dtype=np.uint8)
+    expected_result = np.concatenate(
+        [
+            np.ones((2, 10), dtype=np.uint8) * 255,
+            np.zeros((6, 10), dtype=np.uint8),
+            np.ones((2, 10), dtype=np.uint8) * 255,
+        ],
+        axis=0,
+    )
+
+    result = letterbox_image(image=image, resolution_wh=(10, 10), color=(255, 255, 255))
+
+    assert result.shape == (10, 10)
+    assert np.array_equal(result, expected_result)
+
+
 def test_letterbox_image_for_pillow_image() -> None:
     # given
     image = Image.new(mode="RGB", size=(640, 480), color=(0, 0, 0))

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -89,6 +89,24 @@ def test_letterbox_image_for_grayscale_opencv_image() -> None:
     assert np.array_equal(result, expected_result)
 
 
+def test_letterbox_image_for_rgba_opencv_image() -> None:
+    """RGBA input: padded alpha=0, interior alpha preserved, input array not mutated."""
+    # given
+    image = np.zeros((4, 6, 4), dtype=np.uint8)
+    image[:, :, 3] = 128
+    image_before = image.copy()
+
+    # when
+    result = letterbox_image(image=image, resolution_wh=(10, 10), color=(0, 0, 0))
+
+    # then
+    assert result.shape == (10, 10, 4)
+    assert np.all(result[:2, :, 3] == 0), "padded top rows must have alpha=0"
+    assert np.all(result[8:, :, 3] == 0), "padded bottom rows must have alpha=0"
+    assert np.all(result[2:8, :, 3] == 128), "interior rows must preserve alpha"
+    assert np.array_equal(image, image_before), "input must not be mutated"
+
+
 def test_letterbox_image_for_pillow_image() -> None:
     # given
     image = Image.new(mode="RGB", size=(640, 480), color=(0, 0, 0))


### PR DESCRIPTION
## Summary
- guard `letterbox_image`'s alpha-channel branch so grayscale NumPy images do not crash after resizing
- add a regression test covering grayscale padding output

## Tests
- `uv run pytest tests/utils/test_image.py::test_letterbox_image_for_grayscale_opencv_image -q`
- `uv run pytest tests/utils/test_image.py -q`
- `uv run pytest tests/utils -q`
- `uv run pre-commit run --files src/supervision/utils/image.py tests/utils/test_image.py`
- `uv run pytest -q`