### PR TITLE
fix: accept deprecated `confidence` kwarg in `KeyPoints()` constructor

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ date_modified: 2026-06-15
 
 ### UnReleased
 
+- Fixed [#2335](https://github.com/roboflow/supervision/pull/2335): `sv.KeyPoints(confidence=...)` now works again. The `0.29.0` refactor accidentally dropped the deprecated `confidence` constructor kwarg; it is now accepted and mapped to `keypoint_confidence` with a deprecation warning.
+
 - Fixed [#2322](https://github.com/roboflow/supervision/pull/2322): COCO export now preserves all polygon parts for multi-component masks. Previously, only the first polygon was written when a non-crowd mask had disjoint segments; all parts are now included.
 
 ### 0.29.0 <small>Jun 15, 2026</small>

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -2632,7 +2632,9 @@ class Detections:
         return Detections.merge(result)
 
 
-def _merge_obb_corners(corners_list: list[np.ndarray]) -> npt.NDArray[np.floating]:
+def _merge_obb_corners(
+    corners_list: list[npt.NDArray[np.floating]],
+) -> npt.NDArray[np.floating]:
     """Merge multiple OBB corner arrays using winner-angle projection.
 
     The first entry in *corners_list* is the winner. Its orientation angle

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -249,15 +249,38 @@ class KeyPoints:
         *,
         confidence: npt.NDArray[np.float32] | None = None,
     ) -> None:
+        """Initialize KeyPoints.
+
+        Args:
+            xy: Array of shape `(n, m, 2)` with keypoint coordinates.
+            class_id: Array of shape `(n,)` with class IDs. Defaults to None.
+            keypoint_confidence: Array of shape `(n, m)` with per-keypoint
+                confidence scores. Defaults to None.
+            detection_confidence: Array of shape `(n,)` with detection-level
+                confidence scores. Defaults to None.
+            visible: Boolean array of shape `(n, m)` indicating visible
+                keypoints. Defaults to None.
+            data: Dictionary of additional per-detection data arrays.
+                Defaults to an empty dict.
+            confidence: Deprecated since `0.29.0`, removed in `0.32.0`.
+                Use ``keypoint_confidence`` instead. Raises ``ValueError``
+                if passed together with ``keypoint_confidence``.
+
+        Raises:
+            ValueError: If both ``confidence`` and ``keypoint_confidence``
+                are provided.
+        """
         if confidence is not None:
-            warn_deprecated(
-                "'confidence' parameter in KeyPoints() is deprecated since 0.29.0 "
-                "and will be removed in 0.32.0. Use 'keypoint_confidence' instead."
-            )
             if keypoint_confidence is not None:
                 raise ValueError(
-                    "Cannot pass both 'confidence' and 'keypoint_confidence'."
+                    "Cannot pass both 'confidence' and 'keypoint_confidence'. "
+                    "'confidence' is deprecated — use 'keypoint_confidence' only."
                 )
+            warn_deprecated(
+                "'confidence' parameter in `KeyPoints()` is deprecated since "
+                "`0.29.0` and will be removed in `0.32.0`. Use "
+                "'keypoint_confidence' instead."
+            )
             keypoint_confidence = confidence
 
         self.xy = xy

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -67,7 +67,7 @@ def _normalize_row_index(
     return i
 
 
-@dataclass
+@dataclass(init=False)
 class KeyPoints:
     """
     The `sv.KeyPoints` class in the Supervision library standardizes results from
@@ -237,6 +237,36 @@ class KeyPoints:
     detection_confidence: npt.NDArray[np.float32] | None = None
     visible: npt.NDArray[np.bool_] | None = None
     data: dict[str, npt.NDArray[np.generic] | list[Any]] = field(default_factory=dict)
+
+    def __init__(
+        self,
+        xy: npt.NDArray[np.float32],
+        class_id: npt.NDArray[np.int_] | None = None,
+        keypoint_confidence: npt.NDArray[np.float32] | None = None,
+        detection_confidence: npt.NDArray[np.float32] | None = None,
+        visible: npt.NDArray[np.bool_] | None = None,
+        data: dict[str, npt.NDArray[np.generic] | list[Any]] | None = None,
+        *,
+        confidence: npt.NDArray[np.float32] | None = None,
+    ) -> None:
+        if confidence is not None:
+            warn_deprecated(
+                "'confidence' parameter in KeyPoints() is deprecated since 0.29.0 "
+                "and will be removed in 0.32.0. Use 'keypoint_confidence' instead."
+            )
+            if keypoint_confidence is not None:
+                raise ValueError(
+                    "Cannot pass both 'confidence' and 'keypoint_confidence'."
+                )
+            keypoint_confidence = confidence
+
+        self.xy = xy
+        self.class_id = class_id
+        self.keypoint_confidence = keypoint_confidence
+        self.detection_confidence = detection_confidence
+        self.visible = visible
+        self.data = data if data is not None else {}
+        self.__post_init__()
 
     def __post_init__(self) -> None:
         _validate_keypoints_fields(

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -931,20 +931,85 @@ class TestDeprecatedConfidenceConstructor:
     """Tests for backward-compatible `confidence=` kwarg in KeyPoints()."""
 
     def test_constructor_accepts_and_warns_on_deprecated_confidence_kwarg(self):
+        """Deprecated confidence= warns and maps value to keypoint_confidence."""
         from supervision.utils.internal import SupervisionWarnings
 
         xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
         confidence = np.array([[0.9, 0.8]], dtype=np.float32)
 
-        with pytest.warns(SupervisionWarnings, match="deprecated since 0.29.0"):
+        with pytest.warns(SupervisionWarnings, match="deprecated since"):
             key_points = KeyPoints(xy=xy, confidence=confidence)
 
         np.testing.assert_array_equal(key_points.keypoint_confidence, confidence)
         assert key_points.xy is xy
 
-    def test_constructor_rejects_both_confidence_and_keypoint_confidence(self):
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param(
+                {"confidence": None, "keypoint_confidence": None},
+                id="confidence-first",
+            ),
+            pytest.param(
+                {"keypoint_confidence": None, "confidence": None},
+                id="keypoint-confidence-first",
+            ),
+        ],
+    )
+    def test_constructor_rejects_both_confidence_and_keypoint_confidence(
+        self, kwargs: dict
+    ):
+        """ValueError raised regardless of kwarg order when both are passed."""
         xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
-        confidence = np.array([[0.9, 0.8]], dtype=np.float32)
+        confidence_arr = np.array([[0.9, 0.8]], dtype=np.float32)
+        actual_kwargs = {k: confidence_arr for k in kwargs}
 
         with pytest.raises(ValueError, match="Cannot pass both"):
-            KeyPoints(xy=xy, confidence=confidence, keypoint_confidence=confidence)
+            KeyPoints(xy=xy, **actual_kwargs)
+
+    def test_constructor_normal_keypoint_confidence_path(self):
+        """Normal keypoint_confidence= path works and emits no deprecation warning."""
+        import warnings
+
+        xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
+        kp_conf = np.array([[0.9, 0.8]], dtype=np.float32)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            kp = KeyPoints(xy=xy, keypoint_confidence=kp_conf)
+
+        np.testing.assert_array_equal(kp.keypoint_confidence, kp_conf)
+        assert kp.data == {}
+
+    def test_constructor_confidence_none_does_not_warn(self):
+        """Explicit confidence=None is silently ignored — no warning emitted."""
+        import warnings
+
+        xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            kp = KeyPoints(xy=xy, confidence=None)
+
+        assert kp.keypoint_confidence is None
+
+    def test_constructor_data_none_defaults_to_empty_dict(self):
+        """Explicit data=None normalizes to empty dict, not None."""
+        xy = np.array([[[1.0, 2.0]]], dtype=np.float32)
+
+        assert KeyPoints(xy=xy).data == {}
+        assert KeyPoints(xy=xy, data=None).data == {}
+
+    def test_keypoints_init_covers_all_dataclass_fields(self):
+        """Custom __init__ must assign every dataclass field — guards against drift."""
+        import dataclasses
+        import inspect
+
+        field_names = {f.name for f in dataclasses.fields(KeyPoints)}
+        init_params = set(inspect.signature(KeyPoints.__init__).parameters) - {
+            "self",
+            "confidence",
+        }
+        assert field_names == init_params, (
+            f"Field/init drift: {field_names.symmetric_difference(init_params)}"
+        )

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -930,23 +930,17 @@ def test_from_mediapipe_input(mediapipe_results, resolution_wh, expected_key_poi
 class TestDeprecatedConfidenceConstructor:
     """Tests for backward-compatible `confidence=` kwarg in KeyPoints()."""
 
-    def test_constructor_accepts_deprecated_confidence_kwarg(self):
-        xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
-        confidence = np.array([[0.9, 0.8]], dtype=np.float32)
-
-        key_points = KeyPoints(xy=xy, confidence=confidence)
-
-        np.testing.assert_array_equal(key_points.keypoint_confidence, confidence)
-        assert key_points.xy is xy
-
-    def test_constructor_warns_on_deprecated_confidence_kwarg(self):
+    def test_constructor_accepts_and_warns_on_deprecated_confidence_kwarg(self):
         from supervision.utils.internal import SupervisionWarnings
 
         xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
         confidence = np.array([[0.9, 0.8]], dtype=np.float32)
 
         with pytest.warns(SupervisionWarnings, match="deprecated since 0.29.0"):
-            KeyPoints(xy=xy, confidence=confidence)
+            key_points = KeyPoints(xy=xy, confidence=confidence)
+
+        np.testing.assert_array_equal(key_points.keypoint_confidence, confidence)
+        assert key_points.xy is xy
 
     def test_constructor_rejects_both_confidence_and_keypoint_confidence(self):
         xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -925,3 +925,32 @@ def test_from_mediapipe_input(mediapipe_results, resolution_wh, expected_key_poi
         mediapipe_results, resolution_wh=resolution_wh
     )
     assert key_points == expected_key_points
+
+
+class TestDeprecatedConfidenceConstructor:
+    """Tests for backward-compatible `confidence=` kwarg in KeyPoints()."""
+
+    def test_constructor_accepts_deprecated_confidence_kwarg(self):
+        xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
+        confidence = np.array([[0.9, 0.8]], dtype=np.float32)
+
+        key_points = KeyPoints(xy=xy, confidence=confidence)
+
+        np.testing.assert_array_equal(key_points.keypoint_confidence, confidence)
+        assert key_points.xy is xy
+
+    def test_constructor_warns_on_deprecated_confidence_kwarg(self):
+        from supervision.utils.internal import SupervisionWarnings
+
+        xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
+        confidence = np.array([[0.9, 0.8]], dtype=np.float32)
+
+        with pytest.warns(SupervisionWarnings, match="deprecated since 0.29.0"):
+            KeyPoints(xy=xy, confidence=confidence)
+
+    def test_constructor_rejects_both_confidence_and_keypoint_confidence(self):
+        xy = np.array([[[1.0, 2.0], [3.0, 4.0]]], dtype=np.float32)
+        confidence = np.array([[0.9, 0.8]], dtype=np.float32)
+
+        with pytest.raises(ValueError, match="Cannot pass both"):
+            KeyPoints(xy=xy, confidence=confidence, keypoint_confidence=confidence)


### PR DESCRIPTION
## Summary

### Problem

Since 0.29.0, passing `confidence=` to the `KeyPoints()` constructor raises `TypeError` because the old field was replaced by a `@property` that forwards to `keypoint_confidence`. The property handles read/write on existing objects gracefully, but the dataclass-generated `__init__` rejects the unknown keyword argument entirely.

### Solution

Switch to `@dataclass(init=False)` and define an explicit `__init__` that:

- Accepts a keyword-only `confidence` parameter alongside the new `keypoint_confidence`
- Emits a deprecation warning when `confidence` is used
- Raises `ValueError` if both `confidence` and `keypoint_confidence` are passed
- Forwards `confidence` to `keypoint_confidence` transparently