### PR TITLE
fix: normalize file extension filters

### DIFF
--- a/src/supervision/utils/file.py
+++ b/src/supervision/utils/file.py
@@ -68,10 +68,12 @@ def list_files_with_extensions(
 
     if extensions is not None:
         candidates = [p for p in directory.glob("*") if p.is_file()]
-        path_index: dict[Path, set[str]] = {
-            p: {p.suffix.lower().lstrip("."), "".join(p.suffixes).lower().lstrip(".")}
-            for p in candidates
-        }
+        path_index: dict[Path, set[str]] = {}
+        for path in candidates:
+            suffixes = [suffix.lower().lstrip(".") for suffix in path.suffixes]
+            path_index[path] = {
+                ".".join(suffixes[index:]) for index in range(len(suffixes))
+            }
         seen_paths: set[Path] = set()
         for ext in extensions:
             normalized_extension = ext.lower().lstrip(".")

--- a/src/supervision/utils/file.py
+++ b/src/supervision/utils/file.py
@@ -28,8 +28,12 @@ def list_files_with_extensions(
 
     Args:
         directory: The directory path as a string or Path object.
-        extensions: A list of file extensions to filter.
-            Default is None, which lists all files.
+        extensions: A list of file extensions to filter. Extensions may be
+            supplied with or without a leading dot (e.g. ``'jpg'`` and
+            ``'.jpg'`` are equivalent). Matching is case-insensitive.
+            Multi-part extensions are supported (e.g. ``'tar.gz'``). Pass
+            ``None`` (default) to list all files; pass an empty list to
+            return no files.
 
     Returns:
         A list of Path objects for the matching files.
@@ -50,9 +54,9 @@ def list_files_with_extensions(
         >>> files = sv.list_files_with_extensions(directory=tmpdir)
         >>> len(files)
         3
-        >>> # List only files with '.txt' and '.md' extensions
+        >>> # Leading dot accepted; matching is case-insensitive
         >>> files = sv.list_files_with_extensions(
-        ...     directory=tmpdir, extensions=['txt', 'md'])
+        ...     directory=tmpdir, extensions=['.txt', 'md'])
         >>> len(files)
         2
 
@@ -63,18 +67,18 @@ def list_files_with_extensions(
     files_with_extensions: list[Path] = []
 
     if extensions is not None:
-        candidates = list(directory.glob("*"))
+        candidates = [p for p in directory.glob("*") if p.is_file()]
+        path_index: dict[Path, set[str]] = {
+            p: {p.suffix.lower().lstrip("."), "".join(p.suffixes).lower().lstrip(".")}
+            for p in candidates
+        }
         seen_paths: set[Path] = set()
         for ext in extensions:
             normalized_extension = ext.lower().lstrip(".")
-            for path in candidates:
-                if path in seen_paths:
-                    continue
-                path_extensions = {
-                    path.suffix.lower().lstrip("."),
-                    "".join(path.suffixes).lower().lstrip("."),
-                }
-                if normalized_extension in path_extensions:
+            if not normalized_extension:
+                continue
+            for path, path_extensions in path_index.items():
+                if path not in seen_paths and normalized_extension in path_extensions:
                     files_with_extensions.append(path)
                     seen_paths.add(path)
     else:

--- a/src/supervision/utils/file.py
+++ b/src/supervision/utils/file.py
@@ -63,8 +63,20 @@ def list_files_with_extensions(
     files_with_extensions: list[Path] = []
 
     if extensions is not None:
+        candidates = list(directory.glob("*"))
+        seen_paths: set[Path] = set()
         for ext in extensions:
-            files_with_extensions.extend(directory.glob(f"*.{ext}"))
+            normalized_extension = ext.lower().lstrip(".")
+            for path in candidates:
+                if path in seen_paths:
+                    continue
+                path_extensions = {
+                    path.suffix.lower().lstrip("."),
+                    "".join(path.suffixes).lower().lstrip("."),
+                }
+                if normalized_extension in path_extensions:
+                    files_with_extensions.append(path)
+                    seen_paths.add(path)
     else:
         files_with_extensions.extend(directory.glob("*"))
 

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -76,9 +76,20 @@ def test_read_txt_file(
         (["image.jpg", "image.png"], ".jpg", {"image.jpg"}),
         (["image.JPG"], "jpg", {"image.JPG"}),
         (["archive.tar.gz"], "tar.gz", {"archive.tar.gz"}),
+        (
+            ["archive.backup.tar.gz", "archive.backup.gz"],
+            "tar.gz",
+            {"archive.backup.tar.gz"},
+        ),
         (["archive.tar.gz", "data.gz"], "gz", {"archive.tar.gz", "data.gz"}),
     ],
-    ids=["leading_dot", "case_insensitive", "multi_part_full", "multi_part_suffix"],
+    ids=[
+        "leading_dot",
+        "case_insensitive",
+        "multi_part_full",
+        "multi_part_filename_tail",
+        "multi_part_suffix",
+    ],
 )
 def test_list_files_with_extensions_normalization(
     tmp_path: Path,

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import os
 from contextlib import ExitStack as DoesNotRaise
+from pathlib import Path
 
 import pytest
 
-from supervision.utils.file import read_txt_file
+from supervision.utils.file import list_files_with_extensions, read_txt_file
 
 FILE_1_CONTENT = """Line 1
 Line 2
@@ -67,3 +68,35 @@ def test_read_txt_file(
     with exception:
         result = read_txt_file(file_name, skip_empty)
         assert result == expected_result
+
+
+def test_list_files_with_extensions_accepts_leading_dot(tmp_path: Path) -> None:
+    image_path = tmp_path / "image.jpg"
+    image_path.touch()
+    (tmp_path / "image.png").touch()
+
+    result = list_files_with_extensions(directory=tmp_path, extensions=[".jpg"])
+
+    assert result == [image_path]
+
+
+def test_list_files_with_extensions_matches_case_insensitively(
+    tmp_path: Path,
+) -> None:
+    image_path = tmp_path / "image.JPG"
+    image_path.touch()
+
+    result = list_files_with_extensions(directory=tmp_path, extensions=["jpg"])
+
+    assert result == [image_path]
+
+
+def test_list_files_with_extensions_preserves_multi_part_extensions(
+    tmp_path: Path,
+) -> None:
+    archive_path = tmp_path / "archive.tar.gz"
+    archive_path.touch()
+
+    result = list_files_with_extensions(directory=tmp_path, extensions=["tar.gz"])
+
+    assert result == [archive_path]

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -77,7 +77,7 @@ def test_list_files_with_extensions_accepts_leading_dot(tmp_path: Path) -> None:
 
     result = list_files_with_extensions(directory=tmp_path, extensions=[".jpg"])
 
-    assert result == [image_path]
+    assert set(result) == {image_path}
 
 
 def test_list_files_with_extensions_matches_case_insensitively(
@@ -88,7 +88,7 @@ def test_list_files_with_extensions_matches_case_insensitively(
 
     result = list_files_with_extensions(directory=tmp_path, extensions=["jpg"])
 
-    assert result == [image_path]
+    assert set(result) == {image_path}
 
 
 def test_list_files_with_extensions_preserves_multi_part_extensions(
@@ -99,4 +99,16 @@ def test_list_files_with_extensions_preserves_multi_part_extensions(
 
     result = list_files_with_extensions(directory=tmp_path, extensions=["tar.gz"])
 
-    assert result == [archive_path]
+    assert set(result) == {archive_path}
+
+
+def test_list_files_with_extensions_single_suffix_matches_multi_part(
+    tmp_path: Path,
+) -> None:
+    """extensions=['gz'] matches archive.tar.gz via suffix component matching."""
+    (tmp_path / "archive.tar.gz").touch()
+    (tmp_path / "data.gz").touch()
+
+    result = list_files_with_extensions(directory=tmp_path, extensions=["gz"])
+
+    assert {p.name for p in result} == {"archive.tar.gz", "data.gz"}

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -70,45 +70,26 @@ def test_read_txt_file(
         assert result == expected_result
 
 
-def test_list_files_with_extensions_accepts_leading_dot(tmp_path: Path) -> None:
-    image_path = tmp_path / "image.jpg"
-    image_path.touch()
-    (tmp_path / "image.png").touch()
-
-    result = list_files_with_extensions(directory=tmp_path, extensions=[".jpg"])
-
-    assert set(result) == {image_path}
-
-
-def test_list_files_with_extensions_matches_case_insensitively(
+@pytest.mark.parametrize(
+    ("filenames_to_create", "extension", "expected_names"),
+    [
+        (["image.jpg", "image.png"], ".jpg", {"image.jpg"}),
+        (["image.JPG"], "jpg", {"image.JPG"}),
+        (["archive.tar.gz"], "tar.gz", {"archive.tar.gz"}),
+        (["archive.tar.gz", "data.gz"], "gz", {"archive.tar.gz", "data.gz"}),
+    ],
+    ids=["leading_dot", "case_insensitive", "multi_part_full", "multi_part_suffix"],
+)
+def test_list_files_with_extensions_normalization(
     tmp_path: Path,
+    filenames_to_create: list[str],
+    extension: str,
+    expected_names: set[str],
 ) -> None:
-    image_path = tmp_path / "image.JPG"
-    image_path.touch()
+    """Extension matching normalizes leading dots, case, and multi-part extensions."""
+    for filename in filenames_to_create:
+        (tmp_path / filename).touch()
 
-    result = list_files_with_extensions(directory=tmp_path, extensions=["jpg"])
+    result = list_files_with_extensions(directory=tmp_path, extensions=[extension])
 
-    assert set(result) == {image_path}
-
-
-def test_list_files_with_extensions_preserves_multi_part_extensions(
-    tmp_path: Path,
-) -> None:
-    archive_path = tmp_path / "archive.tar.gz"
-    archive_path.touch()
-
-    result = list_files_with_extensions(directory=tmp_path, extensions=["tar.gz"])
-
-    assert set(result) == {archive_path}
-
-
-def test_list_files_with_extensions_single_suffix_matches_multi_part(
-    tmp_path: Path,
-) -> None:
-    """extensions=['gz'] matches archive.tar.gz via suffix component matching."""
-    (tmp_path / "archive.tar.gz").touch()
-    (tmp_path / "data.gz").touch()
-
-    result = list_files_with_extensions(directory=tmp_path, extensions=["gz"])
-
-    assert {p.name for p in result} == {"archive.tar.gz", "data.gz"}
+    assert {p.name for p in result} == expected_names


### PR DESCRIPTION
## Summary
- normalize file-extension filters so callers can pass `.jpg` or `jpg`
- match extension filters case-insensitively, which keeps uppercase image names discoverable on case-sensitive filesystems
- preserve multi-part extension filters such as `tar.gz`

## Tests
- `uv run pytest tests/utils/test_file.py::test_list_files_with_extensions_accepts_leading_dot -q` (failed before the fix)
- `uv run pytest tests/utils/test_file.py -q`
- `uv run pytest tests/dataset/formats/test_yolo.py tests/dataset/formats/test_pascal_voc.py -q`
- `uv run pre-commit run --files src/supervision/utils/file.py tests/utils/test_file.py`
- `uv run pytest -q`