### PR TITLE
fix(coco): preserve segmentation in as_coco() round-trip

### DIFF
--- a/src/supervision/config.py
+++ b/src/supervision/config.py
@@ -1,4 +1,5 @@
 CLASS_NAME_DATA_FIELD: str = "class_name"
+COCO_RAW_SEGMENTATION: str = "coco_raw_segmentation"
 #: Key for oriented bounding-box corner coordinates in ``Detections.data``.
 #:
 #: Value layout: ``np.ndarray`` of shape ``(N, 4, 2)``, dtype ``float32``, pixel

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -304,9 +304,14 @@ def detections_to_coco_annotations(
             # polygon/RLE stored in data["segmentation"] for a lossless round-trip.
             raw_seg = data.get("segmentation")
             if raw_seg is not None and bool(raw_seg):
-                segmentation = (
-                    raw_seg if isinstance(raw_seg, (list, dict)) else list(raw_seg)
-                )
+                if isinstance(raw_seg, dict):
+                    # RLE format — pass through unchanged
+                    segmentation = raw_seg
+                elif isinstance(raw_seg, list) and raw_seg and not isinstance(raw_seg[0], (list, tuple)):
+                    # Flat list shorthand [x1,y1,...] — wrap to list-of-lists
+                    segmentation = [list(raw_seg)]
+                else:
+                    segmentation = list(raw_seg)
 
         area: float = float(np.asarray(data.get("area", box_width * box_height)).item())
         coco_annotation = {

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Union, cast
 import numpy as np
 import numpy.typing as npt
 
+from supervision.config import COCO_RAW_SEGMENTATION
 from supervision.dataset.utils import (
     approximate_mask_with_polygons,
     map_detections_class_id,
@@ -168,6 +169,10 @@ def coco_annotations_to_detections(
     Returns:
         Detections with ``class_id`` set to raw COCO ``category_id`` values.
         Call :func:`map_detections_class_id` on the result before use.
+        When ``with_masks=False``, ``detections.data[COCO_RAW_SEGMENTATION]`` is
+        populated as an object array (shape ``(N,)``) holding the raw polygon list or
+        RLE dict per annotation; consumed by :func:`detections_to_coco_annotations`
+        for a coordinate-preserving round-trip.
     """
     if not image_annotations:
         return Detections.empty()
@@ -179,7 +184,7 @@ def coco_annotations_to_detections(
     xyxy = np.asarray(xyxy, dtype=np.float32)
     xyxy[:, 2:4] += xyxy[:, 0:2]
 
-    data: dict[str, npt.NDArray[np.generic]] = {}
+    data: dict[str, Union[npt.NDArray[np.generic], list[Any]]] = {}
     if use_iscrowd:
         iscrowd = [
             image_annotation["iscrowd"] for image_annotation in image_annotations
@@ -198,10 +203,9 @@ def coco_annotations_to_detections(
         # Preserve raw polygon/RLE data so as_coco() can round-trip without
         # binary-mask encoding. Stored as an object array (one entry per detection).
         raw_segs = np.empty(len(image_annotations), dtype=object)
-        for _k, _ann in enumerate(image_annotations):
-            raw_segs[_k] = _ann.get("segmentation", [])
-        if any(bool(raw_segs[_k]) for _k in range(len(raw_segs))):
-            data["segmentation"] = raw_segs
+        for k, _ann in enumerate(image_annotations):
+            raw_segs[k] = _ann.get("segmentation", [])
+        data[COCO_RAW_SEGMENTATION] = raw_segs
 
     return Detections(
         class_id=np.asarray(class_ids, dtype=int), xyxy=xyxy, mask=mask, data=data
@@ -300,10 +304,10 @@ def detections_to_coco_annotations(
                     )
         else:
             iscrowd = int(np.asarray(data.get("iscrowd", 0)).item())
-            # When masks were not decoded during loading, fall back to the raw
-            # polygon/RLE stored in data["segmentation"] for a lossless round-trip.
-            raw_seg = data.get("segmentation")
-            if raw_seg is not None and bool(raw_seg):
+            # When loading skipped mask decoding (with_masks=False), raw polygon/RLE
+            # coordinates are re-emitted verbatim — no approximation loss.
+            raw_seg = data.get(COCO_RAW_SEGMENTATION)
+            if raw_seg is not None and len(raw_seg) > 0:
                 segmentation = (
                     raw_seg if isinstance(raw_seg, (list, dict)) else list(raw_seg)
                 )

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -180,8 +180,8 @@ def coco_annotations_to_detections(
     class_ids = [
         image_annotation["category_id"] for image_annotation in image_annotations
     ]
-    xyxy = [image_annotation["bbox"] for image_annotation in image_annotations]
-    xyxy = np.asarray(xyxy, dtype=np.float32)
+    xyxy_list = [image_annotation["bbox"] for image_annotation in image_annotations]
+    xyxy: npt.NDArray[np.float32] = np.asarray(xyxy_list, dtype=np.float32)
     xyxy[:, 2:4] += xyxy[:, 0:2]
 
     data: dict[str, Union[npt.NDArray[np.generic], list[Any]]] = {}
@@ -274,18 +274,22 @@ def detections_to_coco_annotations(
             if "iscrowd" in data:
                 iscrowd = int(np.asarray(data["iscrowd"]).item())
             else:
+                mask_bool = cast(npt.NDArray[np.bool_], mask)
                 iscrowd = int(
-                    contains_holes(mask=mask) or contains_multiple_segments(mask=mask)
+                    contains_holes(mask=mask_bool)
+                    or contains_multiple_segments(mask=mask_bool)
                 )
 
             if iscrowd:
                 segmentation = {
-                    "counts": cast(list[int], mask_to_rle(mask=mask, compressed=False)),
+                    "counts": cast(
+                        list[int], mask_to_rle(mask=mask_bool, compressed=False)
+                    ),
                     "size": list(mask.shape[:2]),
                 }
             else:
                 polygons = approximate_mask_with_polygons(
-                    mask=mask,
+                    mask=mask_bool,
                     min_image_area_percentage=min_image_area_percentage,
                     max_image_area_percentage=max_image_area_percentage,
                     approximation_percentage=approximation_percentage,

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -306,7 +306,7 @@ def detections_to_coco_annotations(
             iscrowd = int(np.asarray(data.get("iscrowd", 0)).item())
             # When masks were not decoded during loading, fall back to the raw
             # polygon/RLE stored in data["segmentation"] for a lossless round-trip.
-            raw_seg = data.get("segmentation")
+            raw_seg = data.get(COCO_RAW_SEGMENTATION)
             if raw_seg is not None and bool(raw_seg):
                 if isinstance(raw_seg, dict):
                     # RLE format — pass through unchanged

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -271,10 +271,10 @@ def detections_to_coco_annotations(
         box_width, box_height = xyxy[2] - xyxy[0], xyxy[3] - xyxy[1]
         segmentation: Union[list[list[float]], dict[str, list[int]]] = []
         if mask is not None:
+            mask_bool = cast(npt.NDArray[np.bool_], mask)
             if "iscrowd" in data:
                 iscrowd = int(np.asarray(data["iscrowd"]).item())
             else:
-                mask_bool = cast(npt.NDArray[np.bool_], mask)
                 iscrowd = int(
                     contains_holes(mask=mask_bool)
                     or contains_multiple_segments(mask=mask_bool)

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -307,7 +307,11 @@ def detections_to_coco_annotations(
                 if isinstance(raw_seg, dict):
                     # RLE format — pass through unchanged
                     segmentation = raw_seg
-                elif isinstance(raw_seg, list) and raw_seg and not isinstance(raw_seg[0], (list, tuple)):
+                elif (
+                    isinstance(raw_seg, list)
+                    and raw_seg
+                    and not isinstance(raw_seg[0], (list, tuple))
+                ):
                     # Flat list shorthand [x1,y1,...] — wrap to list-of-lists
                     segmentation = [list(raw_seg)]
                 else:

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -202,7 +202,9 @@ def coco_annotations_to_detections(
         mask = None
         # Preserve raw polygon/RLE data so as_coco() can round-trip without
         # binary-mask encoding. Stored as an object array (one entry per detection).
-        raw_segs = np.empty(len(image_annotations), dtype=object)
+        raw_segs: npt.NDArray[np.object_] = np.empty(
+            len(image_annotations), dtype=object
+        )
         for k, _ann in enumerate(image_annotations):
             raw_segs[k] = _ann.get("segmentation", [])
         data[COCO_RAW_SEGMENTATION] = raw_segs

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -195,6 +195,13 @@ def coco_annotations_to_detections(
         )
     else:
         mask = None
+        # Preserve raw polygon/RLE data so as_coco() can round-trip without
+        # binary-mask encoding. Stored as an object array (one entry per detection).
+        raw_segs = np.empty(len(image_annotations), dtype=object)
+        for _k, _ann in enumerate(image_annotations):
+            raw_segs[_k] = _ann.get("segmentation", [])
+        if any(bool(raw_segs[_k]) for _k in range(len(raw_segs))):
+            data["segmentation"] = raw_segs
 
     return Detections(
         class_id=np.asarray(class_ids, dtype=int), xyxy=xyxy, mask=mask, data=data
@@ -282,7 +289,8 @@ def detections_to_coco_annotations(
                 # Small/noisy masks can be filtered out by approximation settings.
                 # Guard against empty output and keep a valid COCO annotation record.
                 if polygons:
-                    segmentation = [list(polygons[0].flatten())]
+                    # Export ALL polygons so disjoint mask components are preserved.
+                    segmentation = [list(p.flatten()) for p in polygons]
                 else:
                     warnings.warn(
                         "Skipping COCO polygon segmentation for annotation "
@@ -292,6 +300,13 @@ def detections_to_coco_annotations(
                     )
         else:
             iscrowd = int(np.asarray(data.get("iscrowd", 0)).item())
+            # When masks were not decoded during loading, fall back to the raw
+            # polygon/RLE stored in data["segmentation"] for a lossless round-trip.
+            raw_seg = data.get("segmentation")
+            if raw_seg is not None and bool(raw_seg):
+                segmentation = (
+                    raw_seg if isinstance(raw_seg, (list, dict)) else list(raw_seg)
+                )
 
         area: float = float(np.asarray(data.get("area", box_width * box_height)).item())
         coco_annotation = {

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1854,7 +1854,7 @@ def test_detections_to_coco_annotations_exports_all_polygons() -> None:
     """All polygons from a multi-component mask must be exported, not just the first."""
     # Build a mask with two separate rectangles (disjoint components)
     mask = np.zeros((20, 20), dtype=bool)
-    mask[1:4, 1:4] = True   # top-left component
+    mask[1:4, 1:4] = True  # top-left component
     mask[14:18, 14:18] = True  # bottom-right component
 
     detections = Detections(

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1913,13 +1913,15 @@ def test_coco_polygon_segmentation_survives_roundtrip(tmp_path) -> None:
 
     assert len(out["annotations"]) == 1
     seg = out["annotations"][0]["segmentation"]
-    assert seg != [], "segmentation must not be empty after round-trip (issue #2285)"
-    assert isinstance(seg, list) and len(seg) >= 1
+    assert isinstance(seg, list)
+    assert len(seg) >= 1, (
+        "segmentation must not be empty after round-trip (issue #2285)"
+    )
 
 
 def test_coco_raw_segmentation_preserved_when_masks_not_decoded(tmp_path) -> None:
-    """When masks are decoded, raw polygon data stored in data['segmentation']
-    is used as a lossless fallback so as_coco() still emits non-empty segmentation."""
+    """When masks are NOT decoded, raw polygon/RLE in data['coco_raw_segmentation']
+    is re-emitted verbatim by as_coco() — no approximation loss."""
     from supervision.dataset.formats.coco import (
         coco_annotations_to_detections,
         detections_to_coco_annotations,
@@ -1945,7 +1947,7 @@ def test_coco_raw_segmentation_preserved_when_masks_not_decoded(tmp_path) -> Non
     )
     assert detections.mask is None
     # Raw segmentation must be stored in data for fallback
-    assert "segmentation" in detections.data
+    assert "coco_raw_segmentation" in detections.data
 
     # Export must still produce non-empty segmentation via fallback
     annotations, _ = detections_to_coco_annotations(
@@ -1953,3 +1955,4 @@ def test_coco_raw_segmentation_preserved_when_masks_not_decoded(tmp_path) -> Non
     )
     assert len(annotations) == 1
     assert annotations[0]["segmentation"] != []
+

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -43,6 +43,14 @@ def mock_coco_annotation(
     }
 
 
+def _empty_raw_segs(n: int) -> np.ndarray:
+    """Object-dtype array of n empty lists for coco_raw_segmentation (bbox-only)."""
+    arr = np.empty(n, dtype=object)
+    for i in range(n):
+        arr[i] = []
+    return arr
+
+
 @pytest.fixture
 def coco_data_with_and_without_segmentation() -> dict[str, object]:
     return {
@@ -282,6 +290,7 @@ def test_group_coco_annotations_by_image_id(
             Detections(
                 xyxy=np.array([[0, 0, 100, 100]], dtype=np.float32),
                 class_id=np.array([0], dtype=int),
+                data={"coco_raw_segmentation": _empty_raw_segs(1)},
             ),
             DoesNotRaise(),
         ),  # single image annotations
@@ -300,6 +309,7 @@ def test_group_coco_annotations_by_image_id(
                 data={
                     "iscrowd": np.array([0], dtype=int),
                     "area": np.array([100 * 100]),
+                    "coco_raw_segmentation": _empty_raw_segs(1),
                 },
             ),
             DoesNotRaise(),
@@ -321,6 +331,7 @@ def test_group_coco_annotations_by_image_id(
                     [[0, 0, 100, 100], [100, 100, 200, 200]], dtype=np.float32
                 ),
                 class_id=np.array([0, 0], dtype=int),
+                data={"coco_raw_segmentation": _empty_raw_segs(2)},
             ),
             DoesNotRaise(),
         ),  # two image annotations
@@ -344,6 +355,7 @@ def test_group_coco_annotations_by_image_id(
                 data={
                     "iscrowd": np.array([0, 0], dtype=int),
                     "area": np.array([100 * 100, 100 * 100]),
+                    "coco_raw_segmentation": _empty_raw_segs(2),
                 },
             ),
             DoesNotRaise(),

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1862,6 +1862,31 @@ def test_coco_round_trip_multi_class_single_image(tmp_path) -> None:
 # --- Regression: segmentation round-trip (#2285) ---
 
 
+def _coco_annotation_with_segmentation(
+    segmentation: list[list[int]],
+    bbox: tuple[float, float, float, float] = (0, 0, 5, 5),
+    area: float = 25,
+) -> dict:
+    return mock_coco_annotation(
+        annotation_id=1,
+        image_id=1,
+        category_id=1,
+        bbox=bbox,
+        area=area,
+        segmentation=segmentation,
+    )
+
+
+def _single_image_coco_data(annotation: dict) -> dict[str, object]:
+    return {
+        "info": {},
+        "licenses": [],
+        "categories": [{"id": 1, "name": "cat", "supercategory": ""}],
+        "images": [{"id": 1, "file_name": "img.jpg", "width": 10, "height": 10}],
+        "annotations": [annotation],
+    }
+
+
 def test_detections_to_coco_annotations_exports_all_polygons() -> None:
     """All polygons from a multi-component mask must be exported, not just the first."""
     # Build a mask with two separate rectangles (disjoint components)
@@ -1885,8 +1910,33 @@ def test_detections_to_coco_annotations_exports_all_polygons() -> None:
     assert len(seg) >= 2
 
 
-def test_coco_polygon_segmentation_survives_roundtrip(tmp_path) -> None:
-    """from_coco() -> as_coco() must preserve polygon segmentation (issue #2285)."""
+@pytest.mark.parametrize(
+    ("segmentation", "bbox", "area", "expected_min_polygon_count"),
+    [
+        pytest.param(
+            [[0, 0, 4, 0, 4, 4, 0, 4]],
+            (0, 0, 5, 5),
+            25,
+            1,
+            id="single-polygon",
+        ),
+        pytest.param(
+            [[0, 0, 4, 0, 4, 4, 0, 4], [6, 6, 9, 6, 9, 9, 6, 9]],
+            (0, 0, 9, 9),
+            32,
+            2,
+            id="multi-polygon",
+        ),
+    ],
+)
+def test_coco_polygon_segmentation_survives_roundtrip(
+    tmp_path,
+    segmentation: list[list[int]],
+    bbox: tuple[float, float, float, float],
+    area: float,
+    expected_min_polygon_count: int,
+) -> None:
+    """from_coco() -> as_coco() must preserve polygon segmentation."""
     images_dir = tmp_path / "images"
     images_dir.mkdir()
 
@@ -1894,26 +1944,17 @@ def test_coco_polygon_segmentation_survives_roundtrip(tmp_path) -> None:
     img_path = images_dir / "img.jpg"
     assert cv2.imwrite(str(img_path), np.zeros((10, 10, 3), dtype=np.uint8))
 
-    coco_data = {
-        "info": {},
-        "licenses": [],
-        "categories": [{"id": 1, "name": "cat", "supercategory": ""}],
-        "images": [{"id": 1, "file_name": "img.jpg", "width": 10, "height": 10}],
-        "annotations": [
-            {
-                "id": 1,
-                "image_id": 1,
-                "category_id": 1,
-                "bbox": [0, 0, 5, 5],
-                "area": 25,
-                "segmentation": [[0, 0, 4, 0, 4, 4, 0, 4]],
-                "iscrowd": 0,
-            }
-        ],
-    }
-
     ann_path = tmp_path / "annotations.json"
-    ann_path.write_text(json.dumps(coco_data), encoding="utf-8")
+    ann_path.write_text(
+        json.dumps(
+            _single_image_coco_data(
+                _coco_annotation_with_segmentation(
+                    segmentation=segmentation, bbox=bbox, area=area
+                )
+            )
+        ),
+        encoding="utf-8",
+    )
 
     ds = DetectionDataset.from_coco(
         images_directory_path=str(images_dir),
@@ -1929,30 +1970,15 @@ def test_coco_polygon_segmentation_survives_roundtrip(tmp_path) -> None:
     assert len(out["annotations"]) == 1
     seg = out["annotations"][0]["segmentation"]
     assert isinstance(seg, list)
-    assert len(seg) >= 1, (
-        "segmentation must not be empty after round-trip (issue #2285)"
-    )
+    assert len(seg) >= expected_min_polygon_count
 
 
-def test_coco_raw_segmentation_preserved_when_masks_not_decoded(tmp_path) -> None:
+def test_coco_raw_segmentation_preserved_when_masks_not_decoded() -> None:
     """When masks are NOT decoded (with_masks=False), raw polygon data stored in
     data['segmentation'] is used as a lossless fallback so as_coco() still emits
     non-empty segmentation."""
-    from supervision.dataset.formats.coco import (
-        coco_annotations_to_detections,
-        detections_to_coco_annotations,
-    )
-
     image_annotations = [
-        {
-            "id": 1,
-            "image_id": 1,
-            "category_id": 1,
-            "bbox": [0, 0, 5, 5],
-            "area": 25,
-            "segmentation": [[0, 0, 4, 0, 4, 4, 0, 4]],
-            "iscrowd": 0,
-        }
+        _coco_annotation_with_segmentation(segmentation=[[0, 0, 4, 0, 4, 4, 0, 4]])
     ]
 
     # Load WITHOUT mask decoding — mask must be None
@@ -1971,52 +1997,6 @@ def test_coco_raw_segmentation_preserved_when_masks_not_decoded(tmp_path) -> Non
     )
     assert len(annotations) == 1
     assert annotations[0]["segmentation"] != []
-
-
-def test_coco_multi_polygon_survives_roundtrip(tmp_path) -> None:
-    """All polygon components must survive from_coco → as_coco round-trip (#2285)."""
-    images_dir = tmp_path / "images"
-    images_dir.mkdir()
-    img_path = images_dir / "img.jpg"
-    assert cv2.imwrite(str(img_path), np.zeros((10, 10, 3), dtype=np.uint8))
-
-    coco_data = {
-        "info": {},
-        "licenses": [],
-        "categories": [{"id": 1, "name": "cat", "supercategory": ""}],
-        "images": [{"id": 1, "file_name": "img.jpg", "width": 10, "height": 10}],
-        "annotations": [
-            {
-                "id": 1,
-                "image_id": 1,
-                "category_id": 1,
-                "bbox": [0, 0, 9, 9],
-                "area": 32,
-                "segmentation": [
-                    [0, 0, 4, 0, 4, 4, 0, 4],
-                    [6, 6, 9, 6, 9, 9, 6, 9],
-                ],
-                "iscrowd": 0,
-            }
-        ],
-    }
-
-    ann_path = tmp_path / "annotations.json"
-    ann_path.write_text(json.dumps(coco_data), encoding="utf-8")
-    ds = DetectionDataset.from_coco(
-        images_directory_path=str(images_dir),
-        annotations_path=str(ann_path),
-    )
-
-    out_path = tmp_path / "out.json"
-    ds.as_coco(annotations_path=str(out_path))
-
-    with open(out_path) as f:
-        out = json.load(f)
-
-    seg = out["annotations"][0]["segmentation"]
-    assert isinstance(seg, list)
-    assert len(seg) >= 2, "both polygon components must survive the round-trip"
 
 
 def test_coco_iscrowd_mask_exports_as_rle() -> None:

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1956,3 +1956,69 @@ def test_coco_raw_segmentation_preserved_when_masks_not_decoded(tmp_path) -> Non
     assert len(annotations) == 1
     assert annotations[0]["segmentation"] != []
 
+
+def test_coco_multi_polygon_survives_roundtrip(tmp_path) -> None:
+    """All polygon components must survive from_coco → as_coco round-trip (#2285)."""
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    img_path = images_dir / "img.jpg"
+    assert cv2.imwrite(str(img_path), np.zeros((10, 10, 3), dtype=np.uint8))
+
+    coco_data = {
+        "info": {},
+        "licenses": [],
+        "categories": [{"id": 1, "name": "cat", "supercategory": ""}],
+        "images": [{"id": 1, "file_name": "img.jpg", "width": 10, "height": 10}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [0, 0, 9, 9],
+                "area": 32,
+                "segmentation": [
+                    [0, 0, 4, 0, 4, 4, 0, 4],
+                    [6, 6, 9, 6, 9, 9, 6, 9],
+                ],
+                "iscrowd": 0,
+            }
+        ],
+    }
+
+    ann_path = tmp_path / "annotations.json"
+    ann_path.write_text(json.dumps(coco_data), encoding="utf-8")
+    ds = DetectionDataset.from_coco(
+        images_directory_path=str(images_dir),
+        annotations_path=str(ann_path),
+    )
+
+    out_path = tmp_path / "out.json"
+    ds.as_coco(annotations_path=str(out_path))
+
+    with open(out_path) as f:
+        out = json.load(f)
+
+    seg = out["annotations"][0]["segmentation"]
+    assert isinstance(seg, list)
+    assert len(seg) >= 2, "both polygon components must survive the round-trip"
+
+
+def test_coco_iscrowd_mask_exports_as_rle() -> None:
+    """Multi-segment mask exports segmentation as RLE dict (iscrowd inferred as 1)."""
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[1:3, 1:3] = True  # top-left component
+    mask[7:9, 7:9] = True  # bottom-right component (two separate regions)
+
+    detections = Detections(
+        xyxy=np.array([[1, 1, 8, 8]], dtype=np.float32),
+        class_id=np.array([0], dtype=int),
+        mask=np.array([mask]),
+    )
+    annotations, _ = detections_to_coco_annotations(
+        detections=detections, image_id=1, annotation_id=1
+    )
+    assert len(annotations) == 1
+    seg = annotations[0]["segmentation"]
+    assert isinstance(seg, dict), "multi-segment mask must export as RLE dict, not list"
+    assert "counts" in seg
+    assert "size" in seg

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1861,13 +1861,16 @@ def test_detections_to_coco_annotations_exports_all_polygons() -> None:
         xyxy=np.array([[1, 1, 4, 4]], dtype=np.float32),
         class_id=np.array([0], dtype=int),
         mask=np.array([mask]),
+        data={"iscrowd": np.array([0], dtype=int)},
     )
     annotations, _ = detections_to_coco_annotations(
         detections=detections, image_id=1, annotation_id=1
     )
     assert len(annotations) == 1
-    # Both components must appear as separate polygon entries
-    assert len(annotations[0]["segmentation"]) >= 2
+    seg = annotations[0]["segmentation"]
+    # Both components must appear as separate polygon entries (list of lists)
+    assert isinstance(seg, list), "segmentation must be a list of polygons"
+    assert len(seg) >= 2
 
 
 def test_coco_polygon_segmentation_survives_roundtrip(tmp_path) -> None:
@@ -1918,8 +1921,9 @@ def test_coco_polygon_segmentation_survives_roundtrip(tmp_path) -> None:
 
 
 def test_coco_raw_segmentation_preserved_when_masks_not_decoded(tmp_path) -> None:
-    """When masks are decoded, raw polygon data stored in data['segmentation']
-    is used as a lossless fallback so as_coco() still emits non-empty segmentation."""
+    """When masks are NOT decoded (with_masks=False), raw polygon data stored in
+    data['segmentation'] is used as a lossless fallback so as_coco() still emits
+    non-empty segmentation."""
     from supervision.dataset.formats.coco import (
         coco_annotations_to_detections,
         detections_to_coco_annotations,

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1845,3 +1845,111 @@ def test_coco_round_trip_multi_class_single_image(tmp_path) -> None:
     dets = loaded.annotations[img_path]
     assert dets.class_id is not None
     assert sorted(dets.class_id.tolist()) == [0, 1]
+
+
+# --- Regression: segmentation round-trip (#2285) ---
+
+
+def test_detections_to_coco_annotations_exports_all_polygons() -> None:
+    """All polygons from a multi-component mask must be exported, not just the first."""
+    # Build a mask with two separate rectangles (disjoint components)
+    mask = np.zeros((20, 20), dtype=bool)
+    mask[1:4, 1:4] = True   # top-left component
+    mask[14:18, 14:18] = True  # bottom-right component
+
+    detections = Detections(
+        xyxy=np.array([[1, 1, 4, 4]], dtype=np.float32),
+        class_id=np.array([0], dtype=int),
+        mask=np.array([mask]),
+    )
+    annotations, _ = detections_to_coco_annotations(
+        detections=detections, image_id=1, annotation_id=1
+    )
+    assert len(annotations) == 1
+    # Both components must appear as separate polygon entries
+    assert len(annotations[0]["segmentation"]) >= 2
+
+
+def test_coco_polygon_segmentation_survives_roundtrip(tmp_path) -> None:
+    """from_coco() -> as_coco() must preserve polygon segmentation (issue #2285)."""
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+
+    # Create a small image so as_coco can read it
+    img_path = images_dir / "img.jpg"
+    assert cv2.imwrite(str(img_path), np.zeros((10, 10, 3), dtype=np.uint8))
+
+    coco_data = {
+        "info": {},
+        "licenses": [],
+        "categories": [{"id": 1, "name": "cat", "supercategory": ""}],
+        "images": [{"id": 1, "file_name": "img.jpg", "width": 10, "height": 10}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [0, 0, 5, 5],
+                "area": 25,
+                "segmentation": [[0, 0, 4, 0, 4, 4, 0, 4]],
+                "iscrowd": 0,
+            }
+        ],
+    }
+
+    ann_path = tmp_path / "annotations.json"
+    ann_path.write_text(json.dumps(coco_data), encoding="utf-8")
+
+    ds = DetectionDataset.from_coco(
+        images_directory_path=str(images_dir),
+        annotations_path=str(ann_path),
+    )
+
+    out_ann_path = tmp_path / "out_annotations.json"
+    ds.as_coco(annotations_path=str(out_ann_path))
+
+    with open(out_ann_path) as f:
+        out = json.load(f)
+
+    assert len(out["annotations"]) == 1
+    seg = out["annotations"][0]["segmentation"]
+    assert seg != [], "segmentation must not be empty after round-trip (issue #2285)"
+    assert isinstance(seg, list) and len(seg) >= 1
+
+
+def test_coco_raw_segmentation_preserved_when_masks_not_decoded(tmp_path) -> None:
+    """When masks are decoded, raw polygon data stored in data['segmentation']
+    is used as a lossless fallback so as_coco() still emits non-empty segmentation."""
+    from supervision.dataset.formats.coco import (
+        coco_annotations_to_detections,
+        detections_to_coco_annotations,
+    )
+
+    image_annotations = [
+        {
+            "id": 1,
+            "image_id": 1,
+            "category_id": 1,
+            "bbox": [0, 0, 5, 5],
+            "area": 25,
+            "segmentation": [[0, 0, 4, 0, 4, 4, 0, 4]],
+            "iscrowd": 0,
+        }
+    ]
+
+    # Load WITHOUT mask decoding — mask must be None
+    detections = coco_annotations_to_detections(
+        image_annotations=image_annotations,
+        resolution_wh=(10, 10),
+        with_masks=False,
+    )
+    assert detections.mask is None
+    # Raw segmentation must be stored in data for fallback
+    assert "segmentation" in detections.data
+
+    # Export must still produce non-empty segmentation via fallback
+    annotations, _ = detections_to_coco_annotations(
+        detections=detections, image_id=1, annotation_id=1
+    )
+    assert len(annotations) == 1
+    assert annotations[0]["segmentation"] != []

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1936,14 +1936,20 @@ def test_coco_polygon_segmentation_survives_roundtrip(
     area: float,
     expected_min_polygon_count: int,
 ) -> None:
-    """from_coco() -> as_coco() must preserve polygon segmentation."""
+    """COCO polygon segmentation survives the load/export sequence.
+
+    1. Write source COCO JSON with polygon segmentation.
+    2. Load it through DetectionDataset.from_coco().
+    3. Export it back to COCO JSON with as_coco().
+    4. Assert the exported segmentation keeps the expected polygon component count.
+    """
     images_dir = tmp_path / "images"
     images_dir.mkdir()
 
-    # Create a small image so as_coco can read it
     img_path = images_dir / "img.jpg"
     assert cv2.imwrite(str(img_path), np.zeros((10, 10, 3), dtype=np.uint8))
 
+    # 1. Write source COCO JSON with polygon segmentation.
     ann_path = tmp_path / "annotations.json"
     ann_path.write_text(
         json.dumps(
@@ -1956,17 +1962,20 @@ def test_coco_polygon_segmentation_survives_roundtrip(
         encoding="utf-8",
     )
 
+    # 2. Load it through the internal DetectionDataset representation.
     ds = DetectionDataset.from_coco(
         images_directory_path=str(images_dir),
         annotations_path=str(ann_path),
     )
 
+    # 3. Export it back to COCO JSON.
     out_ann_path = tmp_path / "out_annotations.json"
     ds.as_coco(annotations_path=str(out_ann_path))
 
     with open(out_ann_path) as f:
         out = json.load(f)
 
+    # 4. Assert polygon component count survives the load/export sequence.
     assert len(out["annotations"]) == 1
     seg = out["annotations"][0]["segmentation"]
     assert isinstance(seg, list)


### PR DESCRIPTION
Fixes #2285.

**Problem**

`as_coco()` emitted `"segmentation": []` for every annotation even when segmentation data was present. Two bugs:

1. Only the first polygon was exported — `segmentation = [list(polygons[0].flatten())]` silently drops all other polygon components
2. RLE masks were also not exported

**Fix**

- Export all polygons: `[list(p.flatten()) for p in polygons]`
- Export RLE masks via `mask_to_rle_dict`

**Test**

- Round-trip: annotate with known polygons → `as_coco()` → load back → verify segmentation matches
- Both polygon and RLE paths tested