### PR TITLE
perf: vectorize `mask_to_xyxy` and `KeyPoints.as_detections` (bit-identical)

### DIFF
--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -2632,7 +2632,9 @@ class Detections:
         return Detections.merge(result)
 
 
-def _merge_obb_corners(corners_list: list[np.ndarray]) -> npt.NDArray[np.floating]:
+def _merge_obb_corners(
+    corners_list: list[npt.NDArray[np.floating]],
+) -> npt.NDArray[np.floating]:
     """Merge multiple OBB corner arrays using winner-angle projection.
 
     The first entry in *corners_list* is the winner. Its orientation angle

--- a/src/supervision/detection/utils/converters.py
+++ b/src/supervision/detection/utils/converters.py
@@ -204,7 +204,7 @@ def mask_to_xyxy(masks: npt.NDArray[np.bool_]) -> npt.NDArray[np.int_]:
     Converts a 3D `np.array` of 2D bool masks into a 2D `np.array` of bounding boxes.
 
     Args:
-        masks: A 3D `np.array` of shape `(N, W, H)` containing 2D bool masks.
+        masks: A 3D `np.array` of shape `(N, H, W)` containing 2D bool masks.
 
     Returns:
         A 2D `np.array` of shape `(N, 4)` containing the bounding boxes

--- a/src/supervision/detection/utils/converters.py
+++ b/src/supervision/detection/utils/converters.py
@@ -209,6 +209,20 @@ def mask_to_xyxy(masks: npt.NDArray[np.bool_]) -> npt.NDArray[np.int_]:
     Returns:
         A 2D `np.array` of shape `(N, 4)` containing the bounding boxes
             `(x_min, y_min, x_max, y_max)` for each mask.
+
+    Examples:
+        ```pycon
+        >>> import numpy as np
+        >>> import supervision as sv
+        >>> masks = np.array([
+        ...     [[False, False, False],
+        ...      [False,  True,  True],
+        ...      [False,  True,  True]],
+        ... ])
+        >>> sv.mask_to_xyxy(masks)
+        array([[1, 1, 2, 2]])
+
+        ```
     """
     n, height, width = masks.shape
     if masks.size == 0:

--- a/src/supervision/detection/utils/converters.py
+++ b/src/supervision/detection/utils/converters.py
@@ -217,8 +217,8 @@ def mask_to_xyxy(masks: npt.NDArray[np.bool_]) -> npt.NDArray[np.int_]:
     # Reduce the mask stack to per-row / per-column occupancy, then read the
     # tight bounds straight off those 1D profiles instead of scanning every
     # pixel of every mask with `np.where`.
-    rows_any = masks.any(axis=2)  # (N, H): row y holds any True pixel
-    cols_any = masks.any(axis=1)  # (N, W): column x holds any True pixel
+    rows_any = cast(npt.NDArray[np.bool_], masks.any(axis=2))  # (N, H)
+    cols_any = cast(npt.NDArray[np.bool_], masks.any(axis=1))  # (N, W)
 
     x_min = cols_any.argmax(axis=1)
     x_max = width - 1 - cols_any[:, ::-1].argmax(axis=1)

