### PR TITLE
feat: add `KeyPoints.with_nms()` method

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ date_modified: 2026-06-15
 
 ### UnReleased
 
+- Added [#2338](https://github.com/roboflow/supervision/pull/2338): [`sv.KeyPoints.with_nms`](https://supervision.roboflow.com/latest/keypoint/core/#supervision.key_points.core.KeyPoints.with_nms) — non-maximum suppression for keypoint detections. Derives axis-aligned bounding boxes from valid (non-zero and visible) keypoints and applies `box_non_max_suppression`. Requires `detection_confidence`; supports class-aware and class-agnostic modes via `threshold`, `class_agnostic`, and `overlap_metric`.
+
 - Fixed [#2335](https://github.com/roboflow/supervision/pull/2335): `sv.KeyPoints(confidence=...)` now works again. The `0.29.0` refactor accidentally dropped the deprecated `confidence` constructor kwarg; it is now accepted and mapped to `keypoint_confidence` with a deprecation warning.
 
 - Fixed [#2322](https://github.com/roboflow/supervision/pull/2322): COCO export now preserves all polygon parts for multi-component masks. Previously, only the first polygon was written when a non-crowd mask had disjoint segments; all parts are now included.

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -1159,8 +1159,8 @@ class KeyPoints:
             A new `sv.KeyPoints` object after non-maximum suppression.
 
         Raises:
-            AssertionError: If `detection_confidence` is None.
-            AssertionError: If `class_agnostic` is False and `class_id`
+            ValueError: If `detection_confidence` is None.
+            ValueError: If `class_agnostic` is False and `class_id`
                 is None.
 
         Examples:
@@ -1179,12 +1179,13 @@ class KeyPoints:
         if len(self) == 0:
             return self
 
-        assert self.detection_confidence is not None, (
-            "KeyPoints detection_confidence must be given for NMS to be executed."
-        )
+        if self.detection_confidence is None:
+            raise ValueError(
+                "KeyPoints detection_confidence must be given for NMS to be executed."
+            )
 
-        if not class_agnostic:
-            assert self.class_id is not None, (
+        if not class_agnostic and self.class_id is None:
+            raise ValueError(
                 "KeyPoints class_id must be given for NMS to be executed. If "
                 "you intended to perform class agnostic NMS set "
                 "class_agnostic=True."

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -11,7 +11,10 @@ import numpy.typing as npt
 from supervision.config import CLASS_NAME_DATA_FIELD
 from supervision.detection.core import Detections
 from supervision.detection.utils.internal import get_data_item, is_data_equal
-from supervision.detection.utils.iou_and_nms import box_non_max_suppression
+from supervision.detection.utils.iou_and_nms import (
+    OverlapMetric,
+    box_non_max_suppression,
+)
 from supervision.utils.internal import warn_deprecated
 from supervision.validators import _validate_keypoints_fields
 
@@ -1134,18 +1137,23 @@ class KeyPoints:
         self,
         threshold: float = 0.5,
         class_agnostic: bool = False,
+        overlap_metric: OverlapMetric = OverlapMetric.IOU,
     ) -> KeyPoints:
         """
         Performs non-max suppression on the keypoint detections. Bounding boxes
-        are derived from valid (non-zero) keypoints of each skeleton, and
-        standard box NMS is applied.
+        are derived from valid keypoints of each skeleton, and standard box NMS
+        is applied. A keypoint is considered valid when its coordinates are not
+        all-zero and its `visible` flag is `True` (if `visible` is set).
 
         Args:
-            threshold: The intersection-over-union threshold
-                to use for non-maximum suppression.
-            class_agnostic: Whether to perform class-agnostic
-                non-maximum suppression. If True, the class_id of each
-                detection will be ignored.
+            threshold: The intersection-over-union threshold to use for
+                non-maximum suppression. Must be in [0, 1]. Defaults to 0.5.
+            class_agnostic: Whether to perform class-agnostic non-maximum
+                suppression. If True, the class_id of each detection will be
+                ignored. Defaults to False.
+            overlap_metric: Metric used to compute the degree of overlap
+                between pairs of bounding boxes. Defaults to
+                `OverlapMetric.IOU`.
 
         Returns:
             A new `sv.KeyPoints` object after non-maximum suppression.
@@ -1184,6 +1192,8 @@ class KeyPoints:
 
         xy = self.xy
         valid = ~np.all(xy == 0, axis=-1)
+        if self.visible is not None:
+            valid = valid & self.visible
         x_min = np.min(np.where(valid, xy[..., 0], np.inf), axis=1)
         y_min = np.min(np.where(valid, xy[..., 1], np.inf), axis=1)
         x_max = np.max(np.where(valid, xy[..., 0], -np.inf), axis=1)
@@ -1202,7 +1212,11 @@ class KeyPoints:
                 ]
             )
 
-        keep = box_non_max_suppression(predictions=predictions, iou_threshold=threshold)
+        keep = box_non_max_suppression(
+            predictions=predictions,
+            iou_threshold=threshold,
+            overlap_metric=overlap_metric,
+        )
 
         return cast(KeyPoints, self[keep])
 

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -11,6 +11,7 @@ import numpy.typing as npt
 from supervision.config import CLASS_NAME_DATA_FIELD
 from supervision.detection.core import Detections
 from supervision.detection.utils.internal import get_data_item, is_data_equal
+from supervision.detection.utils.iou_and_nms import box_non_max_suppression
 from supervision.utils.internal import warn_deprecated
 from supervision.validators import _validate_keypoints_fields
 
@@ -1075,6 +1076,82 @@ class KeyPoints:
         empty_key_points = KeyPoints.empty()
         empty_key_points.data = self.data
         return self == empty_key_points
+
+    def with_nms(
+        self,
+        threshold: float = 0.5,
+        class_agnostic: bool = False,
+    ) -> KeyPoints:
+        """
+        Performs non-max suppression on the keypoint detections. Bounding boxes
+        are derived from valid (non-zero) keypoints of each skeleton, and
+        standard box NMS is applied.
+
+        Args:
+            threshold: The intersection-over-union threshold
+                to use for non-maximum suppression.
+            class_agnostic: Whether to perform class-agnostic
+                non-maximum suppression. If True, the class_id of each
+                detection will be ignored.
+
+        Returns:
+            A new `sv.KeyPoints` object after non-maximum suppression.
+
+        Raises:
+            AssertionError: If `detection_confidence` is None.
+            AssertionError: If `class_agnostic` is False and `class_id`
+                is None.
+
+        Examples:
+            ```python
+            import cv2
+            import supervision as sv
+            from rfdetr import RFDETRKeypointPreview
+
+            image = cv2.imread("<SOURCE_IMAGE_PATH>")
+            model = RFDETRKeypointPreview()
+
+            key_points = model.predict(image)
+            key_points = key_points.with_nms(threshold=0.5)
+            ```
+        """
+        if len(self) == 0:
+            return self
+
+        assert self.detection_confidence is not None, (
+            "KeyPoints detection_confidence must be given for NMS to be executed."
+        )
+
+        if not class_agnostic:
+            assert self.class_id is not None, (
+                "KeyPoints class_id must be given for NMS to be executed. If "
+                "you intended to perform class agnostic NMS set "
+                "class_agnostic=True."
+            )
+
+        xy = self.xy
+        valid = ~np.all(xy == 0, axis=-1)
+        x_min = np.min(np.where(valid, xy[..., 0], np.inf), axis=1)
+        y_min = np.min(np.where(valid, xy[..., 1], np.inf), axis=1)
+        x_max = np.max(np.where(valid, xy[..., 0], -np.inf), axis=1)
+        y_max = np.max(np.where(valid, xy[..., 1], -np.inf), axis=1)
+        xyxy = np.stack([x_min, y_min, x_max, y_max], axis=1).astype(np.float32)
+
+        if class_agnostic:
+            predictions = np.hstack([xyxy, self.detection_confidence.reshape(-1, 1)])
+        else:
+            class_id = cast(npt.NDArray[np.int_], self.class_id)
+            predictions = np.hstack(
+                [
+                    xyxy,
+                    self.detection_confidence.reshape(-1, 1),
+                    class_id.reshape(-1, 1),
+                ]
+            )
+
+        keep = box_non_max_suppression(predictions=predictions, iou_threshold=threshold)
+
+        return cast(KeyPoints, self[keep])
 
     def as_detections(
         self, selected_keypoint_indices: Iterable[int] | None = None

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -925,3 +925,243 @@ def test_from_mediapipe_input(mediapipe_results, resolution_wh, expected_key_poi
         mediapipe_results, resolution_wh=resolution_wh
     )
     assert key_points == expected_key_points
+
+
+@pytest.mark.parametrize(
+    ("key_points", "threshold", "class_agnostic", "expected_result"),
+    [
+        pytest.param(
+            KeyPoints.empty(),
+            0.5,
+            True,
+            KeyPoints.empty(),
+            id="empty",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[[[10, 20], [30, 40]]],
+                detection_confidence=[0.9],
+                class_id=[0],
+            ),
+            0.5,
+            False,
+            _create_key_points(
+                xy=[[[10, 20], [30, 40]]],
+                detection_confidence=[0.9],
+                class_id=[0],
+            ),
+            id="single-skeleton",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[10, 10], [20, 20]],
+                    [[500, 500], [600, 600]],
+                ],
+                detection_confidence=[0.9, 0.8],
+                class_id=[0, 0],
+            ),
+            0.5,
+            False,
+            _create_key_points(
+                xy=[
+                    [[10, 10], [20, 20]],
+                    [[500, 500], [600, 600]],
+                ],
+                detection_confidence=[0.9, 0.8],
+                class_id=[0, 0],
+            ),
+            id="two-non-overlapping",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[150, 150], [250, 250]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 0],
+            ),
+            0.9,
+            False,
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[150, 150], [250, 250]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 0],
+            ),
+            id="two-overlapping-below-threshold",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 0],
+            ),
+            0.3,
+            False,
+            _create_key_points(
+                xy=[[[100, 100], [200, 200]]],
+                detection_confidence=[0.9],
+                class_id=[0],
+            ),
+            id="two-overlapping-above-threshold",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                    [[500, 500], [600, 600]],
+                ],
+                detection_confidence=[0.9, 0.7, 0.8],
+                class_id=[0, 0, 0],
+            ),
+            0.3,
+            False,
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[500, 500], [600, 600]],
+                ],
+                detection_confidence=[0.9, 0.8],
+                class_id=[0, 0],
+            ),
+            id="three-skeletons-two-overlap",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 1],
+            ),
+            0.3,
+            False,
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 1],
+            ),
+            id="class-aware-different-classes-kept",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 1],
+            ),
+            0.3,
+            True,
+            _create_key_points(
+                xy=[[[100, 100], [200, 200]]],
+                detection_confidence=[0.9],
+                class_id=[0],
+            ),
+            id="class-agnostic-suppresses-across-classes",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[0, 0], [100, 100], [200, 200]],
+                    [[0, 0], [110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 0],
+            ),
+            0.3,
+            False,
+            _create_key_points(
+                xy=[[[0, 0], [100, 100], [200, 200]]],
+                detection_confidence=[0.9],
+                class_id=[0],
+            ),
+            id="zero-keypoints-excluded-from-bbox",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200], [0, 0], [0, 0]],
+                    [[0, 0], [0, 0], [110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 1],
+            ),
+            0.3,
+            False,
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200], [0, 0], [0, 0]],
+                    [[0, 0], [0, 0], [110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 1],
+            ),
+            id="multi-skeleton-schema-class-aware",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200], [0, 0], [0, 0]],
+                    [[0, 0], [0, 0], [110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 1],
+            ),
+            0.3,
+            True,
+            _create_key_points(
+                xy=[[[100, 100], [200, 200], [0, 0], [0, 0]]],
+                detection_confidence=[0.9],
+                class_id=[0],
+            ),
+            id="multi-skeleton-schema-class-agnostic",
+        ),
+    ],
+)
+def test_with_nms(key_points, threshold, class_agnostic, expected_result):
+    """NMS filters overlapping keypoint skeletons."""
+    result = key_points.with_nms(threshold=threshold, class_agnostic=class_agnostic)
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    ("key_points", "threshold", "class_agnostic"),
+    [
+        pytest.param(
+            _create_key_points(
+                xy=[[[10, 20], [30, 40]]],
+                class_id=[0],
+            ),
+            0.5,
+            False,
+            id="no-detection-confidence",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[[[10, 20], [30, 40]]],
+                detection_confidence=[0.9],
+            ),
+            0.5,
+            False,
+            id="no-class-id-class-aware",
+        ),
+    ],
+)
+def test_with_nms_raises(key_points, threshold, class_agnostic):
+    """NMS raises when required fields are missing."""
+    with pytest.raises(AssertionError):
+        key_points.with_nms(threshold=threshold, class_agnostic=class_agnostic)

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -1400,7 +1400,7 @@ def test_with_nms(key_points, threshold, class_agnostic, expected_result):
 
 
 @pytest.mark.parametrize(
-    ("key_points", "threshold", "class_agnostic"),
+    ("key_points", "threshold", "class_agnostic", "match"),
     [
         pytest.param(
             _create_key_points(
@@ -1409,6 +1409,7 @@ def test_with_nms(key_points, threshold, class_agnostic, expected_result):
             ),
             0.5,
             False,
+            "detection_confidence",
             id="no-detection-confidence",
         ),
         pytest.param(
@@ -1418,6 +1419,7 @@ def test_with_nms(key_points, threshold, class_agnostic, expected_result):
             ),
             0.5,
             False,
+            "class_id",
             id="no-class-id-class-aware",
         ),
         pytest.param(
@@ -1427,11 +1429,12 @@ def test_with_nms(key_points, threshold, class_agnostic, expected_result):
             ),
             0.5,
             True,
+            "detection_confidence",
             id="no-detection-confidence-class-agnostic",
         ),
     ],
 )
-def test_with_nms_raises(key_points, threshold, class_agnostic):
+def test_with_nms_raises(key_points, threshold, class_agnostic, match):
     """NMS raises when required fields are missing."""
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match=match):
         key_points.with_nms(threshold=threshold, class_agnostic=class_agnostic)

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -1218,6 +1218,110 @@ class TestDeprecatedConfidenceConstructor:
             ),
             id="multi-skeleton-schema-class-agnostic",
         ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[0, 0], [0, 0]],
+                    [[100, 100], [200, 200]],
+                ],
+                detection_confidence=[0.9, 0.8],
+                class_id=[0, 0],
+            ),
+            0.5,
+            False,
+            _create_key_points(
+                xy=[
+                    [[0, 0], [0, 0]],
+                    [[100, 100], [200, 200]],
+                ],
+                detection_confidence=[0.9, 0.8],
+                class_id=[0, 0],
+            ),
+            id="all-zero-skeleton-passes-through",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 0],
+                visible=[[True, False], [False, True]],
+            ),
+            0.3,
+            False,
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 0],
+                visible=[[True, False], [False, True]],
+            ),
+            id="visible-mask-excludes-keypoints-from-bbox",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [0, 0]],
+                    [[300, 300], [0, 0]],
+                ],
+                detection_confidence=[0.9, 0.8],
+                class_id=[0, 0],
+            ),
+            0.3,
+            False,
+            _create_key_points(
+                xy=[
+                    [[100, 100], [0, 0]],
+                    [[300, 300], [0, 0]],
+                ],
+                detection_confidence=[0.9, 0.8],
+                class_id=[0, 0],
+            ),
+            id="single-valid-keypoint-zero-area-bbox",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 0],
+            ),
+            0.0,
+            False,
+            _create_key_points(
+                xy=[[[100, 100], [200, 200]]],
+                detection_confidence=[0.9],
+                class_id=[0],
+            ),
+            id="threshold-zero-suppresses-any-overlap",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 0],
+            ),
+            1.0,
+            False,
+            _create_key_points(
+                xy=[
+                    [[100, 100], [200, 200]],
+                    [[110, 110], [210, 210]],
+                ],
+                detection_confidence=[0.9, 0.7],
+                class_id=[0, 0],
+            ),
+            id="threshold-one-keeps-all",
+        ),
     ],
 )
 def test_with_nms(key_points, threshold, class_agnostic, expected_result):
@@ -1246,6 +1350,15 @@ def test_with_nms(key_points, threshold, class_agnostic, expected_result):
             0.5,
             False,
             id="no-class-id-class-aware",
+        ),
+        pytest.param(
+            _create_key_points(
+                xy=[[[10, 20], [30, 40]]],
+                class_id=[0],
+            ),
+            0.5,
+            True,
+            id="no-detection-confidence-class-agnostic",
         ),
     ],
 )

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -1014,6 +1014,7 @@ class TestDeprecatedConfidenceConstructor:
             f"Field/init drift: {field_names.symmetric_difference(init_params)}"
         )
 
+
 @pytest.mark.parametrize(
     ("key_points", "threshold", "class_agnostic", "expected_result"),
     [


### PR DESCRIPTION
## Summary

- Add `with_nms(threshold, class_agnostic)` method to `KeyPoints` that performs non-max suppression by deriving axis-aligned bounding boxes from valid (non-zero) keypoints and delegating to `box_non_max_suppression`
- Requires `detection_confidence` to be set; supports both class-aware and class-agnostic modes.

https://github.com/user-attachments/assets/ed7bd310-4868-4275-ae04-c88e7a0c2561