### PR TITLE
fix(metrics): count false positives on background images and absent classes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ date_modified: 2026-06-15
 
 - Fixed [#2322](https://github.com/roboflow/supervision/pull/2322): COCO export now preserves all polygon parts for multi-component masks. Previously, only the first polygon was written when a non-crowd mask had disjoint segments; all parts are now included.
 
+- Fixed [#2331](https://github.com/roboflow/supervision/pull/2331): `sv.Precision` and `sv.F1Score` now count predictions on background images (empty target set) as false positives, and count predictions of classes absent from ground truth as false positives under `MICRO` and `MACRO` averaging. Previously both edge cases were silently ignored, inflating scores. `WEIGHTED` averaging is unchanged — absent classes retain weight 0, consistent with scikit-learn. Users relying on previous scores should re-evaluate after upgrading; no API change is required.
+
 ### 0.29.0 <small>Jun 15, 2026</small>
 
 - Added [#2277](https://github.com/roboflow/supervision/pull/2277), [#2286](https://github.com/roboflow/supervision/pull/2286): [`sv.VertexEllipseAreaAnnotator`](https://supervision.roboflow.com/0.29.0/keypoint/annotators/#supervision.key_points.annotators.VertexEllipseAreaAnnotator), [`sv.VertexEllipseOutlineAnnotator`](https://supervision.roboflow.com/0.29.0/keypoint/annotators/#supervision.key_points.annotators.VertexEllipseOutlineAnnotator), and [`sv.VertexEllipseHaloAnnotator`](https://supervision.roboflow.com/0.29.0/keypoint/annotators/#supervision.key_points.annotators.VertexEllipseHaloAnnotator) for visualizing keypoint uncertainty as covariance ellipses. Requires models that output keypoint uncertainty (e.g. RF-DETR keypoint models).

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -159,7 +159,18 @@ class F1Score(Metric):
             prediction_contents = self._detections_content(predictions)
             target_contents = self._detections_content(targets)
 
-            if len(targets) > 0:
+            if len(targets) == 0 and len(predictions) > 0:
+                # Only predictions are present (e.g. a background image); every
+                # prediction is a false positive.
+                stats.append(
+                    (
+                        np.zeros((len(predictions), iou_thresholds.size), dtype=bool),
+                        predictions.confidence,
+                        predictions.class_id,
+                        np.zeros((0,), dtype=int),
+                    )
+                )
+            elif len(targets) > 0:
                 if len(predictions) == 0:
                     stats.append(
                         (
@@ -247,7 +258,15 @@ class F1Score(Metric):
         sorted_indices = np.argsort(-prediction_confidence)
         matches = matches[sorted_indices]
         prediction_class_ids = prediction_class_ids[sorted_indices]
-        unique_classes, class_counts = np.unique(true_class_ids, return_counts=True)
+        # Predictions whose class never appears in the ground truth are still
+        # false positives, so include those classes in the confusion matrix
+        # (their true-instance count is zero).
+        unique_classes = np.unique(
+            np.concatenate((true_class_ids, prediction_class_ids))
+        )
+        true_classes, true_counts = np.unique(true_class_ids, return_counts=True)
+        class_counts = np.zeros(unique_classes.shape[0], dtype=int)
+        class_counts[np.searchsorted(unique_classes, true_classes)] = true_counts
 
         # Shape: PxTh,P,C,C -> CxThx3
         confusion_matrix = self._compute_confusion_matrix(
@@ -265,7 +284,13 @@ class F1Score(Metric):
             f1_scores = self._compute_f1(confusion_matrix_merged)
         elif self.averaging_method == AveragingMethod.WEIGHTED:
             class_counts = class_counts.astype(np.float32)
-            f1_scores = np.average(f1_per_class, axis=0, weights=class_counts)
+            if class_counts.sum() == 0:
+                # No ground-truth support (e.g. only false-positive classes, or a
+                # size bucket with predictions but no targets): weighting is
+                # undefined, so report 0 as the empty case did before.
+                f1_scores = np.zeros(f1_per_class.shape[1])
+            else:
+                f1_scores = np.average(f1_per_class, axis=0, weights=class_counts)
 
         return f1_scores, f1_per_class, unique_classes
 

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -162,12 +162,16 @@ class F1Score(Metric):
             if len(targets) == 0 and len(predictions) > 0:
                 # Only predictions are present (e.g. a background image); every
                 # prediction is a false positive.
+                if predictions.class_id is None or predictions.confidence is None:
+                    continue
                 stats.append(
                     (
-                        np.zeros((len(predictions), iou_thresholds.size), dtype=bool),
+                        np.zeros(
+                            (len(predictions), iou_thresholds.size), dtype=np.bool_
+                        ),
                         predictions.confidence,
                         predictions.class_id,
-                        np.zeros((0,), dtype=int),
+                        np.zeros((0,), dtype=np.int32),
                     )
                 )
             elif len(targets) > 0:

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -152,6 +152,14 @@ class F1Score(Metric):
     def _compute(
         self, predictions_list: list[Detections], targets_list: list[Detections]
     ) -> F1ScoreResult:
+        """Build per-image stats tuples and delegate to class-level computation.
+
+        Each stats tuple is ``(matches, confidence, class_ids, true_class_ids)``:
+        - Both empty: skip (no information).
+        - Targets empty, predictions present: all predictions are FPs; true_class_ids
+          is ``zeros((0,))``.
+        - Targets present: IoU matching produces ``matches`` array.
+        """
         iou_thresholds = np.linspace(0.5, 0.95, 10)
         stats: list[Any] = []
 
@@ -259,6 +267,11 @@ class F1Score(Metric):
         npt.NDArray[np.float64],
         npt.NDArray[np.int32],
     ]:
+        """Compute F1 scores from concatenated stats across all images.
+
+        ``unique_classes`` is the union of GT and predicted classes so that
+        predictions of classes absent from GT still count as false positives.
+        """
         sorted_indices = np.argsort(-prediction_confidence)
         matches = matches[sorted_indices]
         prediction_class_ids = prediction_class_ids[sorted_indices]
@@ -512,10 +525,12 @@ class F1ScoreResult:
         f1_scores: the F1 scores at each IoU threshold.
             Shape: `(num_iou_thresholds,)`
         f1_per_class: the F1 scores per class and IoU threshold.
-            Shape: `(num_target_classes, num_iou_thresholds)`
+            Shape: `(num_classes, num_iou_thresholds)`
         iou_thresholds: the IoU thresholds used in the calculations.
-        matched_classes: the class IDs of all matched classes.
-            Corresponds to the rows of `f1_per_class`.
+        matched_classes: the class IDs present in either predictions or ground
+            truth. Corresponds to the rows of `f1_per_class`. Classes that
+            appear only in predictions (no ground-truth instances) are
+            included; their per-threshold F1 values will be `0.0`.
         small_objects: the F1 metric results
             for small objects (area < 32²).
         medium_objects: the F1 metric results

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -155,6 +155,14 @@ class Precision(Metric):
     def _compute(
         self, predictions_list: list[Detections], targets_list: list[Detections]
     ) -> PrecisionResult:
+        """Build per-image stats tuples and delegate to class-level computation.
+
+        Each stats tuple is ``(matches, confidence, class_ids, true_class_ids)``:
+        - Both empty: skip (no information).
+        - Targets empty, predictions present: all predictions are FPs; true_class_ids
+          is ``zeros((0,))``.
+        - Targets present: IoU matching produces ``matches`` array.
+        """
         iou_thresholds = np.linspace(0.5, 0.95, 10)
         stats: list[Any] = []
 
@@ -262,6 +270,11 @@ class Precision(Metric):
         npt.NDArray[np.float64],
         npt.NDArray[np.int32],
     ]:
+        """Compute precision scores from concatenated stats across all images.
+
+        ``unique_classes`` is the union of GT and predicted classes so that
+        predictions of classes absent from GT still count as false positives.
+        """
         sorted_indices = np.argsort(-prediction_confidence)
         matches = matches[sorted_indices]
         prediction_class_ids = prediction_class_ids[sorted_indices]
@@ -457,8 +470,6 @@ class Precision(Metric):
 
         raise ValueError(f"Invalid metric target: {self._metric_target}")
 
-        raise ValueError(f"Invalid metric target: {self._metric_target}")
-
     def _filter_detections_by_size(
         self, detections: Detections, size_category: ObjectSizeCategory
     ) -> Detections:
@@ -523,10 +534,12 @@ class PrecisionResult:
         precision_scores: the precision scores at each IoU threshold.
             Shape: `(num_iou_thresholds,)`
         precision_per_class: the precision scores per class and
-            IoU threshold. Shape: `(num_target_classes, num_iou_thresholds)`
+            IoU threshold. Shape: `(num_classes, num_iou_thresholds)`
         iou_thresholds: the IoU thresholds used in the calculations.
-        matched_classes: the class IDs of all matched classes.
-            Corresponds to the rows of `precision_per_class`.
+        matched_classes: the class IDs present in either predictions or ground
+            truth. Corresponds to the rows of `precision_per_class`. Classes
+            that appear only in predictions (no ground-truth instances) are
+            included; their per-threshold precision values will be `0.0`.
         small_objects: the Precision metric results
             for small objects (area < 32²).
         medium_objects: the Precision metric results

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -162,7 +162,18 @@ class Precision(Metric):
             prediction_contents = self._detections_content(predictions)
             target_contents = self._detections_content(targets)
 
-            if len(targets) > 0:
+            if len(targets) == 0 and len(predictions) > 0:
+                # Only predictions are present (e.g. a background image); every
+                # prediction is a false positive.
+                stats.append(
+                    (
+                        np.zeros((len(predictions), iou_thresholds.size), dtype=bool),
+                        predictions.confidence,
+                        predictions.class_id,
+                        np.zeros((0,), dtype=int),
+                    )
+                )
+            elif len(targets) > 0:
                 if len(predictions) == 0:
                     stats.append(
                         (
@@ -250,7 +261,15 @@ class Precision(Metric):
         sorted_indices = np.argsort(-prediction_confidence)
         matches = matches[sorted_indices]
         prediction_class_ids = prediction_class_ids[sorted_indices]
-        unique_classes, class_counts = np.unique(true_class_ids, return_counts=True)
+        # Predictions whose class never appears in the ground truth are still
+        # false positives, so include those classes in the confusion matrix
+        # (their true-instance count is zero).
+        unique_classes = np.unique(
+            np.concatenate((true_class_ids, prediction_class_ids))
+        )
+        true_classes, true_counts = np.unique(true_class_ids, return_counts=True)
+        class_counts = np.zeros(unique_classes.shape[0], dtype=int)
+        class_counts[np.searchsorted(unique_classes, true_classes)] = true_counts
 
         # Shape: PxTh,P,C,C -> CxThx3
         confusion_matrix = self._compute_confusion_matrix(
@@ -268,9 +287,15 @@ class Precision(Metric):
             precision_scores = self._compute_precision(confusion_matrix_merged)
         elif self.averaging_method == AveragingMethod.WEIGHTED:
             class_counts = class_counts.astype(np.float32)
-            precision_scores = np.average(
-                precision_per_class, axis=0, weights=class_counts
-            )
+            if class_counts.sum() == 0:
+                # No ground-truth support (e.g. only false-positive classes, or a
+                # size bucket with predictions but no targets): weighting is
+                # undefined, so report 0 as the empty case did before.
+                precision_scores = np.zeros(precision_per_class.shape[1])
+            else:
+                precision_scores = np.average(
+                    precision_per_class, axis=0, weights=class_counts
+                )
 
         return precision_scores, precision_per_class, unique_classes
 

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -165,12 +165,16 @@ class Precision(Metric):
             if len(targets) == 0 and len(predictions) > 0:
                 # Only predictions are present (e.g. a background image); every
                 # prediction is a false positive.
+                if predictions.class_id is None or predictions.confidence is None:
+                    continue
                 stats.append(
                     (
-                        np.zeros((len(predictions), iou_thresholds.size), dtype=bool),
+                        np.zeros(
+                            (len(predictions), iou_thresholds.size), dtype=np.bool_
+                        ),
                         predictions.confidence,
                         predictions.class_id,
-                        np.zeros((0,), dtype=int),
+                        np.zeros((0,), dtype=np.int32),
                     )
                 )
             elif len(targets) > 0:

--- a/tests/metrics/test_f1_score.py
+++ b/tests/metrics/test_f1_score.py
@@ -149,9 +149,27 @@ class TestF1Score:
 
         # TP=1, FP=3, FN=0 -> F1 = 2*1 / (2*1 + 3 + 0) = 0.4
         assert result.f1_50 == pytest.approx(0.4)
+        assert 0 in result.matched_classes
 
-    def test_false_positives_of_absent_class_counted(self):
-        """Predictions of a class with no ground truth must count as false positives."""
+    @pytest.mark.parametrize(
+        ("method", "expected"),
+        [
+            pytest.param(
+                AveragingMethod.MICRO, 0.5, id="micro-counts-absent-class-fps"
+            ),
+            pytest.param(
+                AveragingMethod.MACRO, 0.5, id="macro-counts-absent-class-fps"
+            ),
+            pytest.param(
+                AveragingMethod.WEIGHTED,
+                1.0,
+                id="weighted-absent-class-fps-not-counted-by-design",
+            ),
+        ],
+    )
+    def test_false_positives_of_absent_class_counted(self, method, expected):
+        """Predictions of absent class count as FPs under MICRO/MACRO; WEIGHTED
+        excludes them by design (GT support=0 → weight=0, consistent with sklearn)."""
         predictions = Detections(
             xyxy=np.array(
                 [[0, 0, 10, 10], [100, 0, 110, 10], [120, 0, 130, 10]], np.float32
@@ -164,11 +182,27 @@ class TestF1Score:
             class_id=np.array([0]),
         )
 
-        metric = F1Score(averaging_method=AveragingMethod.MICRO)
+        metric = F1Score(averaging_method=method)
         result = metric.update(predictions, targets).compute()
 
-        # TP=1, FP=2, FN=0 -> F1 = 2*1 / (2*1 + 2 + 0) = 0.5
-        assert result.f1_50 == pytest.approx(0.5)
+        # MICRO: TP=1, FP=2, FN=0 -> F1 = 2/(2+2) = 0.5
+        # MACRO: mean([F1_class0=1.0, F1_class1=0.0]) = 0.5
+        # WEIGHTED: class_1 weight=0 -> only class 0 contributes -> 1.0
+        assert result.f1_50 == pytest.approx(expected)
+
+    def test_false_positives_on_background_image_weighted_returns_zero(self):
+        """WEIGHTED F1 is 0.0 when all images are background (no GT anywhere)."""
+        background_predictions = Detections(
+            xyxy=np.array([[20, 0, 25, 5], [40, 0, 45, 5]], np.float32),
+            class_id=np.array([0, 0]),
+            confidence=np.array([0.9, 0.8]),
+        )
+
+        metric = F1Score(averaging_method=AveragingMethod.WEIGHTED)
+        result = metric.update(background_predictions, Detections.empty()).compute()
+
+        # No GT support anywhere -> class_counts.sum() == 0 -> returns 0.0
+        assert result.f1_50 == 0.0
 
     def test_single_class_mixed_results(
         self, predictions_confidence_ranking, targets_50_50

--- a/tests/metrics/test_f1_score.py
+++ b/tests/metrics/test_f1_score.py
@@ -124,6 +124,52 @@ class TestF1Score:
         assert result.f1_50 == 0.0
         assert result.f1_75 == 0.0
 
+    def test_false_positives_on_background_image_counted(self):
+        """Predictions on an image with no targets must count as false positives."""
+        predictions_with_gt = Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+            class_id=np.array([0]),
+            confidence=np.array([0.9]),
+        )
+        targets_with_gt = Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+            class_id=np.array([0]),
+        )
+        background_predictions = Detections(
+            xyxy=np.array([[20, 0, 25, 5], [40, 0, 45, 5], [60, 0, 65, 5]], np.float32),
+            class_id=np.array([0, 0, 0]),
+            confidence=np.array([0.9, 0.9, 0.9]),
+        )
+
+        metric = F1Score(averaging_method=AveragingMethod.MICRO)
+        result = metric.update(
+            [predictions_with_gt, background_predictions],
+            [targets_with_gt, Detections.empty()],
+        ).compute()
+
+        # TP=1, FP=3, FN=0 -> F1 = 2*1 / (2*1 + 3 + 0) = 0.4
+        assert result.f1_50 == pytest.approx(0.4)
+
+    def test_false_positives_of_absent_class_counted(self):
+        """Predictions of a class with no ground truth must count as false positives."""
+        predictions = Detections(
+            xyxy=np.array(
+                [[0, 0, 10, 10], [100, 0, 110, 10], [120, 0, 130, 10]], np.float32
+            ),
+            class_id=np.array([0, 1, 1]),  # class 1 never appears in the targets
+            confidence=np.array([0.9, 0.8, 0.7]),
+        )
+        targets = Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+            class_id=np.array([0]),
+        )
+
+        metric = F1Score(averaging_method=AveragingMethod.MICRO)
+        result = metric.update(predictions, targets).compute()
+
+        # TP=1, FP=2, FN=0 -> F1 = 2*1 / (2*1 + 2 + 0) = 0.5
+        assert result.f1_50 == pytest.approx(0.5)
+
     def test_single_class_mixed_results(
         self, predictions_confidence_ranking, targets_50_50
     ):

--- a/tests/metrics/test_precision.py
+++ b/tests/metrics/test_precision.py
@@ -115,6 +115,52 @@ class TestPrecision:
         assert result.precision_at_50 == 0.0
         assert result.precision_at_75 == 0.0
 
+    def test_false_positives_on_background_image_counted(self):
+        """Predictions on an image with no targets must count as false positives."""
+        predictions_with_gt = Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+            class_id=np.array([0]),
+            confidence=np.array([0.9]),
+        )
+        targets_with_gt = Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+            class_id=np.array([0]),
+        )
+        background_predictions = Detections(
+            xyxy=np.array([[20, 0, 25, 5], [40, 0, 45, 5], [60, 0, 65, 5]], np.float32),
+            class_id=np.array([0, 0, 0]),
+            confidence=np.array([0.9, 0.9, 0.9]),
+        )
+
+        metric = Precision(averaging_method=AveragingMethod.MICRO)
+        result = metric.update(
+            [predictions_with_gt, background_predictions],
+            [targets_with_gt, Detections.empty()],
+        ).compute()
+
+        # 1 TP, 3 background FPs -> precision = 1 / (1 + 3) = 0.25
+        assert result.precision_at_50 == 0.25
+
+    def test_false_positives_of_absent_class_counted(self):
+        """Predictions of a class with no ground truth must count as false positives."""
+        predictions = Detections(
+            xyxy=np.array(
+                [[0, 0, 10, 10], [100, 0, 110, 10], [120, 0, 130, 10]], np.float32
+            ),
+            class_id=np.array([0, 1, 1]),  # class 1 never appears in the targets
+            confidence=np.array([0.9, 0.8, 0.7]),
+        )
+        targets = Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+            class_id=np.array([0]),
+        )
+
+        metric = Precision(averaging_method=AveragingMethod.MICRO)
+        result = metric.update(predictions, targets).compute()
+
+        # 1 TP (class 0), 2 FPs (class 1, no GT) -> precision = 1 / (1 + 2)
+        assert result.precision_at_50 == pytest.approx(1 / 3)
+
     def test_single_class(self, predictions_confidence_ranking, targets_50_50):
         """Test precision calculation for single class with mixed results"""
         metric = Precision()

--- a/tests/metrics/test_precision.py
+++ b/tests/metrics/test_precision.py
@@ -140,9 +140,27 @@ class TestPrecision:
 
         # 1 TP, 3 background FPs -> precision = 1 / (1 + 3) = 0.25
         assert result.precision_at_50 == 0.25
+        assert 0 in result.matched_classes
 
-    def test_false_positives_of_absent_class_counted(self):
-        """Predictions of a class with no ground truth must count as false positives."""
+    @pytest.mark.parametrize(
+        ("method", "expected"),
+        [
+            pytest.param(
+                AveragingMethod.MICRO, 1 / 3, id="micro-counts-absent-class-fps"
+            ),
+            pytest.param(
+                AveragingMethod.MACRO, 0.5, id="macro-counts-absent-class-fps"
+            ),
+            pytest.param(
+                AveragingMethod.WEIGHTED,
+                1.0,
+                id="weighted-absent-class-fps-not-counted-by-design",
+            ),
+        ],
+    )
+    def test_false_positives_of_absent_class_counted(self, method, expected):
+        """Predictions of absent class count as FPs under MICRO/MACRO; WEIGHTED
+        excludes them by design (GT support=0 → weight=0, consistent with sklearn)."""
         predictions = Detections(
             xyxy=np.array(
                 [[0, 0, 10, 10], [100, 0, 110, 10], [120, 0, 130, 10]], np.float32
@@ -155,11 +173,27 @@ class TestPrecision:
             class_id=np.array([0]),
         )
 
-        metric = Precision(averaging_method=AveragingMethod.MICRO)
+        metric = Precision(averaging_method=method)
         result = metric.update(predictions, targets).compute()
 
-        # 1 TP (class 0), 2 FPs (class 1, no GT) -> precision = 1 / (1 + 2)
-        assert result.precision_at_50 == pytest.approx(1 / 3)
+        # MICRO: 1 TP (class 0), 2 FPs (class 1) -> 1/3
+        # MACRO: mean([precision_class0=1.0, precision_class1=0.0]) = 0.5
+        # WEIGHTED: class_1 weight=0 -> only class 0 contributes -> 1.0
+        assert result.precision_at_50 == pytest.approx(expected)
+
+    def test_false_positives_on_background_image_weighted_returns_zero(self):
+        """WEIGHTED precision is 0.0 when all images are background (no GT anywhere)."""
+        background_predictions = Detections(
+            xyxy=np.array([[20, 0, 25, 5], [40, 0, 45, 5]], np.float32),
+            class_id=np.array([0, 0]),
+            confidence=np.array([0.9, 0.8]),
+        )
+
+        metric = Precision(averaging_method=AveragingMethod.WEIGHTED)
+        result = metric.update(background_predictions, Detections.empty()).compute()
+
+        # No GT support anywhere -> class_counts.sum() == 0 -> returns 0.0
+        assert result.precision_at_50 == 0.0
 
     def test_single_class(self, predictions_confidence_ranking, targets_50_50):
         """Test precision calculation for single class with mixed results"""


### PR DESCRIPTION
## Description

`Precision` and `F1Score` silently drop predictions in two situations, which **inflates the reported score**:

1. **Background images** — an image that has predictions but **no ground truth** is skipped entirely (`if len(targets) > 0:`), so its predictions are never counted as false positives.
2. **Hallucinated classes** — predictions whose class never appears in *any* ground truth are dropped, because the confusion matrix is built only from ground-truth classes (`np.unique(true_class_ids)`). Even `MICRO` averaging (a global TP/FP count) is affected.

### This is a bug, not intended behavior

The library's own test documents the intended semantics — `tests/metrics/test_precision.py::test_empty_targets`:

> All predictions are false positives → TP = 0, FP = 1 → precision = 0 / 1 = **0.0**

That test passes today only *by accident*: with a single target-less image, `stats` ends up empty and `_compute` returns the all-zeros default. Add a second image with one true positive and the dropped false positives surface:

```python
import numpy as np, supervision as sv
from supervision.metrics import Precision
from supervision.metrics.core import AveragingMethod

pred_a = sv.Detections(np.array([[0,0,10,10]],float), class_id=np.array([0]), confidence=np.array([0.9]))
gt_a   = sv.Detections(np.array([[0,0,10,10]],float), class_id=np.array([0]))
bg     = sv.Detections(np.array([[20,0,25,5],[40,0,45,5],[60,0,65,5]],float),
                       class_id=np.array([0,0,0]), confidence=np.array([0.9,0.9,0.9]))

r = Precision(averaging_method=AveragingMethod.MICRO).update([pred_a, bg], [gt_a, sv.Detections.empty()]).compute()
print(r.precision_at_50)   # before: 1.0   after: 0.25  (1 TP, 3 FP)
```

## Fix

- Process images that have predictions even when they have no targets — every such prediction is a false positive.
- Build the confusion-matrix class set from the **union** of ground-truth and predicted classes. The existing `num_true == 0` branch in `_compute_confusion_matrix` already scores those as pure false positives; it was simply never reached.
- Guard `WEIGHTED` averaging against zero total support (returning `0`, as the empty case did before). This also fixes a latent `ZeroDivisionError` in the by-size breakdown when a size bucket contains predictions but no targets of that size.

Minimal change — the existing matching block is untouched; the diff just adds the false-positive branch and the class union.

## Notes on averaging semantics

- **MICRO** and **MACRO** now correctly reflect false positives from background images and absent classes.
- **WEIGHTED** still weights each class by its ground-truth support, so a false-positive-only class (support 0) legitimately does not move the weighted score — consistent with `sklearn`'s weighted precision. Use `MICRO`/`MACRO` to see those false positives.
- **`Recall` is intentionally left unchanged**: false positives do not enter recall, and target-less images / absent classes contribute no recall, so its identical-looking guard is already correct.

## Tests

Adds regression tests to both `Precision` and `F1Score` for (a) false positives on a background image and (b) false positives of a class with no ground truth. Both fail on `develop` and pass with this change. Full test suite, `ruff`, and `mypy` pass locally.