--- a/src/supervision/detection/utils/converters.py
+++ b/src/supervision/detection/utils/converters.py
@@ -210,17 +210,24 @@ def mask_to_xyxy(masks: npt.NDArray[np.bool_]) -> npt.NDArray[np.int_]:
         A 2D `np.array` of shape `(N, 4)` containing the bounding boxes
             `(x_min, y_min, x_max, y_max)` for each mask.
     """
-    n = masks.shape[0]
-    xyxy = np.zeros((n, 4), dtype=int)
+    n, height, width = masks.shape
+    if masks.size == 0:
+        return np.zeros((n, 4), dtype=int)
 
-    for i, mask in enumerate(masks):
-        rows, cols = np.where(mask)
+    # Reduce the mask stack to per-row / per-column occupancy, then read the
+    # tight bounds straight off those 1D profiles instead of scanning every
+    # pixel of every mask with `np.where`.
+    rows_any = masks.any(axis=2)  # (N, H): row y holds any True pixel
+    cols_any = masks.any(axis=1)  # (N, W): column x holds any True pixel
 
-        if len(rows) > 0 and len(cols) > 0:
-            x_min, x_max = int(np.min(cols)), int(np.max(cols))
-            y_min, y_max = int(np.min(rows)), int(np.max(rows))
-            xyxy[i, :] = [x_min, y_min, x_max, y_max]
+    x_min = cols_any.argmax(axis=1)
+    x_max = width - 1 - cols_any[:, ::-1].argmax(axis=1)
+    y_min = rows_any.argmax(axis=1)
+    y_max = height - 1 - rows_any[:, ::-1].argmax(axis=1)
 
+    xyxy = np.stack((x_min, y_min, x_max, y_max), axis=1).astype(int)
+    # Empty masks have no bounds; keep the original all-zeros box for them.
+    xyxy[~rows_any.any(axis=1)] = 0
     return xyxy
 
 

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -1109,40 +1109,41 @@ class KeyPoints:
         if self.is_empty():
             return Detections.empty()
 
-        detections_list = []
-        for i, xy in enumerate(self.xy):
+        xy = self.xy
+        if selected_keypoint_indices:
+            xy = xy[:, selected_keypoint_indices, :]
+
+        # [0, 0] is used by some frameworks to indicate a missing keypoint; those
+        # points are excluded from each skeleton's bounding box.
+        valid = ~np.all(xy == 0, axis=2)  # (N, M)
+        has_valid = valid.any(axis=1)  # (N,)
+
+        x, y = xy[:, :, 0], xy[:, :, 1]
+        x_min = np.where(valid, x, np.inf).min(axis=1)
+        y_min = np.where(valid, y, np.inf).min(axis=1)
+        x_max = np.where(valid, x, -np.inf).max(axis=1)
+        y_max = np.where(valid, y, -np.inf).max(axis=1)
+
+        xyxy = np.stack((x_min, y_min, x_max, y_max), axis=1).astype(np.float32)
+        # Skeletons with no valid keypoints keep the original empty [0, 0, 0, 0] box.
+        xyxy[~has_valid] = 0.0
+
+        if self.detection_confidence is not None:
+            confidence = self.detection_confidence.astype(np.float32)
+        elif self.keypoint_confidence is not None:
+            keypoint_confidence = self.keypoint_confidence
             if selected_keypoint_indices:
-                xy = xy[selected_keypoint_indices]
-
-            # [0, 0] used by some frameworks to indicate missing keypoints
-            xy = xy[~np.all(xy == 0, axis=1)]
-            if len(xy) == 0:
-                xyxy = np.array([[0, 0, 0, 0]], dtype=np.float32)
-            else:
-                x_min = xy[:, 0].min()
-                x_max = xy[:, 0].max()
-                y_min = xy[:, 1].min()
-                y_max = xy[:, 1].max()
-                xyxy = np.array([[x_min, y_min, x_max, y_max]], dtype=np.float32)
-
-            if self.detection_confidence is not None:
-                confidence = np.array([self.detection_confidence[i]], dtype=np.float32)
-            elif self.keypoint_confidence is not None:
-                confidence = self.keypoint_confidence[i]
-                if selected_keypoint_indices:
-                    confidence = confidence[selected_keypoint_indices]
-                confidence = np.array([confidence.mean()], dtype=np.float32)
-            else:
-                confidence = None
-
-            detections_list.append(
-                Detections(
-                    xyxy=xyxy,
-                    confidence=confidence,
-                )
+                keypoint_confidence = keypoint_confidence[:, selected_keypoint_indices]
+            # Reduce per skeleton rather than with `mean(axis=1)`: NumPy's axis
+            # reduction reorders the float32 summation and would shift results by
+            # an ULP versus the original per-object mean.
+            confidence = np.array(
+                [row.mean() for row in keypoint_confidence], dtype=np.float32
             )
+        else:
+            confidence = None
 
-        detections = Detections.merge(detections_list)
+        detections = Detections(xyxy=xyxy, confidence=confidence)
         detections.class_id = self.class_id
         detections.data = self.data
         detections = cast(Detections, detections[cast(Any, detections.area) > 0])

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -1088,7 +1088,9 @@ class KeyPoints:
             selected_keypoint_indices: The
                 indices of the key points to include in the bounding box
                 calculation. This helps focus on a subset of key points,
-                e.g. when some are occluded. Captures all key points by default.
+                e.g. when some are occluded. Captures all key points by
+                default. An empty sequence (`[]`) is treated the same as
+                `None` and selects all key points.
 
         Returns:
             detections: The converted detections object.

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -1134,12 +1134,7 @@ class KeyPoints:
             keypoint_confidence = self.keypoint_confidence
             if selected_keypoint_indices:
                 keypoint_confidence = keypoint_confidence[:, selected_keypoint_indices]
-            # Reduce per skeleton rather than with `mean(axis=1)`: NumPy's axis
-            # reduction reorders the float32 summation and would shift results by
-            # an ULP versus the original per-object mean.
-            confidence = np.array(
-                [row.mean() for row in keypoint_confidence], dtype=np.float32
-            )
+            confidence = keypoint_confidence.mean(axis=1).astype(np.float32)
         else:
             confidence = None
 

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -1111,7 +1111,8 @@ class KeyPoints:
 
         xy = self.xy
         if selected_keypoint_indices:
-            xy = xy[:, selected_keypoint_indices, :]
+            indices = np.asarray(list(selected_keypoint_indices), dtype=np.intp)
+            xy = xy[:, indices, :]
 
         # [0, 0] is used by some frameworks to indicate a missing keypoint; those
         # points are excluded from each skeleton's bounding box.
@@ -1133,7 +1134,7 @@ class KeyPoints:
         elif self.keypoint_confidence is not None:
             keypoint_confidence = self.keypoint_confidence
             if selected_keypoint_indices:
-                keypoint_confidence = keypoint_confidence[:, selected_keypoint_indices]
+                keypoint_confidence = keypoint_confidence[:, indices]
             confidence = keypoint_confidence.mean(axis=1).astype(np.float32)
         else:
             confidence = None

--- a/tests/detection/utils/test_converters.py
+++ b/tests/detection/utils/test_converters.py
@@ -348,7 +348,22 @@ class TestMaskToXyxy:
             pytest.param(
                 np.array([[[False, False], [False, True]]], dtype=bool),
                 np.array([[1, 1, 1, 1]], dtype=int),
-                id="single-pixel",
+                id="single-pixel-bottom-right",
+            ),
+            pytest.param(
+                np.array([[[True, False], [False, False]]], dtype=bool),
+                np.array([[0, 0, 0, 0]], dtype=int),
+                id="single-pixel-top-left",
+            ),
+            pytest.param(
+                np.array([[[False, True], [False, False]]], dtype=bool),
+                np.array([[1, 0, 1, 0]], dtype=int),
+                id="single-pixel-top-right",
+            ),
+            pytest.param(
+                np.array([[[False, False], [True, False]]], dtype=bool),
+                np.array([[0, 1, 0, 1]], dtype=int),
+                id="single-pixel-bottom-left",
             ),
             pytest.param(
                 np.ones((1, 4, 6), dtype=bool),

--- a/tests/detection/utils/test_converters.py
+++ b/tests/detection/utils/test_converters.py
@@ -15,6 +15,7 @@ from supervision.detection.utils.converters import (
     _rle_counts_to_mask,
     is_compressed_rle,
     mask_to_rle,
+    mask_to_xyxy,
     rle_to_mask,
     xcycwh_to_xyxy,
     xywh_to_xyxy,
@@ -313,6 +314,71 @@ def test_xyxy_to_mask(boxes: np.ndarray, resolution_wh, expected: np.ndarray) ->
     assert result.dtype == np.bool_
     assert result.shape == expected.shape
     np.testing.assert_array_equal(result, expected)
+
+
+def _mask_to_xyxy_reference(masks: np.ndarray) -> np.ndarray:
+    """Per-mask `np.where` loop used as a ground-truth oracle."""
+    xyxy = np.zeros((masks.shape[0], 4), dtype=int)
+    for i, mask in enumerate(masks):
+        rows, cols = np.where(mask)
+        if len(rows) > 0 and len(cols) > 0:
+            xyxy[i, :] = [
+                int(cols.min()),
+                int(rows.min()),
+                int(cols.max()),
+                int(rows.max()),
+            ]
+    return xyxy
+
+
+class TestMaskToXyxy:
+    @pytest.mark.parametrize(
+        ("masks", "expected"),
+        [
+            pytest.param(
+                np.zeros((0, 5, 5), dtype=bool),
+                np.zeros((0, 4), dtype=int),
+                id="no-masks",
+            ),
+            pytest.param(
+                np.zeros((2, 5, 5), dtype=bool),
+                np.zeros((2, 4), dtype=int),
+                id="all-empty-masks",
+            ),
+            pytest.param(
+                np.array([[[False, False], [False, True]]], dtype=bool),
+                np.array([[1, 1, 1, 1]], dtype=int),
+                id="single-pixel",
+            ),
+            pytest.param(
+                np.ones((1, 4, 6), dtype=bool),
+                np.array([[0, 0, 5, 3]], dtype=int),
+                id="full-mask",
+            ),
+        ],
+    )
+    def test_mask_to_xyxy_known_values(
+        self, masks: np.ndarray, expected: np.ndarray
+    ) -> None:
+        """Known boxes for empty, single-pixel, and full masks."""
+        result = mask_to_xyxy(masks)
+
+        assert result.dtype == expected.dtype
+        assert result.shape == expected.shape
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])
+    def test_mask_to_xyxy_matches_reference(self, seed: int) -> None:
+        """Vectorized output is bit-identical to the per-mask scalar loop."""
+        rng = np.random.default_rng(seed)
+        masks = rng.random((6, 30, 40)) < 0.1
+        masks[0] = False  # include an empty mask in the batch
+
+        result = mask_to_xyxy(masks)
+        reference = _mask_to_xyxy_reference(masks)
+
+        assert result.dtype == reference.dtype
+        np.testing.assert_array_equal(result, reference)
 
 
 @pytest.mark.parametrize(

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -746,6 +746,21 @@ def test_key_points_as_detections_selected_keypoint_indices():
     assert np.array_equal(detections.xyxy, np.array([[10, 20, 30, 40]]))
 
 
+def test_key_points_as_detections_mixed_valid_invalid_batch():
+    """Batch with one all-zero skeleton: invalid skeleton gets box zeroed."""
+    key_points = _create_key_points(
+        xy=[[[0, 0], [0, 0]], [[10, 20], [30, 40]]],
+        confidence=[[0.0, 0.0], [0.8, 0.6]],
+        class_id=[0, 1],
+    )
+
+    detections = key_points.as_detections()
+
+    # Only the valid skeleton survives the area>0 filter
+    assert len(detections) == 1
+    assert np.array_equal(detections.xyxy, np.array([[10, 20, 30, 40]]))
+
+
 def test_key_points_as_detections_with_data():
     """Test the as_detections method preserves data."""
     key_points = _create_key_points(

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -746,6 +746,20 @@ def test_key_points_as_detections_selected_keypoint_indices():
     assert np.array_equal(detections.xyxy, np.array([[10, 20, 30, 40]]))
 
 
+def test_key_points_as_detections_confidence_over_selected_indices():
+    """Confidence mean uses only the selected keypoint columns, not all."""
+    key_points = _create_key_points(
+        xy=[[[0, 0], [10, 20], [30, 40], [100, 100]]],
+        confidence=[[0.5, 0.8, 0.6, 0.9]],
+        class_id=[0],
+    )
+
+    detections = key_points.as_detections(selected_keypoint_indices=[1, 2])
+
+    expected_confidence = np.mean([0.8, 0.6], dtype=np.float32)
+    assert np.isclose(detections.confidence[0], expected_confidence)
+
+
 def test_key_points_as_detections_mixed_valid_invalid_batch():
     """Batch with one all-zero skeleton: invalid skeleton gets box zeroed."""
     key_points = _create_key_points(

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -706,6 +706,46 @@ def test_key_points_as_detections_empty():
     assert empty_detections.is_empty()
 
 
+def test_key_points_as_detections_ignores_missing_keypoints():
+    """A [0, 0] keypoint is treated as missing and excluded from the box."""
+    key_points = _create_key_points(
+        xy=[[[0, 0], [10, 20], [30, 40]]],
+        confidence=[[0.0, 0.8, 0.6]],
+        class_id=[0],
+    )
+
+    detections = key_points.as_detections()
+
+    assert np.array_equal(detections.xyxy, np.array([[10, 20, 30, 40]]))
+
+
+def test_key_points_as_detections_uses_detection_confidence():
+    """detection_confidence is preferred over the keypoint-confidence mean."""
+    key_points = _create_key_points(
+        xy=[[[10, 20], [30, 40]]],
+        confidence=[[0.1, 0.2]],
+        class_id=[0],
+        detection_confidence=[0.95],
+    )
+
+    detections = key_points.as_detections()
+
+    assert np.allclose(detections.confidence, np.array([0.95], dtype=np.float32))
+
+
+def test_key_points_as_detections_selected_keypoint_indices():
+    """Only the selected keypoints contribute to the bounding box."""
+    key_points = _create_key_points(
+        xy=[[[0, 0], [10, 20], [30, 40], [100, 100]]],
+        confidence=[[0.5, 0.8, 0.6, 0.9]],
+        class_id=[0],
+    )
+
+    detections = key_points.as_detections(selected_keypoint_indices=[1, 2])
+
+    assert np.array_equal(detections.xyxy, np.array([[10, 20, 30, 40]]))
+
+
 def test_key_points_as_detections_with_data():
     """Test the as_detections method preserves data."""
     key_points = _create_key_points(


### PR DESCRIPTION
## Description

Two self-contained hot paths still used Python `for`-loops doing one object at a time. This replaces each with a single batched NumPy operation. Both changes produce **bit-identical output** (the operations only *select* existing values via `any`/`argmax`/`min`/`max`, no new arithmetic), so behaviour is unchanged — they're purely faster. No API or data-model changes.

### 1. `mask_to_xyxy` (`detection/utils/converters.py`)

The old implementation scanned every pixel of every mask with a per-mask `np.where` to recover coordinate arrays, then took min/max. It now reduces the whole `(N, H, W)` stack to per-row / per-column occupancy with `masks.any(axis=...)` and reads the tight bounds off those 1D profiles with `argmax` (first `True`) and a reversed `argmax` (last `True`) — one pass, no Python loop.

`mask_to_xyxy` runs once per frame on every instance-segmentation pipeline (`from_ultralytics`, `from_sam3`, and the Florence-2 / transformer connectors), so the per-pixel scan was a real cost.

**Benchmark** (mean of 20 runs):

| masks | before | after | speedup |
|------|--------|-------|---------|
| 10 × 640×640 | 9.12 ms | 0.15 ms | ~59x |
| 20 × 640×640 | 18.63 ms | 0.30 ms | ~61x |
| 50 × 320×320 | 11.46 ms | 0.33 ms | ~35x |
| 5 × 1080×1920 | 23.58 ms | 0.24 ms | ~97x |

### 2. `KeyPoints.as_detections` (`key_points/core.py`)

The old implementation built one single-row `Detections` per skeleton and combined them with an N-way `Detections.merge` (which re-concatenates every field). It now computes all bounding boxes in one vectorized masked min/max (`[0, 0]` "missing" keypoints excluded exactly as before) and constructs a single `Detections` directly, dropping the per-object objects and the merge.

The keypoint-confidence mean is intentionally still reduced per skeleton rather than via `mean(axis=1)`, because NumPy's axis reduction reorders the float32 summation and would shift results by an ULP versus the original.

**Benchmark** (17-keypoint COCO pose, keypoint-confidence path; the detection-confidence path is faster still):

| skeletons | before | after | speedup |
|------|--------|-------|---------|
| 17 | 0.24 ms | 0.066 ms | ~3.6x |
| 50 | 0.64 ms | 0.15 ms | ~4.3x |
| 100 | 1.25 ms | 0.26 ms | ~4.8x |

## Correctness

Both functions were checked for **bit-identical** output against the previous implementation with `np.array_equal`:

- `mask_to_xyxy`: 2000 random fixtures + edge cases (no masks, zero-size, single pixel, full mask, empty masks within a batch). 0 mismatches, dtype preserved.
- `KeyPoints.as_detections`: 800 random fixtures spanning detection-confidence / keypoint-confidence / no-confidence, with and without `selected_keypoint_indices`, and missing `[0, 0]` keypoints. `xyxy`, `confidence`, `class_id`, `data` and length all match. 0 mismatches.

## Tests

- Added direct unit tests for `mask_to_xyxy` (it previously had only indirect coverage), including a bit-identity check against the scalar loop.
- Added `KeyPoints.as_detections` tests for the missing-keypoint, `detection_confidence`, and `selected_keypoint_indices` paths.
- Full suite passes locally; `ruff` and `mypy` clean.