### PR TITLE
docs(contributing): formalise test conventions and doctest guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -323,6 +323,64 @@ To run tests with coverage:
 uv run pytest --cov=supervision
 ```
 
+### Test Structure
+
+Follow **Arrange-Act-Assert (AAA)**: one setup block, one action, one assertion group per
+test. Never put two independent actions in the same test.
+
+**Class grouping:** Group related tests into a class. The class name carries the unit
+under test; method names describe the expected outcome only — not the mechanism.
+
+```python
+class TestDetectionsWithNms:
+    def test_keeps_highest_confidence_detection(self): ...
+    def test_suppresses_lower_score_when_overlap_exceeds_threshold(self): ...
+    def test_raises_when_confidence_missing(self): ...
+```
+
+**Parametrize aggressively:** Three or more structurally identical tests should become a
+single `@pytest.mark.parametrize` case. Use `pytest.param(..., id="slug")` per case —
+not `ids=[...]` on the decorator — so the ID stays co-located with its arguments and
+survives reordering.
+
+```python
+@pytest.mark.parametrize(
+    ("overlap_metric", "expected_keep"),
+    [
+        pytest.param(OverlapMetric.IOU, [True, True], id="iou-keeps-both"),
+        pytest.param(OverlapMetric.IOS, [True, False], id="ios-suppresses-small"),
+    ],
+)
+def test_overlap_metric_determines_suppression(
+    self, overlap_metric: OverlapMetric, expected_keep: list[bool]
+) -> None:
+    """Small box inside large: IOU keeps both; IOS suppresses small."""
+    ...
+```
+
+**Docstrings:** Every test function/method requires at minimum a one-line docstring
+(max 120 chars). Describe the scenario, not the implementation.
+
+### Doctests
+
+Source-file examples (docstrings in `src/**/*.py`) must use `>>>` doctest format when:
+
+- The example is fully self-contained.
+- No optional extras are required (e.g. no `--extra metrics` packages).
+- No external resources are needed (files, network, devices).
+
+Fenced ```` ```python ```` blocks are acceptable when the example cannot reasonably be made
+executable (e.g. imports a third-party model, reads a video file). Do not convert such
+examples.
+
+Doctests run automatically as part of the test suite. `pyproject.toml` enables the
+`ELLIPSIS` and `NORMALIZE_WHITESPACE` flags, so `...` matches any output fragment and
+minor whitespace differences are ignored.
+
+```bash
+uv run pytest --doctest-modules src/
+```
+
 ## 🔍 PR Review Guidelines
 
 These guidelines help reviewers provide consistent, actionable feedback efficiently. Your goals: validate completeness, identify risks, provide actionable feedback, and highlight quality gaps.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -263,9 +263,18 @@ To run the pre-commit tool, follow these steps:
 
 ### Docstrings
 
-All new functions and classes in `supervision` should include docstrings. This is a prerequisite for any new functions and classes to be added to the library.
+All new functions and classes in `supervision` should include docstrings. This is a
+prerequisite for any new functions and classes to be added to the library.
 
