### PR TITLE
chore: postpone annotations and add validation refinements

### DIFF
--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -111,7 +111,7 @@ def coco_annotations_to_masks(
             masks.append(empty_mask.copy())
             continue
 
-        if image_annotation.get("iscrowd", 0):
+        if isinstance(segmentation, dict):
             if "counts" not in segmentation:
                 warnings.warn(
                     "Skipping annotation "

--- a/src/supervision/draw/utils.py
+++ b/src/supervision/draw/utils.py
@@ -318,6 +318,7 @@ def draw_image(
 
     Raises:
         FileNotFoundError: If the image path does not exist.
+        OSError: If the image path exists but cannot be decoded.
         ValueError: For invalid opacity or rectangle dimensions.
     """
 
@@ -325,7 +326,12 @@ def draw_image(
     if isinstance(image, str):
         if not os.path.exists(image):
             raise FileNotFoundError(f"Image path ('{image}') does not exist.")
-        image = cv2.imread(image, cv2.IMREAD_UNCHANGED)
+        loaded_image = cv2.imread(image, cv2.IMREAD_UNCHANGED)
+        if loaded_image is None:
+            raise OSError(f"Could not decode image path ('{image}').")
+        image_np = cast(npt.NDArray[np.uint8], loaded_image)
+    else:
+        image_np = image
 
     # Validate opacity
     if not 0.0 <= opacity <= 1.0:
@@ -345,12 +351,13 @@ def draw_image(
         raise ValueError("Invalid rectangle dimensions.")
 
     # Resize and isolate alpha channel
-    image = cv2.resize(image, (rect_width, rect_height))
-    image = cast(npt.NDArray[np.uint8], image)
+    image_np = cast(
+        npt.NDArray[np.uint8], cv2.resize(image_np, (rect_width, rect_height))
+    )
     alpha_channel = (
-        image[:, :, 3]
-        if image.shape[2] == 4
-        else np.ones((rect_height, rect_width), dtype=image.dtype) * 255
+        image_np[:, :, 3]
+        if image_np.shape[2] == 4
+        else np.ones((rect_height, rect_width), dtype=image_np.dtype) * 255
     )
     alpha_scaled = cv2.convertScaleAbs(alpha_channel * opacity)
 
@@ -359,7 +366,7 @@ def draw_image(
     alpha_float = alpha_scaled.astype(np.float32) / 255.0
     blended_roi = cv2.convertScaleAbs(
         (1 - alpha_float[..., np.newaxis]) * scene_roi
-        + alpha_float[..., np.newaxis] * image[:, :, :3]
+        + alpha_float[..., np.newaxis] * image_np[:, :, :3]
     )
 
     # Update the scene

--- a/src/supervision/draw/utils.py
+++ b/src/supervision/draw/utils.py
@@ -333,6 +333,9 @@ def draw_image(
     else:
         image_np = image
 
+    if image_np.ndim != 3 or image_np.shape[2] not in (3, 4):
+        raise ValueError("Image must have 3 or 4 channels.")
+
     # Validate opacity
     if not 0.0 <= opacity <= 1.0:
         raise ValueError("Opacity must be between 0.0 and 1.0.")

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -171,18 +171,30 @@ class F1Score(Metric):
                 # Only predictions are present (e.g. a background image); every
                 # prediction is a false positive.
                 if predictions.class_id is None or predictions.confidence is None:
-                    continue
+                    raise ValueError(
+                        "F1Score metric requires `class_id` and `confidence` "
+                        "on predictions."
+                    )
+                prediction_class_ids = np.asarray(predictions.class_id, dtype=np.int32)
+                prediction_confidence = np.asarray(
+                    predictions.confidence, dtype=np.float32
+                )
                 stats.append(
                     (
                         np.zeros(
                             (len(predictions), iou_thresholds.size), dtype=np.bool_
                         ),
-                        predictions.confidence,
-                        predictions.class_id,
+                        prediction_confidence,
+                        prediction_class_ids,
                         np.zeros((0,), dtype=np.int32),
                     )
                 )
             elif len(targets) > 0:
+                if predictions.class_id is None or targets.class_id is None:
+                    raise ValueError(
+                        "F1Score metric requires `class_id` on both predictions "
+                        "and targets."
+                    )
                 if len(predictions) == 0:
                     stats.append(
                         (
@@ -194,6 +206,17 @@ class F1Score(Metric):
                     )
 
                 else:
+                    if predictions.confidence is None:
+                        raise ValueError(
+                            "F1Score metric requires `confidence` on predictions."
+                        )
+                    prediction_class_ids = np.asarray(
+                        predictions.class_id, dtype=np.int32
+                    )
+                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)
+                    prediction_confidence = np.asarray(
+                        predictions.confidence, dtype=np.float32
+                    )
                     if self._metric_target == MetricTarget.BOXES:
                         iou = box_iou_batch(target_contents, prediction_contents)
                     elif self._metric_target == MetricTarget.MASKS:
@@ -208,21 +231,17 @@ class F1Score(Metric):
                         )
 
                     matches = self._match_detection_batch(
-                        predictions.class_id
-                        if predictions.class_id is not None
-                        else np.array([]),
-                        targets.class_id
-                        if targets.class_id is not None
-                        else np.array([]),
+                        prediction_class_ids,
+                        target_class_ids,
                         iou,
                         iou_thresholds,
                     )
                     stats.append(
                         (
                             matches,
-                            predictions.confidence,
-                            predictions.class_id,
-                            targets.class_id,
+                            prediction_confidence,
+                            prediction_class_ids,
+                            target_class_ids,
                         )
                     )
 

--- a/src/supervision/metrics/mean_average_recall.py
+++ b/src/supervision/metrics/mean_average_recall.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -389,6 +389,11 @@ class MeanAverageRecall(Metric):
             target_contents = self._detections_content(targets)
 
             if len(targets) > 0:
+                if predictions.class_id is None or targets.class_id is None:
+                    raise ValueError(
+                        "MeanAverageRecall metric requires `class_id` on both "
+                        "predictions and targets."
+                    )
                 if len(predictions) == 0:
                     stats.append(
                         (
@@ -400,6 +405,18 @@ class MeanAverageRecall(Metric):
                     )
 
                 else:
+                    if predictions.confidence is None:
+                        raise ValueError(
+                            "MeanAverageRecall metric requires `confidence` on "
+                            "predictions."
+                        )
+                    prediction_class_ids = np.asarray(
+                        predictions.class_id, dtype=np.int32
+                    )
+                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)
+                    prediction_confidence = np.asarray(
+                        predictions.confidence, dtype=np.float32
+                    )
                     if self._metric_target == MetricTarget.BOXES:
                         iou = box_iou_batch(target_contents, prediction_contents)
                     elif self._metric_target == MetricTarget.MASKS:
@@ -414,27 +431,19 @@ class MeanAverageRecall(Metric):
                         )
 
                     matches = self._match_detection_batch(
-                        predictions.class_id
-                        if predictions.class_id is not None
-                        else np.array([]),
-                        targets.class_id
-                        if targets.class_id is not None
-                        else np.array([]),
+                        prediction_class_ids,
+                        target_class_ids,
                         iou,
                         iou_thresholds,
                     )
 
-                    sorted_indices = np.argsort(
-                        -cast(npt.NDArray[np.float32], predictions.confidence)
-                    )
+                    sorted_indices = np.argsort(-prediction_confidence)
                     stats.append(
                         (
                             matches[sorted_indices],
                             np.arange(len(predictions)),
-                            cast(npt.NDArray[np.int32], predictions.class_id)[
-                                sorted_indices
-                            ],
-                            cast(npt.NDArray[np.int32], targets.class_id),
+                            prediction_class_ids[sorted_indices],
+                            target_class_ids,
                         )
                     )
 

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -174,18 +174,30 @@ class Precision(Metric):
                 # Only predictions are present (e.g. a background image); every
                 # prediction is a false positive.
                 if predictions.class_id is None or predictions.confidence is None:
-                    continue
+                    raise ValueError(
+                        "Precision metric requires `class_id` and `confidence` "
+                        "on predictions."
+                    )
+                prediction_class_ids = np.asarray(predictions.class_id, dtype=np.int32)
+                prediction_confidence = np.asarray(
+                    predictions.confidence, dtype=np.float32
+                )
                 stats.append(
                     (
                         np.zeros(
                             (len(predictions), iou_thresholds.size), dtype=np.bool_
                         ),
-                        predictions.confidence,
-                        predictions.class_id,
+                        prediction_confidence,
+                        prediction_class_ids,
                         np.zeros((0,), dtype=np.int32),
                     )
                 )
             elif len(targets) > 0:
+                if predictions.class_id is None or targets.class_id is None:
+                    raise ValueError(
+                        "Precision metric requires `class_id` on both predictions "
+                        "and targets."
+                    )
                 if len(predictions) == 0:
                     stats.append(
                         (
@@ -197,6 +209,17 @@ class Precision(Metric):
                     )
 
                 else:
+                    if predictions.confidence is None:
+                        raise ValueError(
+                            "Precision metric requires `confidence` on predictions."
+                        )
+                    prediction_class_ids = np.asarray(
+                        predictions.class_id, dtype=np.int32
+                    )
+                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)
+                    prediction_confidence = np.asarray(
+                        predictions.confidence, dtype=np.float32
+                    )
                     if self._metric_target == MetricTarget.BOXES:
                         iou = box_iou_batch(target_contents, prediction_contents)
                     elif self._metric_target == MetricTarget.MASKS:
@@ -211,21 +234,17 @@ class Precision(Metric):
                         )
 
                     matches = self._match_detection_batch(
-                        predictions.class_id
-                        if predictions.class_id is not None
-                        else np.array([]),
-                        targets.class_id
-                        if targets.class_id is not None
-                        else np.array([]),
+                        prediction_class_ids,
+                        target_class_ids,
                         iou,
                         iou_thresholds,
                     )
                     stats.append(
                         (
                             matches,
-                            predictions.confidence,
-                            predictions.class_id,
-                            targets.class_id,
+                            prediction_confidence,
+                            prediction_class_ids,
+                            target_class_ids,
                         )
                     )
 

--- a/src/supervision/metrics/recall.py
+++ b/src/supervision/metrics/recall.py
@@ -163,6 +163,11 @@ class Recall(Metric):
             target_contents = self._detections_content(targets)
 
             if len(targets) > 0:
+                if predictions.class_id is None or targets.class_id is None:
+                    raise ValueError(
+                        "Recall metric requires `class_id` on both predictions "
+                        "and targets."
+                    )
                 if len(predictions) == 0:
                     stats.append(
                         (
@@ -174,6 +179,17 @@ class Recall(Metric):
                     )
 
                 else:
+                    if predictions.confidence is None:
+                        raise ValueError(
+                            "Recall metric requires `confidence` on predictions."
+                        )
+                    prediction_class_ids = np.asarray(
+                        predictions.class_id, dtype=np.int32
+                    )
+                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)
+                    prediction_confidence = np.asarray(
+                        predictions.confidence, dtype=np.float32
+                    )
                     if self._metric_target == MetricTarget.BOXES:
                         iou = box_iou_batch(target_contents, prediction_contents)
                     elif self._metric_target == MetricTarget.MASKS:
@@ -188,21 +204,17 @@ class Recall(Metric):
                         )
 
                     matches = self._match_detection_batch(
-                        predictions.class_id
-                        if predictions.class_id is not None
-                        else np.array([]),
-                        targets.class_id
-                        if targets.class_id is not None
-                        else np.array([]),
+                        prediction_class_ids,
+                        target_class_ids,
                         iou,
                         iou_thresholds,
                     )
                     stats.append(
                         (
                             matches,
-                            predictions.confidence,
-                            predictions.class_id,
-                            targets.class_id,
+                            prediction_confidence,
+                            prediction_class_ids,
+                            target_class_ids,
                         )
                     )
 

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -2,6 +2,8 @@
 Tests for supervision/annotators/core.py
 """
 
+from __future__ import annotations
+
 import warnings
 
 import numpy as np

--- a/tests/annotators/test_docs.py
+++ b/tests/annotators/test_docs.py
@@ -1,5 +1,7 @@
 """Regression tests for docs/detection/annotators.md tab structure."""
 
+from __future__ import annotations
+
 import ast
 import re
 from pathlib import Path

--- a/tests/assets/test_downloader.py
+++ b/tests/assets/test_downloader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest

--- a/tests/assets/test_list.py
+++ b/tests/assets/test_list.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from supervision.assets.list import (
     BASE_IMAGE_URL,
     BASE_VIDEO_URL,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import matplotlib
 import numpy as np
 import pytest

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1247,6 +1247,31 @@ def test_load_coco_annotations_force_masks_with_no_annotations(
     assert annotations[no_annotations_path] == Detections.empty()
 
 
+def test_coco_annotations_to_masks_handles_rle_polygon_and_invalid_dict() -> None:
+    image_annotations = [
+        {"id": 1, "segmentation": {"size": [5, 5], "counts": [15, 2, 3, 2, 3]}},
+        {"id": 2, "segmentation": [[0, 0, 4, 0, 4, 4, 0, 4]]},
+        {"id": 3, "segmentation": {"size": [5, 5]}},
+    ]
+
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "Skipping annotation 3: segmentation is a dict but missing 'counts' key "
+            r"\(expected RLE format\)"
+        ),
+    ):
+        masks = coco_annotations_to_masks(
+            image_annotations=image_annotations,
+            resolution_wh=(5, 5),
+        )
+
+    assert masks.shape == (3, 5, 5)
+    assert masks[0].any()
+    assert masks[1].any()
+    assert not masks[2].any()
+
+
 @pytest.mark.parametrize(
     "file_name",
     [".", "", "subdir/.."],

--- a/tests/detection/test_polygon_zone_annotator.py
+++ b/tests/detection/test_polygon_zone_annotator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/detection/test_polygonzone.py
+++ b/tests/detection/test_polygonzone.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import ExitStack as DoesNotRaise
 
 import numpy as np

--- a/tests/detection/utils/test_vlms.py
+++ b/tests/detection/utils/test_vlms.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from supervision.detection.utils.vlms import edit_distance, fuzzy_match_index

--- a/tests/draw/test_utils.py
+++ b/tests/draw/test_utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pytest
+
+from supervision.draw.utils import draw_image
+from supervision.geometry.core import Rect
+
+
+def test_draw_image_invalid_path_raises_oserror(tmp_path) -> None:
+    """Existing but undecodable image files raise OSError."""
+    invalid_image_path = tmp_path / "invalid_image.dat"
+    invalid_image_path.write_bytes(b"not an image")
+    scene = np.zeros((100, 100, 3), dtype=np.uint8)
+    rect = Rect(x=0, y=0, width=100, height=100)
+
+    with pytest.raises(OSError, match="Could not decode image path"):
+        draw_image(
+            scene=scene,
+            image=str(invalid_image_path),
+            opacity=1.0,
+            rect=rect,
+        )
+
+
+def test_draw_image_valid_image(tmp_path) -> None:
+    """Valid image files are decoded and drawn onto the scene."""
+    image = np.zeros((100, 100, 3), dtype=np.uint8)
+    image_path = tmp_path / "image.png"
+    cv2.imwrite(str(image_path), image)
+
+    scene = np.zeros((100, 100, 3), dtype=np.uint8)
+    rect = Rect(x=0, y=0, width=100, height=100)
+
+    result = draw_image(
+        scene=scene,
+        image=str(image_path),
+        opacity=1.0,
+        rect=rect,
+    )
+
+    assert isinstance(result, np.ndarray)

--- a/tests/draw/test_utils.py
+++ b/tests/draw/test_utils.py
@@ -41,3 +41,36 @@ def test_draw_image_valid_image(tmp_path) -> None:
     )
 
     assert isinstance(result, np.ndarray)
+
+
+def test_draw_image_grayscale_file_raises_value_error(tmp_path) -> None:
+    """Grayscale image files raise ValueError before channel access."""
+    image = np.zeros((100, 100), dtype=np.uint8)
+    image_path = tmp_path / "grayscale.png"
+    cv2.imwrite(str(image_path), image)
+
+    scene = np.zeros((100, 100, 3), dtype=np.uint8)
+    rect = Rect(x=0, y=0, width=100, height=100)
+
+    with pytest.raises(ValueError, match="3 or 4 channels"):
+        draw_image(
+            scene=scene,
+            image=str(image_path),
+            opacity=1.0,
+            rect=rect,
+        )
+
+
+def test_draw_image_grayscale_array_raises_value_error() -> None:
+    """Grayscale image arrays raise ValueError before channel access."""
+    image = np.zeros((100, 100), dtype=np.uint8)
+    scene = np.zeros((100, 100, 3), dtype=np.uint8)
+    rect = Rect(x=0, y=0, width=100, height=100)
+
+    with pytest.raises(ValueError, match="3 or 4 channels"):
+        draw_image(
+            scene=scene,
+            image=image,
+            opacity=1.0,
+            rect=rect,
+        )

--- a/tests/geometry/test_core.py
+++ b/tests/geometry/test_core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from supervision.geometry.core import Point, Vector

--- a/tests/geometry/test_utils.py
+++ b/tests/geometry/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/key_points/test_annotators.py
+++ b/tests/key_points/test_annotators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import nullcontext as DoesNotRaise
 
 import numpy as np

--- a/tests/key_points/test_skeletons.py
+++ b/tests/key_points/test_skeletons.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from supervision.key_points.skeletons import (
     SKELETONS_BY_EDGE_COUNT,
     SKELETONS_BY_VERTEX_COUNT,

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 import numpy as np
 import pytest
@@ -145,7 +145,7 @@ def target_class_1():
 def _yolo_dataset_factory(
     tmp_path,
     num_images: int = 20,
-    classes: Optional[list[str]] = None,
+    classes: list[str] | None = None,
     objects_per_image_range: tuple[int, int] = (1, 3),
 ):
     """

--- a/tests/metrics/test_f1_score.py
+++ b/tests/metrics/test_f1_score.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/metrics/test_f1_score.py
+++ b/tests/metrics/test_f1_score.py
@@ -299,6 +299,45 @@ class TestF1Score:
             metric.update([detections_50_50], [targets_50_50, targets_50_50])
 
     @pytest.mark.parametrize(
+        "missing_attribute",
+        ["predictions_class_id", "targets_class_id", "predictions_confidence"],
+    )
+    def test_compute_value_error_for_missing_required_fields(
+        self, missing_attribute
+    ) -> None:
+        """Test compute raises ValueError when required fields are missing."""
+        metric = F1Score()
+        boxes = np.array([[10, 10, 50, 50]], dtype=np.float32)
+        class_id = np.array([0], dtype=np.int32)
+        confidence = np.array([0.9], dtype=np.float32)
+
+        predictions = Detections(
+            xyxy=boxes,
+            confidence=confidence,
+            class_id=class_id,
+        )
+        targets = Detections(
+            xyxy=boxes,
+            class_id=class_id,
+        )
+
+        if missing_attribute == "predictions_class_id":
+            predictions = Detections(
+                xyxy=boxes,
+                confidence=confidence,
+            )
+        elif missing_attribute == "targets_class_id":
+            targets = Detections(xyxy=boxes)
+        else:
+            predictions = Detections(
+                xyxy=boxes,
+                class_id=class_id,
+            )
+
+        with pytest.raises(ValueError, match="F1Score metric requires"):
+            metric.update(predictions, targets).compute()
+
+    @pytest.mark.parametrize(
         "averaging_method",
         [AveragingMethod.MACRO, AveragingMethod.MICRO, AveragingMethod.WEIGHTED],
     )

--- a/tests/metrics/test_mean_average_precision.py
+++ b/tests/metrics/test_mean_average_precision.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from supervision.config import ORIENTED_BOX_COORDINATES

--- a/tests/metrics/test_mean_average_recall.py
+++ b/tests/metrics/test_mean_average_recall.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/metrics/test_mean_average_recall.py
+++ b/tests/metrics/test_mean_average_recall.py
@@ -377,6 +377,44 @@ def test_single_perfect_detection():
     np.testing.assert_almost_equal(result.recall_scores, expected, decimal=6)
 
 
+@pytest.mark.parametrize(
+    "missing_attribute",
+    ["predictions_class_id", "targets_class_id", "predictions_confidence"],
+)
+def test_compute_value_error_for_missing_required_fields(missing_attribute) -> None:
+    """Test compute raises ValueError when required fields are missing."""
+    metric = MeanAverageRecall()
+    boxes = np.array([[10, 10, 50, 50]], dtype=np.float32)
+    class_id = np.array([0], dtype=np.int32)
+    confidence = np.array([0.9], dtype=np.float32)
+
+    predictions = Detections(
+        xyxy=boxes,
+        confidence=confidence,
+        class_id=class_id,
+    )
+    targets = Detections(
+        xyxy=boxes,
+        class_id=class_id,
+    )
+
+    if missing_attribute == "predictions_class_id":
+        predictions = Detections(
+            xyxy=boxes,
+            confidence=confidence,
+        )
+    elif missing_attribute == "targets_class_id":
+        targets = Detections(xyxy=boxes)
+    else:
+        predictions = Detections(
+            xyxy=boxes,
+            class_id=class_id,
+        )
+
+    with pytest.raises(ValueError, match="MeanAverageRecall metric requires"):
+        metric.update(predictions, targets).compute()
+
+
 def test_complex_integration_scenario(
     complex_scenario_predictions, complex_scenario_targets
 ):

--- a/tests/metrics/test_oriented_bounding_box_metrics.py
+++ b/tests/metrics/test_oriented_bounding_box_metrics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/metrics/test_precision.py
+++ b/tests/metrics/test_precision.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/metrics/test_precision.py
+++ b/tests/metrics/test_precision.py
@@ -267,6 +267,45 @@ class TestPrecision:
             metric.update([detections_50_50], [targets_50_50, targets_50_50])
 
     @pytest.mark.parametrize(
+        "missing_attribute",
+        ["predictions_class_id", "targets_class_id", "predictions_confidence"],
+    )
+    def test_compute_value_error_for_missing_required_fields(
+        self, missing_attribute
+    ) -> None:
+        """Test compute raises ValueError when required fields are missing."""
+        metric = Precision()
+        boxes = np.array([[10, 10, 50, 50]], dtype=np.float32)
+        class_id = np.array([0], dtype=np.int32)
+        confidence = np.array([0.9], dtype=np.float32)
+
+        predictions = Detections(
+            xyxy=boxes,
+            confidence=confidence,
+            class_id=class_id,
+        )
+        targets = Detections(
+            xyxy=boxes,
+            class_id=class_id,
+        )
+
+        if missing_attribute == "predictions_class_id":
+            predictions = Detections(
+                xyxy=boxes,
+                confidence=confidence,
+            )
+        elif missing_attribute == "targets_class_id":
+            targets = Detections(xyxy=boxes)
+        else:
+            predictions = Detections(
+                xyxy=boxes,
+                class_id=class_id,
+            )
+
+        with pytest.raises(ValueError, match="Precision metric requires"):
+            metric.update(predictions, targets).compute()
+
+    @pytest.mark.parametrize(
         "averaging_method",
         [AveragingMethod.MACRO, AveragingMethod.MICRO, AveragingMethod.WEIGHTED],
     )

--- a/tests/metrics/test_recall.py
+++ b/tests/metrics/test_recall.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/metrics/test_recall.py
+++ b/tests/metrics/test_recall.py
@@ -198,6 +198,45 @@ class TestRecall:
             metric.update([detections_50_50], [targets_50_50, targets_50_50])
 
     @pytest.mark.parametrize(
+        "missing_attribute",
+        ["predictions_class_id", "targets_class_id", "predictions_confidence"],
+    )
+    def test_compute_value_error_for_missing_required_fields(
+        self, missing_attribute
+    ) -> None:
+        """Test compute raises ValueError when required fields are missing."""
+        metric = Recall()
+        boxes = np.array([[10, 10, 50, 50]], dtype=np.float32)
+        class_id = np.array([0], dtype=np.int32)
+        confidence = np.array([0.9], dtype=np.float32)
+
+        predictions = Detections(
+            xyxy=boxes,
+            confidence=confidence,
+            class_id=class_id,
+        )
+        targets = Detections(
+            xyxy=boxes,
+            class_id=class_id,
+        )
+
+        if missing_attribute == "predictions_class_id":
+            predictions = Detections(
+                xyxy=boxes,
+                confidence=confidence,
+            )
+        elif missing_attribute == "targets_class_id":
+            targets = Detections(xyxy=boxes)
+        else:
+            predictions = Detections(
+                xyxy=boxes,
+                class_id=class_id,
+            )
+
+        with pytest.raises(ValueError, match="Recall metric requires"):
+            metric.update(predictions, targets).compute()
+
+    @pytest.mark.parametrize(
         "averaging_method",
         [AveragingMethod.MACRO, AveragingMethod.MICRO, AveragingMethod.WEIGHTED],
     )

--- a/tests/tracker/test_byte_tracker.py
+++ b/tests/tracker/test_byte_tracker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import cv2

--- a/tests/utils/test_conversion.py
+++ b/tests/utils/test_conversion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from PIL import Image, ImageChops
 

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from PIL import Image, ImageChops

--- a/tests/utils/test_internal.py
+++ b/tests/utils/test_internal.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import ExitStack as DoesNotRaise
 from dataclasses import dataclass, field
 from typing import Any

--- a/tests/utils/test_iterables.py
+++ b/tests/utils/test_iterables.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from supervision.utils.iterables import create_batches, fill

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
This pull request ports the useful Python typing and validation refinements from #2260 while keeping the branch focused.

Summary:
- Adds postponed annotation evaluation to the touched test modules.
- Modernizes the _yolo_dataset_factory classes annotation to list[str] | None.
- Adds targeted runtime validation for metric inputs so missing class_id or prediction confidence raises clear ValueErrors instead of lower-level NumPy/type errors.
- Adds COCO mask handling for malformed RLE segmentation dictionaries missing counts, preserving mask alignment with an empty mask and warning.
- Adds draw_image validation for undecodable files and unsupported image channel shapes.

Compatibility note:
- Metric classes now fail fast on missing required detection fields instead of silently skipping some prediction-only invalid inputs. This is intentional because those fields are required to compute meaningful detection metrics.