### PR TITLE
fix(dataset): stop Pascal VOC export from mutating source detections

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ date_modified: 2026-06-15
 
 - Fixed [#2333](https://github.com/roboflow/supervision/pull/2333): [`sv.DetectionsSmoother`](https://supervision.roboflow.com/latest/detection/tools/smoother/#supervision.detection.tools.smoother.DetectionsSmoother) no longer raises when smoothing detections without `confidence`. Confidence is now averaged over the frames that carry it; when tracks in the same frame disagree on confidence presence, `confidence` is set to `None` for all smoothed detections.
 
+- Fixed [#2341](https://github.com/roboflow/supervision/pull/2341): `sv.DetectionDataset.as_pascal_voc` no longer mutates the source `Detections.xyxy` by the 1-index offset on every call. Previously, repeated exports accumulated a `+1` shift in the caller's bounding boxes.
+
 - Fixed [#2331](https://github.com/roboflow/supervision/pull/2331): `sv.Precision` and `sv.F1Score` now count predictions on background images (empty target set) as false positives, and count predictions of classes absent from ground truth as false positives under `MICRO` and `MACRO` averaging. Previously both edge cases were silently ignored, inflating scores. `WEIGHTED` averaging is unchanged — absent classes retain weight 0, consistent with scikit-learn. Users relying on previous scores should re-evaluate after upgrading; no API change is required.
 
 ### 0.29.0 <small>Jun 15, 2026</small>

--- a/src/supervision/dataset/formats/pascal_voc.py
+++ b/src/supervision/dataset/formats/pascal_voc.py
@@ -21,6 +21,31 @@ def object_to_pascal_voc(
     name: str,
     polygon: npt.NDArray[np.number] | None = None,
 ) -> Element:
+    """Build a Pascal VOC ``<object>`` XML element for one detection.
+
+    Coordinates are converted to 1-indexed Pascal VOC convention before writing.
+    The input arrays are never mutated; new arrays are allocated for the offset.
+
+    Args:
+        xyxy: Bounding box in zero-indexed pixel coordinates ``[x1, y1, x2, y2]``.
+            Shape ``(4,)``.
+        name: Class label string written to the ``<name>`` child element.
+        polygon: Optional segmentation polygon in zero-indexed pixel coordinates.
+            Shape ``(N, 2)``.
+
+    Returns:
+        An XML ``Element`` rooted at ``<object>`` containing ``<name>``,
+        ``<bndbox>``, and optionally ``<polygon>`` children.
+
+    Examples:
+        >>> import numpy as np
+        >>> from supervision.dataset.formats.pascal_voc import object_to_pascal_voc
+        >>> elem = object_to_pascal_voc(np.array([0, 0, 9, 9]), name="cat")
+        >>> elem.find("bndbox/xmin").text
+        '1'
+        >>> elem.find("bndbox/xmax").text
+        '10'
+    """
     root = Element("object")
 
     object_name = SubElement(root, "name")
@@ -84,6 +109,11 @@ def detections_to_pascal_voc(
             polygon points to be removed from the input polygon, in the range [0, 1).
     Returns:
         An XML string in Pascal VOC format representing the detections.
+
+    Note:
+        ``detections`` is never mutated by this function; the source ``xyxy``
+        array is unchanged after the call. The function is therefore safe to
+        call multiple times on the same ``Detections`` object.
     """
     height, width, depth = image_shape
 

--- a/src/supervision/dataset/formats/pascal_voc.py
+++ b/src/supervision/dataset/formats/pascal_voc.py
@@ -26,8 +26,11 @@ def object_to_pascal_voc(
     object_name = SubElement(root, "name")
     object_name.text = name
 
-    # https://github.com/roboflow/supervision/issues/144
-    xyxy += 1
+    # Pascal VOC coordinates are 1-indexed (https://github.com/roboflow/supervision/issues/144).
+    # Rebind to a new array instead of `+= 1`: `xyxy` is a view into the source
+    # `Detections.xyxy` (yielded by `Detections.__iter__`), so an in-place add
+    # would corrupt the caller's detections by +1 on every export.
+    xyxy = xyxy + 1
 
     bndbox = SubElement(root, "bndbox")
     xmin = SubElement(bndbox, "xmin")
@@ -40,8 +43,8 @@ def object_to_pascal_voc(
     ymax.text = str(int(xyxy[3]))
 
     if polygon is not None:
-        # https://github.com/roboflow/supervision/issues/144
-        polygon += 1
+        # 1-indexed, rebound to avoid mutating the caller's array (see above).
+        polygon = polygon + 1
         object_polygon = SubElement(root, "polygon")
         for index, point in enumerate(polygon, start=1):
             x_coordinate, y_coordinate = point

--- a/tests/dataset/formats/test_pascal_voc.py
+++ b/tests/dataset/formats/test_pascal_voc.py
@@ -8,6 +8,7 @@ from defusedxml import ElementTree
 
 from supervision.dataset.formats.pascal_voc import (
     detections_from_xml_obj,
+    detections_to_pascal_voc,
     object_to_pascal_voc,
     parse_polygon_points,
 )
@@ -70,6 +71,35 @@ def test_object_to_pascal_voc(
     with exception:
         result = object_to_pascal_voc(xyxy=xyxy, name=name, polygon=polygon)
         assert are_xml_elements_equal(result, expected_result)
+
+
+def test_object_to_pascal_voc_does_not_mutate_inputs():
+    """Serializing an object must not write the 1-index offset back into the inputs."""
+    xyxy = np.array([10, 20, 30, 40], dtype=np.float32)
+    polygon = np.array([[0, 0], [10, 0], [10, 10], [0, 10]], dtype=np.float32)
+
+    object_to_pascal_voc(xyxy=xyxy, name="test", polygon=polygon)
+
+    assert np.array_equal(xyxy, np.array([10, 20, 30, 40], dtype=np.float32))
+    assert np.array_equal(
+        polygon, np.array([[0, 0], [10, 0], [10, 10], [0, 10]], dtype=np.float32)
+    )
+
+
+def test_detections_to_pascal_voc_does_not_mutate_detections():
+    """Exporting detections must not shift the source xyxy, and must be repeatable."""
+    detections = _create_detections(xyxy=[[10, 20, 30, 40]], class_id=[0])
+    expected_xyxy = detections.xyxy.copy()
+
+    first = detections_to_pascal_voc(
+        detections, classes=["test"], filename="image.jpg", image_shape=(100, 100, 3)
+    )
+    second = detections_to_pascal_voc(
+        detections, classes=["test"], filename="image.jpg", image_shape=(100, 100, 3)
+    )
+
+    assert np.array_equal(detections.xyxy, expected_xyxy)
+    assert first == second
 
 
 @pytest.mark.parametrize(

--- a/tests/dataset/formats/test_pascal_voc.py
+++ b/tests/dataset/formats/test_pascal_voc.py
@@ -86,6 +86,18 @@ def test_object_to_pascal_voc_does_not_mutate_inputs():
     )
 
 
+def test_object_to_pascal_voc_does_not_mutate_view_input():
+    """Mutation guard holds when xyxy is a NumPy row-view (the actual bug scenario)."""
+    base = np.array([[10, 20, 30, 40]], dtype=np.float32)
+    xyxy_view = base[0]  # row-view, shares memory with base
+
+    object_to_pascal_voc(xyxy=xyxy_view, name="test", polygon=None)
+
+    assert np.array_equal(base[0], np.array([10, 20, 30, 40], dtype=np.float32)), (
+        "object_to_pascal_voc mutated the source array via a view"
+    )
+
+
 def test_detections_to_pascal_voc_does_not_mutate_detections():
     """Exporting detections must not shift the source xyxy, and must be repeatable."""
     detections = _create_detections(xyxy=[[10, 20, 30, 40]], class_id=[0])


### PR DESCRIPTION
## Description

`detections_to_pascal_voc` silently mutates the `Detections` it serializes, shifting every bounding box by +1 pixel.

`object_to_pascal_voc` applies the Pascal VOC 1-index offset in place:

```python
xyxy += 1   # src/supervision/dataset/formats/pascal_voc.py
```

`Detections.__iter__` yields each row of `xyxy` as a NumPy **view that shares memory** with `detections.xyxy`, so the in-place `+= 1` writes the offset straight back into the caller's array.

### Impact

```python
det = sv.Detections(xyxy=np.array([[10., 20., 110., 120.]]), class_id=np.array([0]))
ds = sv.DetectionDataset(classes=["cat"], images={...}, annotations={"img": det})
ds.as_pascal_voc(annotations_directory_path="out")

det.xyxy   # -> [[11., 21., 111., 121.]]  (mutated!)
# exporting again compounds it: [[12., 22., 112., 122.]]
```

- A single export corrupts every box in the dataset's in-memory annotations (+1px). Any subsequent use (training, exporting to YOLO/COCO, computing metrics) sees shifted boxes.
- Exporting the same dataset to VOC twice writes materially wrong XML on the second pass (offset compounds by +1 each time).

A single export-then-reload happens to round-trip correctly, because `from_pascal_voc` subtracts 1 and the +1/-1 cancel on the values written to disk. That is why the existing tests (which build a fresh array per case and never assert non-mutation) did not catch it.

## Fix

Rebind to a new array instead of mutating in place:

```python
xyxy = xyxy + 1
polygon = polygon + 1
```

On-disk output is byte-for-byte unchanged; the source `Detections` is left intact.

## Tests

- `test_object_to_pascal_voc_does_not_mutate_inputs` — the serializer leaves its `xyxy`/`polygon` arguments unchanged.
- `test_detections_to_pascal_voc_does_not_mutate_detections` — exporting does not shift `detections.xyxy`, and two consecutive exports produce identical XML.

Both fail on `develop` and pass with this change. Full suite: `tests/dataset/` 179 passed; `pre-commit` (ruff, ruff-format, mypy, codespell) clean.
