### PR TITLE
fix(detection): scale `from_tensorflow` boxes by correct axes

### DIFF
--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -404,9 +404,11 @@ class Detections:
             ```
         """
 
+        # Tensorflow returns normalized boxes as [ymin, xmin, ymax, xmax], so the
+        # y coordinates (cols 0, 2) scale by height and x (cols 1, 3) by width.
         boxes = tensorflow_results["detection_boxes"][0].numpy()
-        boxes[:, [0, 2]] *= resolution_wh[0]
-        boxes[:, [1, 3]] *= resolution_wh[1]
+        boxes[:, [0, 2]] *= resolution_wh[1]
+        boxes[:, [1, 3]] *= resolution_wh[0]
         boxes = boxes[:, [1, 0, 3, 2]]
         return cls(
             xyxy=boxes,

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -407,13 +407,25 @@ class Detections:
         inference result.
 
         Args:
-            tensorflow_results: The output results from Tensorflow Hub.
+            tensorflow_results: Raw output dict from a TensorFlow Hub
+                object-detection model. Must contain:
+                ``"detection_boxes"`` (shape ``[1, N, 4]``, normalized
+                ``[ymin, xmin, ymax, xmax]``), ``"detection_scores"``
+                (shape ``[1, N]``), and ``"detection_classes"``
+                (shape ``[1, N]``).
             resolution_wh: The input image resolution as `(width, height)`.
                 Bounding boxes from Tensorflow are normalized and are scaled
                 to absolute coordinates using this resolution.
 
         Returns:
             A new Detections object.
+
+        Note:
+            TensorFlow Hub object-detection models return bounding boxes
+            normalized as ``[ymin, xmin, ymax, xmax]``. This method rescales
+            them to absolute pixel coordinates and reorders them to ``xyxy``
+            (``[xmin, ymin, xmax, ymax]``) before constructing the
+            :class:`Detections` object.
 
         Example:
             ```python
@@ -424,7 +436,7 @@ class Detections:
 
             module_handle = "https://tfhub.dev/tensorflow/centernet/hourglass_512x512_kpts/1"
             model = hub.load(module_handle)
-            img = np.array(cv2.imread(SOURCE_IMAGE_PATH))
+            img = np.array(cv2.imread("<SOURCE_IMAGE_PATH>"))
             result = model(img)
             detections = sv.Detections.from_tensorflow(
                 result, resolution_wh=(img.shape[1], img.shape[0])

--- a/tests/detection/test_from_adapters.py
+++ b/tests/detection/test_from_adapters.py
@@ -113,8 +113,7 @@ def test_from_yolo_nas_handles_empty_and_non_empty(
 
 
 def test_from_tensorflow_scales_axes_on_non_square_image() -> None:
-    # Tensorflow boxes are normalized [ymin, xmin, ymax, xmax]; y must scale by
-    # height and x by width. A non-square image exposes a swapped scaling.
+    """Non-square image exposes swapped scaling: y uses height, x uses width."""
     results = {
         "detection_boxes": [
             _FakeTensor(np.array([[0.1, 0.2, 0.5, 0.6]], dtype=np.float32))

--- a/tests/detection/test_from_adapters.py
+++ b/tests/detection/test_from_adapters.py
@@ -7,6 +7,7 @@ import supervision.detection.core as detection_core
 from supervision.config import CLASS_NAME_DATA_FIELD
 from supervision.detection.core import Detections
 from tests.helpers import (
+    _FakeTensor,
     _FakeUltralyticsBoxes,
     _FakeUltralyticsResults,
     _FakeYoloNasPrediction,
@@ -111,3 +112,22 @@ def test_from_yolo_nas_handles_empty_and_non_empty(
         np.testing.assert_allclose(det.xyxy, bboxes)
         np.testing.assert_allclose(det.confidence, conf)
         np.testing.assert_array_equal(det.class_id, labels.astype(int))
+
+
+def test_from_tensorflow_scales_axes_on_non_square_image() -> None:
+    # Tensorflow boxes are normalized [ymin, xmin, ymax, xmax]; y must scale by
+    # height and x by width. A non-square image exposes a swapped scaling.
+    results = {
+        "detection_boxes": [
+            _FakeTensor(np.array([[0.1, 0.2, 0.5, 0.6]], dtype=np.float32))
+        ],
+        "detection_scores": [_FakeTensor(np.array([0.9], dtype=np.float32))],
+        "detection_classes": [_FakeTensor(np.array([1], dtype=np.float32))],
+    }
+
+    det = Detections.from_tensorflow(results, resolution_wh=(1000, 500))
+
+    # xmin=0.2*1000, ymin=0.1*500, xmax=0.6*1000, ymax=0.5*500
+    np.testing.assert_allclose(det.xyxy, [[200.0, 50.0, 600.0, 250.0]])
+    np.testing.assert_allclose(det.confidence, [0.9])
+    np.testing.assert_array_equal(det.class_id, [1])


### PR DESCRIPTION
## Description

`Detections.from_tensorflow` scaled the normalized box coordinates by the **wrong image dimensions**. Tensorflow Hub object-detection models emit `detection_boxes` as normalized `[ymin, xmin, ymax, xmax]` (the connector's own `[1, 0, 3, 2]` reorder confirms this layout), so the y coordinates must scale by **height** and x by **width**. The code did the opposite:

```python
boxes[:, [0, 2]] *= resolution_wh[0]   # ymin, ymax scaled by WIDTH  (should be height)
boxes[:, [1, 3]] *= resolution_wh[1]   # xmin, xmax scaled by HEIGHT (should be width)
```

The bug is masked on **square** images (`width == height`) but corrupts **every coordinate** on the common non-square case.

## Reproduction

A box normalized to `[ymin=0.1, xmin=0.2, ymax=0.5, xmax=0.6]` on a `1000×500` image (`resolution_wh=(1000, 500)`):

| | xmin | ymin | xmax | ymax |
|---|---|---|---|---|
| before (wrong) | 100 | 100 | 300 | 500 |
| after (correct) | 200 | 50 | 600 | 250 |

Correct values: `xmin = 0.2·1000`, `ymin = 0.1·500`, `xmax = 0.6·1000`, `ymax = 0.5·500`.

## Fix

Swap the two multipliers so y scales by `resolution_wh[1]` (height) and x by `resolution_wh[0]` (width). No behavior change on square images.

## Tests

Adds `test_from_tensorflow_scales_axes_on_non_square_image` (the connector was previously untested — no references in `tests/` or `docs/`). It fails on `develop` (`[100,100,300,500]`) and passes with this fix (`[200,50,600,250]`). `ruff check`/`format` clean.