-`supervision` adheres to the [Google Python docstring style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods). Please refer to the style guide while writing docstrings for your contribution.
+`supervision` adheres to the
+[Google Python docstring style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods).
+Please refer to the style guide while writing docstrings for your contribution.
+
+Every docstring **must** include a usage example. If the example only uses
+`supervision`, NumPy, and the standard library — no optional extras, no external files
+or network access — write it as a `>>>` doctest. This makes the example runnable and
+automatically verified by the test suite. See [Doctests](#doctests) below for syntax
+guidance and for when fenced ```` ```python ```` blocks are appropriate instead.
 
 ### Type checking
 
@@ -363,23 +372,65 @@ def test_overlap_metric_determines_suppression(
 
 ### Doctests
 
-Source-file examples (docstrings in `src/**/*.py`) must use `>>>` doctest format when:
+**Rule:** if an example uses only `supervision`, NumPy, and the standard library — no
+optional extras (e.g. no `--extra metrics` packages), no external files, no network,
+no devices — **always write it as a `>>>` doctest**. Fenced ```` ```python ```` blocks
+are reserved for examples that genuinely cannot be executed (e.g. loading a third-party
+model checkpoint, reading a video file). Never leave a self-contained example as a
+fenced block.
 
-- The example is fully self-contained.
-- No optional extras are required (e.g. no `--extra metrics` packages).
-- No external resources are needed (files, network, devices).
-
-Fenced ```` ```python ```` blocks are acceptable when the example cannot reasonably be made
-executable (e.g. imports a third-party model, reads a video file). Do not convert such
-examples.
-
-Doctests run automatically as part of the test suite. `pyproject.toml` enables the
-`ELLIPSIS` and `NORMALIZE_WHITESPACE` flags, so `...` matches any output fragment and
-minor whitespace differences are ignored.
+Doctests run automatically as part of the test suite via `--doctest-modules` in
+`pyproject.toml`. The `ELLIPSIS` and `NORMALIZE_WHITESPACE` flags are enabled globally,
+so `...` matches any output fragment and minor whitespace differences are ignored.
 
 ```bash
 uv run pytest --doctest-modules src/
 ```
+
+#### Writing a doctest
+
+Use the `Example:` section of a Google-style docstring. Prefix each input line with
+`>>>` and each continuation line with `...`. Place expected output immediately after
+the last input line with no blank line between them.
+
+```python
+def clip_boxes(xyxy: np.ndarray, resolution_wh: tuple) -> np.ndarray:
+    """Clip bounding boxes to frame boundaries.
+
+    Args:
+        xyxy: Box coordinates as (N, 4) float array.
+        resolution_wh: Frame size as (width, height).
+
+    Returns:
+        Clipped boxes as (N, 4) float array.
+
+    Example:
+        >>> import numpy as np
+        >>> import supervision as sv
+        >>> boxes = np.array([[-10, -5, 120, 80]], dtype=np.float32)
+        >>> sv.clip_boxes(boxes, resolution_wh=(100, 60))
+        array([[ 0.,  0., 100.,  60.]], dtype=float32)
+    """
+```
+
+Key rules:
+
+- **Single-line expression** — write the repr as expected output:
+    `>>> len(result)` → `1`
+- **Multi-line statement** — use `...` continuation:
+    `>>> arr = np.array([` / `...     [1, 2],` / `... ])`
+- **Print output** — write the printed string as expected output (no quotes).
+- **`None` return** — no output line needed (suppress with assignment or `_ =`).
+- **Large/variable arrays** — use `ELLIPSIS`: `array([...])` matches any content.
+- **`# doctest: +SKIP`** — use only as a last resort for genuinely non-runnable lines
+    (e.g. a GPU-only call inside an otherwise runnable example). Prefer splitting the
+    example into two blocks instead.
+
+Fenced ```` ```python ```` blocks remain appropriate for:
+
+- Examples that import optional extras (`supervision[metrics]`, `torch`, `ultralytics`).
+- Examples that read files, capture video, or require a running service.
+- Illustrative pseudocode that is intentionally incomplete.
 
 ## 🔍 PR Review Guidelines
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -361,7 +361,7 @@ survives reordering.
     ],
 )
 def test_overlap_metric_determines_suppression(
-    self, overlap_metric: OverlapMetric, expected_keep: list[bool]
+    overlap_metric: OverlapMetric, expected_keep: list[bool]
 ) -> None:
     """Small box inside large: IOU keeps both; IOS suppresses small."""
     ...

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -368,7 +368,8 @@ def test_overlap_metric_determines_suppression(
 ```
 
 **Docstrings:** Every test function/method requires at minimum a one-line docstring
-(max 120 chars). Describe the scenario, not the implementation.
+(within the project line length configured in `pyproject.toml`). Describe the scenario,
+not the implementation.
 
 ### Doctests
 
@@ -388,7 +389,7 @@ so `...` matches any output fragment and minor whitespace differences are ignore
 uv run pytest --doctest-modules src/
 ```
 
-#### Writing a doctest
+**Writing a doctest**
 
 Use the `Example:` section of a Google-style docstring. Prefix each input line with
 `>>>` and each continuation line with `...`. Place expected output immediately after
@@ -414,7 +415,7 @@ def clip_boxes(xyxy: np.ndarray, resolution_wh: tuple) -> np.ndarray:
     """
 ```
 
-Key rules:
+### Key rules
 
 - **Single-line expression** — write the repr as expected output:
     `>>> len(result)` → `1`

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -270,11 +270,11 @@ prerequisite for any new functions and classes to be added to the library.
 [Google Python docstring style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods).
 Please refer to the style guide while writing docstrings for your contribution.
 
-Every docstring **must** include a usage example. If the example only uses
+Every docstring should include a usage example. When the example only uses
 `supervision`, NumPy, and the standard library — no optional extras, no external files
-or network access — write it as a `>>>` doctest. This makes the example runnable and
-automatically verified by the test suite. See [Doctests](#doctests) below for syntax
-guidance and for when fenced ```` ```python ```` blocks are appropriate instead.
+or network access — strongly prefer `>>>` doctest format so it is automatically
+verified by the test suite. See [Doctests](#doctests) below for syntax guidance and for
+when fenced ```` ```python ```` blocks are appropriate instead.
 
 ### Type checking
 
@@ -372,12 +372,13 @@ def test_overlap_metric_determines_suppression(
 
 ### Doctests
 
-**Rule:** if an example uses only `supervision`, NumPy, and the standard library — no
-optional extras (e.g. no `--extra metrics` packages), no external files, no network,
-no devices — **always write it as a `>>>` doctest**. Fenced ```` ```python ```` blocks
-are reserved for examples that genuinely cannot be executed (e.g. loading a third-party
-model checkpoint, reading a video file). Never leave a self-contained example as a
-fenced block.
+**Guidance:** when an example uses only `supervision`, NumPy, and the standard library
+— no optional extras (e.g. no `--extra metrics` packages), no external files, no
+network, no devices — prefer `>>>` doctest format so it is automatically verified by
+the test suite. Fenced ```` ```python ```` blocks are appropriate when the example
+cannot reasonably be executed (e.g. loading a third-party model, reading a video file)
+or when the primary purpose is demonstrating error/exception behaviour rather than
+return values.
 
 Doctests run automatically as part of the test suite via `--doctest-modules` in
 `pyproject.toml`. The `ELLIPSIS` and `NORMALIZE_WHITESPACE` flags are enabled globally,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ All work must follow the conventions of the `supervision` library
 
 ## 3a. Test Conventions
 
-Full test guidelines are in [CONTRIBUTING.md](.github/CONTRIBUTING.md#-tests). Key rules:
+Full test guidelines are in [CONTRIBUTING.md](.github/CONTRIBUTING.md#tests). Key rules:
 
 - **AAA structure**: one arrange, one act, one assertion group per test. No second act.
 - **Class grouping**: group related tests into a class. Class name = unit under test.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,17 @@ All work must follow the conventions of the `supervision` library
 
 ### Code Style
 
+- **Heading depth in docs/docstrings**: `###` maximum. `####` and deeper render
+    identically to bold in mkdocs — use `**bold**` instead.
+
 - **Formatting and linting** are enforced by **pre-commit**.
     The hook chain typically includes: ruff-check, ruff-format, codespell, mdformat,
     prettier, pyproject-fmt, and standard pre-commit-hooks (trailing whitespace, YAML, TOML, etc.).
+
 - **Type hints**: required on all new code. Type checking with mypy is encouraged but not
     currently enforced systematically by pre-commit; see [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md)
     for the latest type-checking expectations.
+
 - **Docstrings**: Google Python docstring style. Required for all new functions and classes.
     Every docstring should include a usage example. Prefer `>>>` doctest format when
     the example only uses `supervision`, NumPy, and stdlib (no optional extras, no
@@ -76,7 +81,7 @@ Full test guidelines are in [CONTRIBUTING.md](.github/CONTRIBUTING.md#tests). Ke
 - **Parametrize**: 3+ structurally identical tests → `@pytest.mark.parametrize`.
     Use `pytest.param(..., id="slug")` per case (not `ids=[...]` on the decorator).
 - **Docstrings**: every test function/method needs at minimum a one-line docstring
-    (≤120 chars). Describe the scenario, not the implementation.
+    within the project line length (see `pyproject.toml`). Describe the scenario, not the implementation.
 - **Doctests**: prefer `>>>` doctest when example uses only `supervision`, NumPy, and
     stdlib (no optional extras, no external files). Fenced ```` ```python ```` is fine
     when non-runnable (third-party model, video file, optional extra) or when the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@ All work must follow the conventions of the `supervision` library
     currently enforced systematically by pre-commit; see [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md)
     for the latest type-checking expectations.
 - **Docstrings**: Google Python docstring style. Required for all new functions and classes.
-    Every docstring must include a usage example. Write it as a `>>>` doctest whenever
-    the example only uses `supervision`, NumPy, and the standard library (no optional
-    extras, no external files or network). See §3a and CONTRIBUTING.md for syntax.
+    Every docstring should include a usage example. Prefer `>>>` doctest format when
+    the example only uses `supervision`, NumPy, and stdlib (no optional extras, no
+    external files or network). See §3a and CONTRIBUTING.md for syntax.
 
 ### API Consistency
 
@@ -77,9 +77,10 @@ Full test guidelines are in [CONTRIBUTING.md](.github/CONTRIBUTING.md#tests). Ke
     Use `pytest.param(..., id="slug")` per case (not `ids=[...]` on the decorator).
 - **Docstrings**: every test function/method needs at minimum a one-line docstring
     (≤120 chars). Describe the scenario, not the implementation.
-- **Doctests**: if example uses only `supervision`, NumPy, and stdlib — **always `>>>`
-    doctest, never a fenced block**. Fenced ```` ```python ```` only when genuinely
-    non-runnable (third-party model, video file, optional extra). See CONTRIBUTING.md
+- **Doctests**: prefer `>>>` doctest when example uses only `supervision`, NumPy, and
+    stdlib (no optional extras, no external files). Fenced ```` ```python ```` is fine
+    when non-runnable (third-party model, video file, optional extra) or when the
+    example's purpose is showing exception/error behaviour. See CONTRIBUTING.md
     §Doctests for syntax guide (continuation lines, ELLIPSIS, `+SKIP` rules).
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,24 @@ All work must follow the conventions of the `supervision` library
 
 ---
 
+## 3a. Test Conventions
+
+Full test guidelines are in [CONTRIBUTING.md](.github/CONTRIBUTING.md#-tests). Key rules:
+
+- **AAA structure**: one arrange, one act, one assertion group per test. No second act.
+- **Class grouping**: group related tests into a class. Class name = unit under test.
+    Method names describe the expected outcome only — not the mechanism.
+- **Parametrize**: 3+ structurally identical tests → `@pytest.mark.parametrize`.
+    Use `pytest.param(..., id="slug")` per case (not `ids=[...]` on the decorator).
+- **Docstrings**: every test function/method needs at minimum a one-line docstring
+    (≤120 chars). Describe the scenario, not the implementation.
+- **Doctests**: source-file examples in `src/**/*.py` must use `>>>` doctest format
+    when fully self-contained and requiring no optional extras or external resources.
+    Fenced ```` ```python ```` blocks are acceptable only when the example cannot be made
+    executable (e.g. loads a third-party model, reads a video file).
+
+---
+
 ## 4. Fixing Bugs
 
 1. Reproduce and understand the root cause.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,9 @@ All work must follow the conventions of the `supervision` library
     currently enforced systematically by pre-commit; see [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md)
     for the latest type-checking expectations.
 - **Docstrings**: Google Python docstring style. Required for all new functions and classes.
-    Docstrings should include usage examples demonstrating the function with primitive values
-    so they serve as runnable documentation.
+    Every docstring must include a usage example. Write it as a `>>>` doctest whenever
+    the example only uses `supervision`, NumPy, and the standard library (no optional
+    extras, no external files or network). See §3a and CONTRIBUTING.md for syntax.
 
 ### API Consistency
 
@@ -76,10 +77,10 @@ Full test guidelines are in [CONTRIBUTING.md](.github/CONTRIBUTING.md#-tests). K
     Use `pytest.param(..., id="slug")` per case (not `ids=[...]` on the decorator).
 - **Docstrings**: every test function/method needs at minimum a one-line docstring
     (≤120 chars). Describe the scenario, not the implementation.
-- **Doctests**: source-file examples in `src/**/*.py` must use `>>>` doctest format
-    when fully self-contained and requiring no optional extras or external resources.
-    Fenced ```` ```python ```` blocks are acceptable only when the example cannot be made
-    executable (e.g. loads a third-party model, reads a video file).
+- **Doctests**: if example uses only `supervision`, NumPy, and stdlib — **always `>>>`
+    doctest, never a fenced block**. Fenced ```` ```python ```` only when genuinely
+    non-runnable (third-party model, video file, optional extra). See CONTRIBUTING.md
+    §Doctests for syntax guide (continuation lines, ELLIPSIS, `+SKIP` rules).
 
 ---
 


### PR DESCRIPTION
This pull request updates the project's documentation to clarify and standardize the testing conventions. It introduces detailed guidelines for structuring tests and using doctests, ensuring consistency and readability across the codebase. The changes primarily affect the contributing and agent documentation.

**Testing conventions and guidelines:**

* Added a new section to `.github/CONTRIBUTING.md` outlining best practices for writing tests, including the Arrange-Act-Assert (AAA) structure, class-based grouping, aggressive use of `pytest.mark.parametrize`, and mandatory docstrings for all test functions.
* Provided explicit instructions for when to use doctest format in source file examples, including when fenced code blocks are acceptable, and how doctests are run as part of the test suite.

**Documentation consistency:**

* Added a summary of key test conventions to `AGENTS.md`, referencing the full guidelines in `CONTRIBUTING.md` and highlighting the most important rules for writing and organizing tests.