### PR TITLE
fix(json_sink): serialize NumPy scalars in `custom_data`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,11 @@ date_modified: 2026-06-15
 
 ### UnReleased
 
+- Fixed [#2334](https://github.com/roboflow/supervision/pull/2334): `sv.JSONSink` now
+  serializes NumPy scalars (e.g. `np.int64` frame indices) in `custom_data` as JSON
+  numbers instead of raising `TypeError` at close time. File handle is now guaranteed
+  to close even when serialization fails.
+
 - Fixed [#2335](https://github.com/roboflow/supervision/pull/2335): `sv.KeyPoints(confidence=...)` now works again. The `0.29.0` refactor accidentally dropped the deprecated `confidence` constructor kwarg; it is now accepted and mapped to `keypoint_confidence` with a deprecation warning.
 
 - Fixed [#2322](https://github.com/roboflow/supervision/pull/2322): COCO export now preserves all polygon parts for multi-component masks. Previously, only the first polygon was written when a non-crowd mask had disjoint segments; all parts are now included.

--- a/src/supervision/detection/tools/json_sink.py
+++ b/src/supervision/detection/tools/json_sink.py
@@ -24,6 +24,8 @@ class JSONSink:
         When a list or tuple value in custom_data (or detections.data) has the
         same length as the detection count, each element is written to the
         corresponding detection row; any other value is broadcast to all rows.
+        NumPy scalars (e.g. ``np.int64``, ``np.float32``) are serialized as
+        JSON numbers; NumPy arrays are serialized as JSON arrays.
 
     Args:
         file_name: The name of the JSON file where the detections will be stored.
@@ -81,8 +83,21 @@ class JSONSink:
 
     @staticmethod
     def _json_default(value: Any) -> Any:
-        """Make NumPy scalars/arrays JSON serializable (e.g. a `np.int64` frame
-        index passed through `custom_data`)."""
+        """Return a JSON-serializable equivalent of a NumPy scalar or array.
+
+        Called as the ``default`` hook by :func:`json.dump`. Converts
+        :class:`numpy.generic` scalars via ``.item()`` and
+        :class:`numpy.ndarray` instances via ``.tolist()``.
+
+        Args:
+            value: Object the standard JSON encoder could not serialize.
+
+        Returns:
+            A Python scalar or nested list equivalent of ``value``.
+
+        Raises:
+            TypeError: If ``value`` is neither a NumPy scalar nor an ndarray.
+        """
         if isinstance(value, np.generic):
             return value.item()
         if isinstance(value, np.ndarray):
@@ -97,7 +112,9 @@ class JSONSink:
         """
         if self.file:
             try:
-                json.dump(self.data, self.file, indent=4, default=self._json_default)
+                json.dump(
+                    self.data, self.file, indent=4, default=JSONSink._json_default
+                )
             finally:
                 self.file.close()
 

--- a/src/supervision/detection/tools/json_sink.py
+++ b/src/supervision/detection/tools/json_sink.py
@@ -79,13 +79,27 @@ class JSONSink:
 
         self.file = open(self.file_name, "w")
 
+    @staticmethod
+    def _json_default(value: Any) -> Any:
+        """Make NumPy scalars/arrays JSON serializable (e.g. a `np.int64` frame
+        index passed through `custom_data`)."""
+        if isinstance(value, np.generic):
+            return value.item()
+        if isinstance(value, np.ndarray):
+            return value.tolist()
+        raise TypeError(
+            f"Object of type {type(value).__name__} is not JSON serializable"
+        )
+
     def write_and_close(self) -> None:
         """
         Write and close the JSON file.
         """
         if self.file:
-            json.dump(self.data, self.file, indent=4)
-            self.file.close()
+            try:
+                json.dump(self.data, self.file, indent=4, default=self._json_default)
+            finally:
+                self.file.close()
 
     @staticmethod
     def _slice_value(value: Any, i: int, n: int) -> Any:

--- a/tests/detection/test_json.py
+++ b/tests/detection/test_json.py
@@ -395,6 +395,29 @@ def test_json_sink(
     assert_json_equal(file_name, expected_result)
 
 
+def test_json_sink_serializes_numpy_scalar_custom_data() -> None:
+    """A NumPy scalar in custom_data (e.g. a frame index) is written as a number."""
+    file_name = "test_detections_numpy_scalar_custom_data.json"
+    detections = sv.Detections(
+        xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+        class_id=np.array([0]),
+        confidence=np.array([0.9]),
+    )
+
+    with sv.JSONSink(file_name) as sink:
+        sink.append(
+            detections,
+            custom_data={"frame": np.int64(7), "score": np.float32(0.5)},
+        )
+
+    with open(file_name) as file:
+        data = json.load(file)
+    os.remove(file_name)
+
+    assert data[0]["frame"] == 7
+    assert data[0]["score"] == pytest.approx(0.5)
+
+
 def assert_json_equal(file_name, expected_rows):
     with open(file_name) as file:
         data = json.load(file)

--- a/tests/detection/test_json.py
+++ b/tests/detection/test_json.py
@@ -395,27 +395,51 @@ def test_json_sink(
     assert_json_equal(file_name, expected_result)
 
 
-def test_json_sink_serializes_numpy_scalar_custom_data() -> None:
-    """A NumPy scalar in custom_data (e.g. a frame index) is written as a number."""
-    file_name = "test_detections_numpy_scalar_custom_data.json"
+@pytest.mark.parametrize(
+    ("scalar", "expected"),
+    [
+        pytest.param(np.int64(7), 7, id="np_int64"),
+        pytest.param(np.float32(0.5), pytest.approx(0.5), id="np_float32"),
+        pytest.param(np.float64(1.5), pytest.approx(1.5), id="np_float64"),
+        pytest.param(np.int32(3), 3, id="np_int32"),
+        pytest.param(np.bool_(True), True, id="np_bool"),
+    ],
+)
+def test_json_sink_serializes_numpy_scalar_custom_data(
+    tmp_path: Any, scalar: Any, expected: Any
+) -> None:
+    """NumPy scalar in custom_data serializes as a JSON number or boolean."""
+    file_name = str(tmp_path / "test_numpy_scalar.json")
     detections = sv.Detections(
         xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
         class_id=np.array([0]),
         confidence=np.array([0.9]),
     )
-
     with sv.JSONSink(file_name) as sink:
-        sink.append(
-            detections,
-            custom_data={"frame": np.int64(7), "score": np.float32(0.5)},
-        )
+        sink.append(detections, custom_data={"value": scalar})
+    with open(file_name) as f:
+        data = json.load(f)
+    assert data[0]["value"] == expected
 
-    with open(file_name) as file:
-        data = json.load(file)
-    os.remove(file_name)
 
-    assert data[0]["frame"] == 7
-    assert data[0]["score"] == pytest.approx(0.5)
+def test_json_sink_serializes_nested_numpy_array_custom_data(tmp_path: Any) -> None:
+    """NumPy array nested inside a custom_data dict value serializes as a JSON array."""
+    file_name = str(tmp_path / "test_nested_array.json")
+    detections = sv.Detections(
+        xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+        class_id=np.array([0]),
+    )
+    with sv.JSONSink(file_name) as sink:
+        sink.append(detections, custom_data={"meta": {"arr": np.array([1, 2, 3])}})
+    with open(file_name) as f:
+        data = json.load(f)
+    assert data[0]["meta"]["arr"] == [1, 2, 3]
+
+
+def test_json_default_raises_for_unserializable_type() -> None:
+    """_json_default raises TypeError for non-numpy objects."""
+    with pytest.raises(TypeError, match="is not JSON serializable"):
+        sv.JSONSink._json_default(object())
 
 
 def assert_json_equal(file_name, expected_rows):


### PR DESCRIPTION
## Description

`JSONSink` buffers rows and writes them all on close. A NumPy **scalar** passed via `custom_data` — for example a `np.int64` frame index — slips through the row builder unchanged (it is not an `np.ndarray`, so the existing `str(...)` guard does not apply), and then `json.dump` raises on close, **discarding every buffered row**.

### Repro

```python
import numpy as np
import supervision as sv

d = sv.Detections(xyxy=np.array([[0, 0, 10, 10]], float),
                  class_id=np.array([0]), confidence=np.array([0.9]))
with sv.JSONSink("out.json") as sink:
    sink.append(d, custom_data={"frame": np.int64(7)})
# TypeError: Object of type int64 is not JSON serializable  -> out.json is empty
```

(`np.float64` happens to work because it subclasses `float`, but `np.int64` / `np.float32` do not — so the failure depends on the dtype the user logs.)

## Fix

Pass a `default` serializer to `json.dump` that converts NumPy scalars with `.item()` and arrays with `.tolist()`. This only affects values that previously failed to serialize; existing string-formatted fields are unchanged. The numpy scalar now serializes as a proper JSON number (`"frame": 7`).

## Tests

Adds a regression test writing a `np.int64` and `np.float32` via `custom_data` and asserting they round-trip as JSON numbers. `ruff` and `mypy` pass locally.