### PR TITLE
fix(ci): clear latest alias before deploying docs to `release/latest`

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -62,6 +62,7 @@ jobs:
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          mike delete latest || true
           mike deploy --push latest
 
       - name: 🏷️ Determine release deployment metadata

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mike delete latest || true
+          if mike list | grep -Eq '^latest(\s|$)'; then mike delete latest; fi
           mike deploy --push latest
 
       - name: 🏷️ Determine release deployment metadata


### PR DESCRIPTION
mike deploy fails when target name exists as an alias; delete it first.