### PR TITLE
fix(smoother): handle detections without confidence

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,12 @@ date_modified: 2026-06-15
 
 - Fixed [#2322](https://github.com/roboflow/supervision/pull/2322): COCO export now preserves all polygon parts for multi-component masks. Previously, only the first polygon was written when a non-crowd mask had disjoint segments; all parts are now included.
 
+- Fixed [#2333](https://github.com/roboflow/supervision/pull/2333):
+  [`sv.DetectionsSmoother`](https://supervision.roboflow.com/latest/detection/tools/smoother/#supervision.detection.tools.smoother.DetectionsSmoother)
+  no longer raises when smoothing detections without `confidence`. Confidence is now
+  averaged over the frames that carry it; when tracks in the same frame disagree on
+  confidence presence, `confidence` is set to `None` for all smoothed detections.
+
 - Fixed [#2331](https://github.com/roboflow/supervision/pull/2331): `sv.Precision` and `sv.F1Score` now count predictions on background images (empty target set) as false positives, and count predictions of classes absent from ground truth as false positives under `MICRO` and `MACRO` averaging. Previously both edge cases were silently ignored, inflating scores. `WEIGHTED` averaging is unchanged — absent classes retain weight 0, consistent with scikit-learn. Users relying on previous scores should re-evaluate after upgrading; no API change is required.
 
 ### 0.29.0 <small>Jun 15, 2026</small>

--- a/src/supervision/detection/tools/smoother.py
+++ b/src/supervision/detection/tools/smoother.py
@@ -29,6 +29,9 @@ class DetectionsSmoother:
           [Roboflow Trackers](/latest/trackers/) for
           information on integrating tracking into your inference pipeline.
         - This class is not compatible with segmentation models.
+        - When detections in a frame disagree on confidence presence — some tracks
+          carry confidence scores and others do not — `confidence` is set to `None`
+          for all smoothed detections in that frame.
 
     Example:
         ```pycon
@@ -128,6 +131,20 @@ class DetectionsSmoother:
         return self.get_smoothed_detections()
 
     def get_track(self, track_id: int) -> Detections | None:
+        """Return the smoothed `Detections` for a single track.
+
+        Averages `xyxy` over all valid (non-`None`) frames in the track window.
+        `confidence` is averaged only over frames that carry it; frames with
+        `confidence=None` are excluded. Returns `None` when the track is unknown
+        or its entire window is empty.
+
+        Args:
+            track_id: The tracker ID whose smoothed detection to retrieve.
+
+        Returns:
+            Smoothed `Detections` for the track, or `None` if the track is
+            unknown or all frames in its window are empty.
+        """
         track = self.tracks.get(track_id, None)
         if track is None:
             return None
@@ -138,13 +155,11 @@ class DetectionsSmoother:
 
         ret = deepcopy(valid[0])
         ret.xyxy = np.mean([d.xyxy for d in valid], axis=0)
-        # `confidence` is optional on `Detections`; average it only when every
-        # frame in the window carries it, otherwise `np.mean([..., None])` raises.
-        # A window that mixes present and missing confidence yields `None`.
-        if all(d.confidence is not None for d in valid):
-            ret.confidence = np.mean([d.confidence for d in valid], axis=0)
-        else:
-            ret.confidence = None
+        # Average confidence only over frames that carry it; frames with
+        # confidence=None contribute nothing to the mean. Retain None when
+        # no frame in the window carries confidence.
+        confidences = [d.confidence for d in valid if d.confidence is not None]
+        ret.confidence = np.mean(np.array(confidences), axis=0) if confidences else None
 
         return ret
 
@@ -154,6 +169,13 @@ class DetectionsSmoother:
             track = self.get_track(track_id)
             if track is not None:
                 tracked_detections.append(track)
+
+        # Detections.merge requires all-or-none for optional fields.
+        # When tracks disagree on confidence presence, drop it from all to
+        # prevent ValueError inside Detections.merge (stack_or_none invariant).
+        if tracked_detections and any(d.confidence is None for d in tracked_detections):
+            for d in tracked_detections:
+                d.confidence = None
 
         detections = Detections.merge(tracked_detections)
         if len(detections) == 0:

--- a/src/supervision/detection/tools/smoother.py
+++ b/src/supervision/detection/tools/smoother.py
@@ -138,7 +138,13 @@ class DetectionsSmoother:
 
         ret = deepcopy(valid[0])
         ret.xyxy = np.mean([d.xyxy for d in valid], axis=0)
-        ret.confidence = np.mean([d.confidence for d in valid], axis=0)
+        # `confidence` is optional on `Detections`; average it only when every
+        # frame in the window carries it, otherwise `np.mean([..., None])` raises.
+        # A window that mixes present and missing confidence yields `None`.
+        if all(d.confidence is not None for d in valid):
+            ret.confidence = np.mean([d.confidence for d in valid], axis=0)
+        else:
+            ret.confidence = None
 
         return ret
 

--- a/tests/detection/tools/test_smoother.py
+++ b/tests/detection/tools/test_smoother.py
@@ -1,69 +1,128 @@
+"""Tests for DetectionsSmoother bounding-box and confidence smoothing."""
+
 from __future__ import annotations
 
 import numpy as np
+import pytest
+from numpy.testing import assert_allclose
 
 from supervision.detection.core import Detections
 from supervision.detection.tools.smoother import DetectionsSmoother
+from supervision.utils.internal import SupervisionWarnings
 
 
-def test_smoother_averages_xyxy_and_confidence() -> None:
-    """Boxes and confidence are averaged over the window."""
-    smoother = DetectionsSmoother(length=3)
-    smoother.update_with_detections(
-        Detections(
+class TestDetectionsSmoother:
+    @pytest.mark.parametrize(
+        ("conf1", "conf2", "expected_confidence"),
+        [
+            pytest.param(
+                np.array([0.5]),
+                np.array([0.7]),
+                np.array([0.6]),
+                id="with_confidence",
+            ),
+            pytest.param(
+                None,
+                None,
+                None,
+                id="no_confidence",
+            ),
+            pytest.param(
+                np.array([0.5]),
+                None,
+                np.array([0.5]),
+                id="mixed_window_averages_present",
+            ),
+        ],
+    )
+    def test_smoother_confidence_scenarios(
+        self,
+        conf1: np.ndarray | None,
+        conf2: np.ndarray | None,
+        expected_confidence: np.ndarray | None,
+    ) -> None:
+        """Boxes average over window; confidence averages present values or None."""
+        smoother = DetectionsSmoother(length=3)
+        smoother.update_with_detections(
+            Detections(
+                xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+                confidence=conf1,
+                tracker_id=np.array([1]),
+            )
+        )
+        smoothed = smoother.update_with_detections(
+            Detections(
+                xyxy=np.array([[2, 2, 12, 12]], dtype=np.float32),
+                confidence=conf2,
+                tracker_id=np.array([1]),
+            )
+        )
+
+        assert_allclose(smoothed.xyxy, np.array([[1, 1, 11, 11]]), atol=1e-5)
+        if expected_confidence is None:
+            assert smoothed.confidence is None
+        else:
+            assert smoothed.confidence is not None
+            assert_allclose(smoothed.confidence, expected_confidence, atol=1e-5)
+
+    def test_smoother_multi_track_mixed_confidence_does_not_crash(self) -> None:
+        """Two tracks with different confidence presence must not raise on merge."""
+        smoother = DetectionsSmoother(length=3)
+        smoother.update_with_detections(
+            Detections(
+                xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+                confidence=np.array([0.5]),
+                tracker_id=np.array([1]),
+            )
+        )
+        smoothed = smoother.update_with_detections(
+            Detections(
+                xyxy=np.array([[20, 20, 30, 30]], dtype=np.float32),
+                tracker_id=np.array([2]),
+            )
+        )
+
+        assert len(smoothed) == 2
+        assert smoothed.confidence is None
+
+    def test_smoother_tracker_id_none_warns_and_returns_unchanged(self) -> None:
+        """update_with_detections warns and returns input when tracker_id is None."""
+        smoother = DetectionsSmoother(length=3)
+        detections = Detections(
             xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
-            confidence=np.array([0.5]),
-            tracker_id=np.array([1]),
+            tracker_id=None,
         )
-    )
-    smoothed = smoother.update_with_detections(
-        Detections(
-            xyxy=np.array([[2, 2, 12, 12]], dtype=np.float32),
-            confidence=np.array([0.7]),
-            tracker_id=np.array([1]),
+
+        with pytest.warns(SupervisionWarnings):
+            result = smoother.update_with_detections(detections)
+
+        assert result is detections
+
+    def test_smoother_window_full_averages_all_frames(self) -> None:
+        """Full window (length=3) averages all 3 frames, not just the last two."""
+        smoother = DetectionsSmoother(length=3)
+        smoother.update_with_detections(
+            Detections(
+                xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+                confidence=np.array([0.3]),
+                tracker_id=np.array([1]),
+            )
         )
-    )
-
-    np.testing.assert_array_equal(smoothed.xyxy, np.array([[1, 1, 11, 11]]))
-    np.testing.assert_allclose(smoothed.confidence, np.array([0.6]))
-
-
-def test_smoother_without_confidence_does_not_crash() -> None:
-    """Detections without confidence smooth boxes and keep confidence as None."""
-    smoother = DetectionsSmoother(length=3)
-    smoother.update_with_detections(
-        Detections(
-            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
-            tracker_id=np.array([1]),
+        smoother.update_with_detections(
+            Detections(
+                xyxy=np.array([[3, 3, 13, 13]], dtype=np.float32),
+                confidence=np.array([0.6]),
+                tracker_id=np.array([1]),
+            )
         )
-    )
-    smoothed = smoother.update_with_detections(
-        Detections(
-            xyxy=np.array([[2, 2, 12, 12]], dtype=np.float32),
-            tracker_id=np.array([1]),
+        smoothed = smoother.update_with_detections(
+            Detections(
+                xyxy=np.array([[6, 6, 16, 16]], dtype=np.float32),
+                confidence=np.array([0.9]),
+                tracker_id=np.array([1]),
+            )
         )
-    )
 
-    np.testing.assert_array_equal(smoothed.xyxy, np.array([[1, 1, 11, 11]]))
-    assert smoothed.confidence is None
-
-
-def test_smoother_mixed_confidence_window_yields_none() -> None:
-    """A window mixing frames with and without confidence keeps confidence as None."""
-    smoother = DetectionsSmoother(length=3)
-    smoother.update_with_detections(
-        Detections(
-            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
-            confidence=np.array([0.5]),
-            tracker_id=np.array([1]),
-        )
-    )
-    smoothed = smoother.update_with_detections(
-        Detections(
-            xyxy=np.array([[2, 2, 12, 12]], dtype=np.float32),
-            tracker_id=np.array([1]),
-        )
-    )
-
-    np.testing.assert_array_equal(smoothed.xyxy, np.array([[1, 1, 11, 11]]))
-    assert smoothed.confidence is None
+        assert_allclose(smoothed.xyxy, np.array([[3, 3, 13, 13]]), atol=1e-5)
+        assert smoothed.confidence is not None
+        assert_allclose(smoothed.confidence, np.array([0.6]), atol=1e-5)

--- a/tests/detection/tools/test_smoother.py
+++ b/tests/detection/tools/test_smoother.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import numpy as np
+
+from supervision.detection.core import Detections
+from supervision.detection.tools.smoother import DetectionsSmoother
+
+
+def test_smoother_averages_xyxy_and_confidence() -> None:
+    """Boxes and confidence are averaged over the window."""
+    smoother = DetectionsSmoother(length=3)
+    smoother.update_with_detections(
+        Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+            confidence=np.array([0.5]),
+            tracker_id=np.array([1]),
+        )
+    )
+    smoothed = smoother.update_with_detections(
+        Detections(
+            xyxy=np.array([[2, 2, 12, 12]], dtype=np.float32),
+            confidence=np.array([0.7]),
+            tracker_id=np.array([1]),
+        )
+    )
+
+    np.testing.assert_array_equal(smoothed.xyxy, np.array([[1, 1, 11, 11]]))
+    np.testing.assert_allclose(smoothed.confidence, np.array([0.6]))
+
+
+def test_smoother_without_confidence_does_not_crash() -> None:
+    """Detections without confidence smooth boxes and keep confidence as None."""
+    smoother = DetectionsSmoother(length=3)
+    smoother.update_with_detections(
+        Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+            tracker_id=np.array([1]),
+        )
+    )
+    smoothed = smoother.update_with_detections(
+        Detections(
+            xyxy=np.array([[2, 2, 12, 12]], dtype=np.float32),
+            tracker_id=np.array([1]),
+        )
+    )
+
+    np.testing.assert_array_equal(smoothed.xyxy, np.array([[1, 1, 11, 11]]))
+    assert smoothed.confidence is None
+
+
+def test_smoother_mixed_confidence_window_yields_none() -> None:
+    """A window mixing frames with and without confidence keeps confidence as None."""
+    smoother = DetectionsSmoother(length=3)
+    smoother.update_with_detections(
+        Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+            confidence=np.array([0.5]),
+            tracker_id=np.array([1]),
+        )
+    )
+    smoothed = smoother.update_with_detections(
+        Detections(
+            xyxy=np.array([[2, 2, 12, 12]], dtype=np.float32),
+            tracker_id=np.array([1]),
+        )
+    )
+
+    np.testing.assert_array_equal(smoothed.xyxy, np.array([[1, 1, 11, 11]]))
+    assert smoothed.confidence is None


### PR DESCRIPTION
## Description

`DetectionsSmoother` crashes on the first frame when detections have no `confidence`.

`get_track` unconditionally averages confidence:

```python
ret.confidence = np.mean([d.confidence for d in valid], axis=0)
```

`confidence` is optional on `Detections` (it defaults to `None`), so for trackers or detection sources that carry no confidence this becomes `np.mean([None, ...])` and raises.

### Repro

```python
import numpy as np
import supervision as sv

smoother = sv.DetectionsSmoother()
detections = sv.Detections(
    xyxy=np.array([[0, 0, 10, 10]], dtype=float),
    tracker_id=np.array([1]),
)
smoother.update_with_detections(detections)
# TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```

## Fix

Average `confidence` only when it is present; otherwise leave it as `None`. Box smoothing is unaffected.

## Tests

Adds `tests/detection/tools/test_smoother.py` covering both the with-confidence (averaging) and without-confidence (no crash, confidence stays `None`) paths. `ruff` and `mypy` pass locally.