### PR TITLE
fix(detection): do not crash `from_inference` on partial `tracker_id`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ date_modified: 2026-06-25
 
 ### 0.29.1 <small>Jun 23, 2026</small>
 
+- Fixed [#2353](https://github.com/roboflow/supervision/pull/2353): `sv.Detections.from_inference` no longer raises `TypeError` when the Inference package returns a mixed batch where only some predictions carry a `tracker_id`. `detections.tracker_id` is `None` for the full result in that case; fully-tracked and fully-untracked batches are unchanged.
+
 - Added [#2275](https://github.com/roboflow/supervision/pull/2275): `show_progress: bool = False` parameter to all `sv.DetectionDataset` load and save methods — `from_coco`, `from_yolo`, `from_pascal_voc`, `as_coco`, `as_yolo`, `as_pascal_voc`, and `save_dataset_images`. When `True`, a `tqdm.auto` progress bar is shown (works in terminal and Jupyter). Defaults to `False` for full backward compatibility; no new dependencies.
 
 - Added [#2027](https://github.com/roboflow/supervision/issues/2027): [`sv.InferenceSlicer`](https://supervision.roboflow.com/latest/detection/tools/inference_slicer/#supervision.detection.tools.inference_slicer.InferenceSlicer) now accepts an open rasterio-style dataset in addition to in-memory images. Each tile is read lazily via a windowed read instead of loading the whole image, enabling tiled inference on multi-GB aerial/drone GeoTIFFs without running out of memory. Detection is duck-typed, so `rasterio` stays an optional dependency installable via `pip install "supervision[geotiff]"` and the core library imports no rasterio symbols. A geographic (non-projected) CRS raises `ValueError`.

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -635,7 +635,13 @@ class Detections:
                 `detections.data["class_name"]` is always present as a
                 string-dtype NumPy array aligned with the detections; it is
                 empty (shape `(0,)`, dtype str) when `predictions` is empty
-                or absent.
+                or absent. `detections.tracker_id` is `None` when no
+                predictions carry a tracker ID, or when only a subset do
+                (mixed batch) — in that case all tracker IDs are dropped to
+                preserve alignment with the bounding boxes. Note: mixed
+                batches containing both RLE/polygon predictions and box-only
+                predictions may misalign the `mask` array; this is a
+                pre-existing limitation not addressed by this fix.
 
         Example:
             ```python

--- a/src/supervision/detection/utils/internal.py
+++ b/src/supervision/detection/utils/internal.py
@@ -143,15 +143,13 @@ def process_roboflow_result(
             class_name.append(prediction["class"])
             confidence.append(prediction["confidence"])
             masks.append(mask)
-            if "tracker_id" in prediction:
-                tracker_ids.append(prediction["tracker_id"])
+            tracker_ids.append(prediction.get("tracker_id"))
         elif "points" not in prediction:
             xyxy.append([x_min, y_min, x_max, y_max])
             class_id.append(prediction["class_id"])
             class_name.append(prediction["class"])
             confidence.append(prediction["confidence"])
-            if "tracker_id" in prediction:
-                tracker_ids.append(prediction["tracker_id"])
+            tracker_ids.append(prediction.get("tracker_id"))
         elif len(prediction["points"]) >= 3:
             polygon = np.array(
                 [[point["x"], point["y"]] for point in prediction["points"]], dtype=int
@@ -164,8 +162,7 @@ def process_roboflow_result(
             class_name.append(prediction["class"])
             confidence.append(prediction["confidence"])
             masks.append(mask)
-            if "tracker_id" in prediction:
-                tracker_ids.append(prediction["tracker_id"])
+            tracker_ids.append(prediction.get("tracker_id"))
 
     xyxy_arr: npt.NDArray[np.floating] = (
         np.array(xyxy, dtype=np.float64) if len(xyxy) > 0 else np.empty((0, 4))
@@ -185,7 +182,9 @@ def process_roboflow_result(
         np.array(masks, dtype=bool) if len(masks) > 0 else None
     )
     tracker_id_arr: npt.NDArray[np.integer] | None = (
-        np.array(tracker_ids, dtype=np.int64) if len(tracker_ids) > 0 else None
+        np.array(tracker_ids, dtype=np.int64)
+        if tracker_ids and None not in tracker_ids
+        else None
     )
     data: dict[str, npt.NDArray[np.generic]] = {CLASS_NAME_DATA_FIELD: class_name_arr}
 

--- a/src/supervision/detection/utils/internal.py
+++ b/src/supervision/detection/utils/internal.py
@@ -74,8 +74,11 @@ def process_roboflow_result(
 
     Returns:
         A 6-tuple of ``(xyxy, confidence, class_id, masks, tracker_ids, data)``
-        where each array is aligned with the others. ``masks`` and
-        ``tracker_ids`` are ``None`` when absent from the predictions.
+        where each array is aligned with the others. ``masks`` is ``None``
+        when no predictions include mask data. ``tracker_ids`` is ``None``
+        when no predictions carry a tracker ID, or when only a subset do
+        (mixed batch) — in that case all tracker IDs are dropped to preserve
+        alignment with ``xyxy``.
 
     Examples:
         >>> from supervision.detection.utils.internal import process_roboflow_result
@@ -181,6 +184,11 @@ def process_roboflow_result(
     masks_arr: npt.NDArray[np.bool_] | None = (
         np.array(masks, dtype=bool) if len(masks) > 0 else None
     )
+    if tracker_ids and 0 < tracker_ids.count(None) < len(tracker_ids):
+        logger.warning(
+            "Partial tracker_id in batch; dropping all tracker_ids to preserve "
+            "alignment with xyxy."
+        )
     tracker_id_arr: npt.NDArray[np.integer] | None = (
         np.array(tracker_ids, dtype=np.int64)
         if tracker_ids and None not in tracker_ids

--- a/src/supervision/detection/utils/internal.py
+++ b/src/supervision/detection/utils/internal.py
@@ -99,7 +99,7 @@ def process_roboflow_result(
     class_id: list[int] = []
     class_name: list[str] = []
     masks: list[npt.NDArray[np.bool_]] = []
-    tracker_ids: list[int] = []
+    tracker_ids: list[int | None] = []
 
     image_width = int(roboflow_result["image"]["width"])
     image_height = int(roboflow_result["image"]["height"])

--- a/tests/detection/test_core.py
+++ b/tests/detection/test_core.py
@@ -943,6 +943,40 @@ def test_is_empty(detections: Detections, expected: bool) -> None:
     assert detections.is_empty() == expected
 
 
+def test_from_inference_partial_tracker_id_does_not_crash() -> None:
+    """Results where only some predictions carry a tracker_id must not raise."""
+    result = {
+        "image": {"width": 200, "height": 200},
+        "predictions": [
+            {
+                "x": 50,
+                "y": 50,
+                "width": 20,
+                "height": 20,
+                "confidence": 0.9,
+                "class": "a",
+                "class_id": 0,
+                "tracker_id": 7,
+            },
+            {
+                "x": 120,
+                "y": 120,
+                "width": 20,
+                "height": 20,
+                "confidence": 0.8,
+                "class": "b",
+                "class_id": 1,
+            },
+        ],
+    }
+
+    detections = Detections.from_inference(result)
+
+    # all detections are kept; tracker_id is dropped rather than misaligned
+    assert len(detections) == 2
+    assert detections.tracker_id is None
+
+
 def test_from_inference_empty_class_name_dtype_matches_non_empty() -> None:
     """Empty and non-empty results should produce string-kind class_name arrays."""
     empty_result = {"predictions": [], "image": {"width": 100, "height": 100}}

--- a/tests/detection/test_core.py
+++ b/tests/detection/test_core.py
@@ -975,6 +975,12 @@ def test_from_inference_partial_tracker_id_does_not_crash() -> None:
     # all detections are kept; tracker_id is dropped rather than misaligned
     assert len(detections) == 2
     assert detections.tracker_id is None
+    assert detections.class_id is not None
+    assert np.array_equal(detections.class_id, np.array([0, 1]))
+    assert detections.confidence is not None
+    assert np.array_equal(detections.confidence, np.array([0.9, 0.8]))
+    assert detections.xyxy.shape == (2, 4)
+    assert detections["class_name"] is not None
 
 
 def test_from_inference_empty_class_name_dtype_matches_non_empty() -> None:

--- a/tests/detection/utils/test_internal.py
+++ b/tests/detection/utils/test_internal.py
@@ -449,6 +449,43 @@ TEST_RLE_NONCONTIGUOUS_MASK[0, 3, 2:4] = True
             ),
             DoesNotRaise(),
         ),  # mixed RLE + box-only batch — masks misaligned with xyxy (known limitation)
+        (
+            {
+                "predictions": [
+                    {
+                        "x": 1.5,
+                        "y": 1.5,
+                        "width": 2.0,
+                        "height": 2.0,
+                        "confidence": 0.9,
+                        "class_id": 0,
+                        "class": "person",
+                        "tracker_id": 7,
+                    },
+                    {
+                        "x": 3.0,
+                        "y": 3.0,
+                        "width": 2.0,
+                        "height": 2.0,
+                        "confidence": 0.8,
+                        "class_id": 1,
+                        "class": "car",
+                    },
+                ],
+                "image": {"width": 4, "height": 4},
+            },
+            (
+                np.array([[0.5, 0.5, 2.5, 2.5], [2.0, 2.0, 4.0, 4.0]]),
+                np.array([0.9, 0.8]),
+                np.array([0, 1]),
+                None,
+                # tracker_id is None when only some detections carry one, rather
+                # than an array misaligned with xyxy that would raise ValueError.
+                None,
+                {CLASS_NAME_DATA_FIELD: np.array(["person", "car"])},
+            ),
+            DoesNotRaise(),
+        ),  # mixed tracker_id batch — tracker_id is None instead of misaligning
     ],
 )
 def test_process_roboflow_result(

--- a/tests/detection/utils/test_internal.py
+++ b/tests/detection/utils/test_internal.py
@@ -449,7 +449,7 @@ TEST_RLE_NONCONTIGUOUS_MASK[0, 3, 2:4] = True
             ),
             DoesNotRaise(),
         ),  # mixed RLE + box-only batch — masks misaligned with xyxy (known limitation)
-        (
+        pytest.param(
             {
                 "predictions": [
                     {
@@ -485,7 +485,44 @@ TEST_RLE_NONCONTIGUOUS_MASK[0, 3, 2:4] = True
                 {CLASS_NAME_DATA_FIELD: np.array(["person", "car"])},
             ),
             DoesNotRaise(),
-        ),  # mixed tracker_id batch — tracker_id is None instead of misaligning
+            id="mixed_tracker_id_batch_drops_to_none",
+        ),
+        pytest.param(
+            {
+                "predictions": [
+                    {
+                        "x": 1.5,
+                        "y": 1.5,
+                        "width": 2.0,
+                        "height": 2.0,
+                        "confidence": 0.9,
+                        "class_id": 0,
+                        "class": "person",
+                    },
+                    {
+                        "x": 3.0,
+                        "y": 3.0,
+                        "width": 2.0,
+                        "height": 2.0,
+                        "confidence": 0.8,
+                        "class_id": 1,
+                        "class": "car",
+                    },
+                ],
+                "image": {"width": 4, "height": 4},
+            },
+            (
+                np.array([[0.5, 0.5, 2.5, 2.5], [2.0, 2.0, 4.0, 4.0]]),
+                np.array([0.9, 0.8]),
+                np.array([0, 1]),
+                None,
+                # None not in tracker_ids prevents np.array([None, None], dtype=int64)
+                None,
+                {CLASS_NAME_DATA_FIELD: np.array(["person", "car"])},
+            ),
+            DoesNotRaise(),
+            id="all_absent_tracker_id_no_raise",
+        ),
     ],
 )
 def test_process_roboflow_result(


### PR DESCRIPTION
## Bug

`Detections.from_inference` raises when a Roboflow/Inference result has some predictions with a `tracker_id` and some without:

```
ValueError: tracker_id must be a 1D np.ndarray with shape (3,), but got shape (2,)
```

In `process_roboflow_result`, every branch appends `xyxy`, `confidence`, `class_id` and `class` for each prediction, but `tracker_id` was appended only when the key was present. A mixed batch then leaves `tracker_ids` shorter than the boxes, and `Detections` validation rejects it.

To be clear about scope: ByteTrack (both supervision's own and the inference block) attaches a `tracker_id` to every detection, so a standard tracking pipeline won't hit this. It comes up when predictions are assembled or merged by hand, or come from a source that only tracks some of them. So this is more of a robustness fix: the connector degrades gracefully instead of raising a confusing shape error on that input.

## Fix

Collect `tracker_id` for every prediction (`None` when absent) and build the array only when all detections carry one, otherwise keep it `None`. Fully tracked results still get the array, fully untracked results still get `None`, so existing behavior is unchanged; only the previously crashing mixed case changes (it now drops `tracker_id` rather than misaligning).

## Tests

Added a `process_roboflow_result` case for a mixed batch and an end to end `from_inference` test that asserts it no longer raises and keeps all detections.