### PR TITLE
Optimize mask annotation ROI blending

### DIFF
--- a/examples/compact_mask/benchmark.py
+++ b/examples/compact_mask/benchmark.py
@@ -2,7 +2,9 @@
 
 Demonstrates that ``CompactMask`` is a drop-in replacement for dense
 ``(N, H, W)`` bool arrays in ``supervision.Detections``, while using
-significantly less memory and enabling faster annotation.
+significantly less memory and enabling faster annotation. The annotation
+timing reports frame size, detection count, mask area ratio, and
+``MaskAnnotator`` speedup from ROI-only blending.
 
 Run with:
     uv run python examples/compact_mask/benchmark.py
@@ -74,7 +76,7 @@ class ScenarioResult:
     name: str
     resolution: str  # e.g. "1920x1080"
     num_objects: int
-    fill_name: str  # e.g. "5%"
+    fill_name: str  # mask area ratio, e.g. "5%"
     num_vertices: int  # polygon vertex count — complexity proxy
     # memory (theoretical: raw numpy nbytes)
     dense_bytes: int
@@ -956,7 +958,7 @@ def print_summary(results: list[ScenarioResult]) -> None:
     table.add_column("Scenario", style="bold", min_width=22)
     table.add_column("Objects", justify="right", min_width=7)
     table.add_column("Resolution", min_width=12, no_wrap=True)
-    table.add_column("Fill", justify="right", min_width=5, no_wrap=True)
+    table.add_column("Mask\narea", justify="right", min_width=5, no_wrap=True)
     table.add_column("Vertices", justify="right", min_width=8, no_wrap=True)
     table.add_column("Dense\ntheory", justify="right", min_width=10)
     table.add_column("Compact\ntheory", justify="right", style="green", min_width=9)
@@ -1037,7 +1039,8 @@ def print_summary(results: list[ScenarioResult]) -> None:
                 "Decode ms/mask — to_dense() / N (compact→dense overhead per mask)",
                 "Area x — .area speedup (RLE sum, no materialisation)",
                 "Filter x — boolean-index speedup",
-                "Annot x — MaskAnnotator speedup (crop-paint vs full-frame alloc)",
+                "Annot x — MaskAnnotator speedup "
+                "(ROI-only blend vs full-frame overlay)",
                 f"IoU x — pairwise self-IoU speedup "
                 f"(dense skipped >{IOU_DENSE_SKIP_GB:.0f} GB)",
                 "NMS x — mask_non_max_suppression speedup",

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -33,9 +33,7 @@ from supervision.detection.utils.converters import (
     polygon_to_mask,
     xyxy_to_polygons,
 )
-from supervision.detection.utils.masks import (
-    _masks_to_roi,
-)
+from supervision.detection.utils.masks import _masks_to_roi
 from supervision.draw.base import ImageType
 from supervision.draw.color import Color, ColorPalette
 from supervision.draw.utils import draw_polygon, draw_rounded_rectangle, draw_text

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -33,6 +33,9 @@ from supervision.detection.utils.converters import (
     polygon_to_mask,
     xyxy_to_polygons,
 )
+from supervision.detection.utils.masks import (
+    _masks_to_roi,
+)
 from supervision.draw.base import ImageType
 from supervision.draw.color import Color, ColorPalette
 from supervision.draw.utils import draw_polygon, draw_rounded_rectangle, draw_text
@@ -381,8 +384,9 @@ def _paint_masks_by_area(
             image. Use the default for full-frame painting.
 
     Returns:
-        A ``(H, W)`` boolean union array when ``collect_union=True``,
-        otherwise ``None``.
+        A boolean array matching the canvas dimensions when
+        ``collect_union=True``, otherwise ``None``. When called with an
+        ROI sub-canvas, dimensions are the ROI size, not the full image.
     """
     masks = detections.mask
     if masks is None:
@@ -433,61 +437,6 @@ def _paint_masks_by_area(
             if union is not None:
                 union |= mask
     return union
-
-
-def _mask_to_roi(mask: npt.NDArray[np.bool_]) -> tuple[int, int, int, int] | None:
-    """Return exclusive ``(x1, y1, x2, y2)`` bounds for true mask pixels."""
-    rows = np.flatnonzero(np.any(mask, axis=1))
-    if len(rows) == 0:
-        return None
-    cols = np.flatnonzero(np.any(mask, axis=0))
-    return int(cols[0]), int(rows[0]), int(cols[-1]) + 1, int(rows[-1]) + 1
-
-
-def _compact_masks_to_roi(
-    masks: CompactMask,
-    image_shape: tuple[int, int],
-) -> tuple[int, int, int, int] | None:
-    """Return exclusive true-pixel bounds for compact masks."""
-    image_h, image_w = image_shape
-    x_min, y_min = image_w, image_h
-    x_max, y_max = 0, 0
-    for detection_idx in range(len(masks)):
-        crop_roi = _mask_to_roi(masks.crop(detection_idx))
-        if crop_roi is None:
-            continue
-        crop_x1, crop_y1, crop_x2, crop_y2 = crop_roi
-        offset_x = int(masks.offsets[detection_idx, 0])
-        offset_y = int(masks.offsets[detection_idx, 1])
-        x_min = min(x_min, offset_x + crop_x1)
-        y_min = min(y_min, offset_y + crop_y1)
-        x_max = max(x_max, offset_x + crop_x2)
-        y_max = max(y_max, offset_y + crop_y2)
-    if x_min >= x_max or y_min >= y_max:
-        return None
-    return (
-        max(0, x_min),
-        max(0, y_min),
-        min(image_w, x_max),
-        min(image_h, y_max),
-    )
-
-
-def _masks_to_roi(
-    masks: CompactMask | npt.NDArray[Any],
-    image_shape: tuple[int, int],
-) -> tuple[int, int, int, int] | None:
-    """Return exclusive true-pixel bounds for dense or compact masks."""
-    if isinstance(masks, CompactMask):
-        return _compact_masks_to_roi(masks=masks, image_shape=image_shape)
-    mask_array = np.asarray(masks, dtype=bool)
-    if mask_array.size == 0:
-        return None
-    if mask_array.ndim == 2:
-        union = mask_array
-    else:
-        union = np.any(mask_array, axis=0)
-    return _mask_to_roi(union)
 
 
 class MaskAnnotator(BaseAnnotator):
@@ -566,7 +515,17 @@ class MaskAnnotator(BaseAnnotator):
             return scene
 
         image_shape = (int(scene.shape[0]), int(scene.shape[1]))
-        roi = _masks_to_roi(detections.mask, image_shape)
+        effective_lookup = (
+            self.color_lookup if custom_color_lookup is None else custom_color_lookup
+        )
+        if len(detections) > 0:
+            resolve_color(
+                color=self.color,
+                detections=detections,
+                detection_idx=0,
+                color_lookup=effective_lookup,
+            )
+        roi = _masks_to_roi(detections.mask, image_shape, detections.xyxy)
         if roi is None:
             return scene
 
@@ -577,12 +536,13 @@ class MaskAnnotator(BaseAnnotator):
             colored_mask,
             detections,
             self.color,
-            self.color_lookup if custom_color_lookup is None else custom_color_lookup,
+            effective_lookup,
             canvas_origin=(x1, y1),
         )
-        cv2.addWeighted(
-            colored_mask, self.opacity, scene_roi, 1 - self.opacity, 0, dst=scene_roi
+        tmp = cv2.addWeighted(
+            colored_mask, self.opacity, scene_roi.copy(), 1 - self.opacity, 0
         )
+        scene_roi[:] = tmp
         return scene
 
 

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -371,6 +371,7 @@ def _paint_masks_by_area(
     color: Color | ColorPalette,
     color_lookup: ColorLookup | npt.NDArray[np.int_],
     collect_union: bool = False,
+    canvas_origin: tuple[int, int] = (0, 0),
 ) -> npt.NDArray[np.bool_] | None:
     """Paint each detection's mask into `canvas` in descending-area order.
 
@@ -388,6 +389,8 @@ def _paint_masks_by_area(
             boolean array that accumulates the union of all painted masks
             (useful for callers like `HaloAnnotator` that need the combined
             mask footprint). When ``False`` (default), returns ``None``.
+        canvas_origin: Absolute ``(x, y)`` origin of `canvas` within the source
+            image. Use the default for full-frame painting.
 
     Returns:
         A ``(H, W)`` boolean union array when ``collect_union=True``,
@@ -400,6 +403,8 @@ def _paint_masks_by_area(
         np.zeros(canvas.shape[:2], dtype=bool) if collect_union else None
     )
     compact_mask = masks if isinstance(masks, CompactMask) else None
+    origin_x, origin_y = canvas_origin
+    canvas_h, canvas_w = canvas.shape[:2]
     for detection_idx in np.flip(np.argsort(detections.area)):
         color_bgr = resolve_color(
             color=color,
@@ -412,15 +417,89 @@ def _paint_masks_by_area(
             y1 = int(compact_mask.offsets[detection_idx, 1])
             crop_m = compact_mask.crop(detection_idx)
             crop_h, crop_w = crop_m.shape
-            canvas[y1 : y1 + crop_h, x1 : x1 + crop_w][crop_m] = color_bgr
+            crop_x1 = max(0, origin_x - x1)
+            crop_y1 = max(0, origin_y - y1)
+            canvas_x1 = max(0, x1 - origin_x)
+            canvas_y1 = max(0, y1 - origin_y)
+            paint_w = min(crop_w - crop_x1, canvas_w - canvas_x1)
+            paint_h = min(crop_h - crop_y1, canvas_h - canvas_y1)
+            if paint_w <= 0 or paint_h <= 0:
+                continue
+            crop_slice = crop_m[
+                crop_y1 : crop_y1 + paint_h, crop_x1 : crop_x1 + paint_w
+            ]
+            canvas_slice = canvas[
+                canvas_y1 : canvas_y1 + paint_h,
+                canvas_x1 : canvas_x1 + paint_w,
+            ]
+            canvas_slice[crop_slice] = color_bgr
             if union is not None:
-                union[y1 : y1 + crop_h, x1 : x1 + crop_w] |= crop_m
+                union[
+                    canvas_y1 : canvas_y1 + paint_h,
+                    canvas_x1 : canvas_x1 + paint_w,
+                ] |= crop_slice
         else:
             mask = np.asarray(masks[detection_idx], dtype=bool)
+            mask = mask[origin_y : origin_y + canvas_h, origin_x : origin_x + canvas_w]
             canvas[mask] = color_bgr
             if union is not None:
                 union |= mask
     return union
+
+
+def _mask_to_roi(mask: npt.NDArray[np.bool_]) -> tuple[int, int, int, int] | None:
+    """Return exclusive ``(x1, y1, x2, y2)`` bounds for true mask pixels."""
+    rows = np.flatnonzero(np.any(mask, axis=1))
+    if len(rows) == 0:
+        return None
+    cols = np.flatnonzero(np.any(mask, axis=0))
+    return int(cols[0]), int(rows[0]), int(cols[-1]) + 1, int(rows[-1]) + 1
+
+
+def _compact_masks_to_roi(
+    masks: CompactMask,
+    image_shape: tuple[int, int],
+) -> tuple[int, int, int, int] | None:
+    """Return exclusive true-pixel bounds for compact masks."""
+    image_h, image_w = image_shape
+    x_min, y_min = image_w, image_h
+    x_max, y_max = 0, 0
+    for detection_idx in range(len(masks)):
+        crop_roi = _mask_to_roi(masks.crop(detection_idx))
+        if crop_roi is None:
+            continue
+        crop_x1, crop_y1, crop_x2, crop_y2 = crop_roi
+        offset_x = int(masks.offsets[detection_idx, 0])
+        offset_y = int(masks.offsets[detection_idx, 1])
+        x_min = min(x_min, offset_x + crop_x1)
+        y_min = min(y_min, offset_y + crop_y1)
+        x_max = max(x_max, offset_x + crop_x2)
+        y_max = max(y_max, offset_y + crop_y2)
+    if x_min >= x_max or y_min >= y_max:
+        return None
+    return (
+        max(0, x_min),
+        max(0, y_min),
+        min(image_w, x_max),
+        min(image_h, y_max),
+    )
+
+
+def _masks_to_roi(
+    masks: CompactMask | npt.NDArray[Any],
+    image_shape: tuple[int, int],
+) -> tuple[int, int, int, int] | None:
+    """Return exclusive true-pixel bounds for dense or compact masks."""
+    if isinstance(masks, CompactMask):
+        return _compact_masks_to_roi(masks=masks, image_shape=image_shape)
+    mask_array = np.asarray(masks, dtype=bool)
+    if mask_array.size == 0:
+        return None
+    if mask_array.ndim == 2:
+        union = mask_array
+    else:
+        union = np.any(mask_array, axis=0)
+    return _mask_to_roi(union)
 
 
 class MaskAnnotator(BaseAnnotator):
@@ -498,15 +577,23 @@ class MaskAnnotator(BaseAnnotator):
         if detections.mask is None:
             return scene
 
-        colored_mask = np.array(scene, copy=True, dtype=np.uint8)
+        image_shape = (int(scene.shape[0]), int(scene.shape[1]))
+        roi = _masks_to_roi(detections.mask, image_shape)
+        if roi is None:
+            return scene
+
+        x1, y1, x2, y2 = roi
+        scene_roi = scene[y1:y2, x1:x2]
+        colored_mask = np.array(scene_roi, copy=True, dtype=np.uint8)
         _paint_masks_by_area(
             colored_mask,
             detections,
             self.color,
             self.color_lookup if custom_color_lookup is None else custom_color_lookup,
+            canvas_origin=(x1, y1),
         )
         cv2.addWeighted(
-            colored_mask, self.opacity, scene, 1 - self.opacity, 0, dst=scene
+            colored_mask, self.opacity, scene_roi, 1 - self.opacity, 0, dst=scene_roi
         )
         return scene
 

--- a/src/supervision/detection/utils/masks.py
+++ b/src/supervision/detection/utils/masks.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import cv2
 import numpy as np
@@ -422,3 +422,97 @@ def filter_segments_by_distance(
         raise ValueError("mode must be 'edge' or 'centroid'")
 
     return keep_labels[labels]
+
+
+def _mask_to_roi(mask: npt.NDArray[np.bool_]) -> tuple[int, int, int, int] | None:
+    """Return exclusive ``(x1, y1, x2, y2)`` bounds for true mask pixels.
+
+    Unlike :func:`~supervision.detection.utils.converters.mask_to_xyxy`,
+    this function uses **exclusive** upper bounds (``+1``) and returns
+    ``None`` for empty masks (instead of zeros). These semantics are
+    required for NumPy slice-based ROI extraction.
+
+    Args:
+        mask: 2D boolean array of shape ``(H, W)``.
+
+    Returns:
+        Exclusive ``(x1, y1, x2, y2)`` bounds, or ``None`` when the mask
+        has no true pixels.
+    """
+    rows = np.flatnonzero(np.any(mask, axis=1))
+    if len(rows) == 0:
+        return None
+    cols = np.flatnonzero(np.any(mask, axis=0))
+    return int(cols[0]), int(rows[0]), int(cols[-1]) + 1, int(rows[-1]) + 1
+
+
+def _compact_masks_to_roi(
+    masks: CompactMask,
+    image_shape: tuple[int, int],
+) -> tuple[int, int, int, int] | None:
+    """Return exclusive bounding-box union for compact masks.
+
+    Uses crop metadata (offsets + shapes) — no RLE decode required.
+
+    Args:
+        masks: Compact mask collection.
+        image_shape: Image dimensions as ``(height, width)``.
+
+    Returns:
+        Exclusive ``(x1, y1, x2, y2)`` bounds, or ``None`` when empty.
+    """
+    if len(masks) == 0:
+        return None
+    image_h, image_w = image_shape
+    bboxes = masks.bbox_xyxy  # shape (N, 4), inclusive int32
+    x_min = int(bboxes[:, 0].min())
+    y_min = int(bboxes[:, 1].min())
+    x_max = int(bboxes[:, 2].max()) + 1  # convert inclusive to exclusive
+    y_max = int(bboxes[:, 3].max()) + 1
+    return (
+        max(0, x_min),
+        max(0, y_min),
+        min(image_w, x_max),
+        min(image_h, y_max),
+    )
+
+
+def _masks_to_roi(
+    masks: CompactMask | npt.NDArray[Any],
+    image_shape: tuple[int, int],
+    xyxy: npt.NDArray[np.number] | None = None,
+) -> tuple[int, int, int, int] | None:
+    """Return exclusive true-pixel bounds for dense or compact masks.
+
+    Args:
+        masks: Dense boolean mask array of shape ``(N, H, W)`` or ``(H, W)``,
+            or a :class:`~supervision.detection.compact_mask.CompactMask`.
+        image_shape: Image dimensions as ``(height, width)``.
+        xyxy: Optional detection boxes of shape ``(N, 4)`` in
+            ``[x1, y1, x2, y2]`` format. When provided, the dense path
+            uses box union (O(N)) instead of a full pixel scan (O(N·H·W)).
+
+    Returns:
+        Exclusive ``(x1, y1, x2, y2)`` bounds, or ``None`` when no true
+        pixels exist.
+    """
+    if isinstance(masks, CompactMask):
+        return _compact_masks_to_roi(masks=masks, image_shape=image_shape)
+    mask_array = np.asarray(masks, dtype=bool)
+    if mask_array.size == 0:
+        return None
+    # Fast path: union of detection boxes (O(N)) avoids full N·H·W pixel scan.
+    # supervision xyxy uses inclusive max coords; floor(x2)+1 converts to exclusive.
+    if xyxy is not None and len(xyxy) > 0:
+        image_h, image_w = image_shape
+        return (
+            max(0, int(np.floor(xyxy[:, 0].min()))),
+            max(0, int(np.floor(xyxy[:, 1].min()))),
+            min(image_w, int(np.floor(xyxy[:, 2].max())) + 1),
+            min(image_h, int(np.floor(xyxy[:, 3].max())) + 1),
+        )
+    if mask_array.ndim == 2:
+        union = mask_array
+    else:
+        union = np.any(mask_array, axis=0)
+    return _mask_to_roi(union)

--- a/src/supervision/detection/utils/masks.py
+++ b/src/supervision/detection/utils/masks.py
@@ -499,7 +499,7 @@ def _masks_to_roi(
     if isinstance(masks, CompactMask):
         return _compact_masks_to_roi(masks=masks, image_shape=image_shape)
     mask_array = np.asarray(masks, dtype=bool)
-    if mask_array.size == 0:
+    if mask_array.size == 0 or not mask_array.any():
         return None
     # Fast path: union of detection boxes (O(N)) avoids full N·H·W pixel scan.
     # supervision xyxy uses inclusive max coords; floor(x2)+1 converts to exclusive.

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import warnings
 
+import cv2
 import numpy as np
 import pytest
 
@@ -261,6 +262,89 @@ class TestMaskAnnotator:
             scene=test_image.copy(), detections=detections_uint8
         )
         assert np.array_equal(result_bool, result_uint8)
+
+    def test_annotate_blends_only_dense_mask_roi(self, monkeypatch):
+        """Dense mask annotation should blend only the touched ROI."""
+        height, width = 80, 90
+        scene = np.random.default_rng(1).integers(
+            0, 256, (height, width, 3), dtype=np.uint8
+        )
+        mask = np.zeros((height, width), dtype=bool)
+        mask[10:20, 15:25] = True
+        mask[45:55, 60:75] = True
+        detections = _create_detections(
+            xyxy=[[0.0, 0.0, 80.0, 70.0]], mask=[mask], class_id=[0]
+        )
+        original_add_weighted = cv2.addWeighted
+        blended_shapes = []
+
+        def add_weighted_spy(src1, alpha, src2, beta, gamma, dst=None, dtype=None):
+            blended_shapes.append(src1.shape)
+            return original_add_weighted(src1, alpha, src2, beta, gamma, dst, dtype)
+
+        monkeypatch.setattr(cv2, "addWeighted", add_weighted_spy)
+
+        result = MaskAnnotator(
+            opacity=0.5, color=Color.RED, color_lookup=ColorLookup.INDEX
+        ).annotate(scene=scene.copy(), detections=detections)
+
+        assert not np.array_equal(result, scene)
+        assert blended_shapes == [(45, 60, 3)]
+
+    def test_annotate_blends_only_compact_mask_roi(self, monkeypatch):
+        """CompactMask annotation should blend only the touched ROI."""
+        height, width = 80, 90
+        scene = np.random.default_rng(2).integers(
+            0, 256, (height, width, 3), dtype=np.uint8
+        )
+        masks = np.zeros((2, height, width), dtype=bool)
+        masks[0, 10:20, 15:25] = True
+        masks[1, 45:55, 60:75] = True
+        xyxy = np.array([[15.0, 10.0, 24.0, 19.0], [60.0, 45.0, 74.0, 54.0]])
+        detections = _create_detections(xyxy=xyxy.tolist(), mask=masks, class_id=[0, 1])
+        detections.mask = CompactMask.from_dense(
+            masks, detections.xyxy, (height, width)
+        )
+        original_add_weighted = cv2.addWeighted
+        blended_shapes = []
+
+        def add_weighted_spy(src1, alpha, src2, beta, gamma, dst=None, dtype=None):
+            blended_shapes.append(src1.shape)
+            return original_add_weighted(src1, alpha, src2, beta, gamma, dst, dtype)
+
+        monkeypatch.setattr(cv2, "addWeighted", add_weighted_spy)
+
+        result = MaskAnnotator(opacity=0.5, color_lookup=ColorLookup.INDEX).annotate(
+            scene=scene.copy(), detections=detections
+        )
+
+        assert not np.array_equal(result, scene)
+        assert blended_shapes == [(45, 60, 3)]
+
+    def test_annotate_skips_all_false_mask_blend(self, monkeypatch):
+        """All-false masks should return an unchanged image without blending."""
+        height, width = 30, 40
+        scene = np.random.default_rng(3).integers(
+            0, 256, (height, width, 3), dtype=np.uint8
+        )
+        mask = np.zeros((height, width), dtype=bool)
+        detections = _create_detections(
+            xyxy=[[5.0, 5.0, 20.0, 20.0]], mask=[mask], class_id=[0]
+        )
+        blended_shapes = []
+
+        def add_weighted_spy(src1, alpha, src2, beta, gamma, dst=None, dtype=None):
+            blended_shapes.append(src1.shape)
+            return src2
+
+        monkeypatch.setattr(cv2, "addWeighted", add_weighted_spy)
+
+        result = MaskAnnotator(
+            opacity=0.5, color=Color.RED, color_lookup=ColorLookup.INDEX
+        ).annotate(scene=scene.copy(), detections=detections)
+
+        assert np.array_equal(result, scene)
+        assert blended_shapes == []
 
 
 class TestPolygonAnnotator:

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -40,19 +40,6 @@ from supervision.draw.color import Color
 from supervision.geometry.core import Position
 from tests.helpers import _create_detections, assert_image_mostly_same
 
-try:
-    from supervision.detection.utils.masks import (
-        _compact_masks_to_roi,
-        _mask_to_roi,
-        _masks_to_roi,
-    )
-except ImportError:
-    from supervision.annotators.core import (  # type: ignore[no-redef]
-        _compact_masks_to_roi,
-        _mask_to_roi,
-        _masks_to_roi,
-    )
-
 
 @pytest.fixture
 def test_image() -> np.ndarray:
@@ -412,104 +399,6 @@ class TestMaskAnnotator:
             result_roi[roi_mask].astype(np.int16) - ref_blend[roi_mask].astype(np.int16)
         )
         assert np.all(diff <= 1), f"Max pixel diff: {diff.max()}"
-
-
-class TestMaskROIHelpers:
-    """Tests for _mask_to_roi, _compact_masks_to_roi, _masks_to_roi helpers."""
-
-    def test_mask_to_roi_all_false_returns_none(self):
-        """All-false mask should return None."""
-        mask = np.zeros((10, 15), dtype=bool)
-        assert _mask_to_roi(mask) is None
-
-    def test_mask_to_roi_single_pixel_exclusive_bounds(self):
-        """Single true pixel at (row=3, col=5) gives bounds (5, 3, 6, 4)."""
-        mask = np.zeros((10, 15), dtype=bool)
-        mask[3, 5] = True
-        assert _mask_to_roi(mask) == (5, 3, 6, 4)
-
-    def test_mask_to_roi_boundary_row_col_zero(self):
-        """True pixel at top-left boundary should give (0, 0, 1, 1)."""
-        mask = np.zeros((10, 15), dtype=bool)
-        mask[0, 0] = True
-        assert _mask_to_roi(mask) == (0, 0, 1, 1)
-
-    def test_mask_to_roi_full_image(self):
-        """Full-image true mask should span the entire array."""
-        h, w = 8, 12
-        mask = np.ones((h, w), dtype=bool)
-        assert _mask_to_roi(mask) == (0, 0, w, h)
-
-    def test_mask_to_roi_region(self):
-        """Region [10:20, 15:25] in 80x90 mask gives exclusive bounds (15,10,25,20)."""
-        mask = np.zeros((80, 90), dtype=bool)
-        mask[10:20, 15:25] = True
-        assert _mask_to_roi(mask) == (15, 10, 25, 20)
-
-    def test_compact_masks_to_roi_empty_returns_none(self):
-        """Zero-length CompactMask should return None."""
-        masks = np.zeros((0, 10, 10), dtype=bool)
-        xyxy = np.empty((0, 4), dtype=np.float32)
-        cm = CompactMask.from_dense(masks, xyxy, image_shape=(10, 10))
-        assert _compact_masks_to_roi(cm, (10, 10)) is None
-
-    def test_compact_masks_to_roi_single_detection_coordinates(self):
-        """Single compact mask with known crop should give correct exclusive bounds."""
-        masks = np.zeros((1, 20, 20), dtype=bool)
-        masks[0, 5:10, 3:8] = True
-        xyxy = np.array([[3.0, 5.0, 7.0, 9.0]], dtype=np.float32)
-        cm = CompactMask.from_dense(masks, xyxy, image_shape=(20, 20))
-        result = _compact_masks_to_roi(cm, (20, 20))
-        assert result is not None
-        x1, y1, x2, y2 = result
-        # Bounding-box crop defines the extent; true pixels lie within [3:8, 5:10]
-        assert x1 <= 3
-        assert y1 <= 5
-        assert x2 >= 8
-        assert y2 >= 10
-
-    def test_compact_masks_to_roi_two_detections_union(self):
-        """Two disjoint compact masks union should span both regions."""
-        masks = np.zeros((2, 30, 40), dtype=bool)
-        masks[0, 2:8, 1:6] = True
-        masks[1, 15:25, 20:35] = True
-        xyxy = np.array(
-            [[1.0, 2.0, 5.0, 7.0], [20.0, 15.0, 34.0, 24.0]], dtype=np.float32
-        )
-        cm = CompactMask.from_dense(masks, xyxy, image_shape=(30, 40))
-        result = _compact_masks_to_roi(cm, (30, 40))
-        assert result is not None
-        x1, y1, x2, y2 = result
-        # Union must contain both regions
-        assert x1 <= 1
-        assert y1 <= 2
-        assert x2 >= 35
-        assert y2 >= 25
-
-    def test_masks_to_roi_empty_array_returns_none(self):
-        """Zero-element dense mask array (N=0) should return None."""
-        masks = np.zeros((0, 10, 10), dtype=bool)
-        assert _masks_to_roi(masks, (10, 10)) is None
-
-    def test_masks_to_roi_2d_array(self):
-        """2D boolean array (single mask) should work as union mask."""
-        mask = np.zeros((10, 15), dtype=bool)
-        mask[3:6, 7:11] = True
-        assert _masks_to_roi(mask, (10, 15)) == (7, 3, 11, 6)
-
-    def test_masks_to_roi_dense_with_xyxy_uses_box_union(self):
-        """Dense path with xyxy should return union of boxes (O(N) path)."""
-        masks = np.zeros((2, 30, 40), dtype=bool)
-        masks[0, 5:10, 5:10] = True
-        masks[1, 20:25, 25:30] = True
-        xyxy = np.array([[5.0, 5.0, 9.0, 9.0], [25.0, 20.0, 29.0, 24.0]])
-        result = _masks_to_roi(masks, (30, 40), xyxy)
-        assert result is not None
-        x1, y1, x2, y2 = result
-        assert x1 <= 5
-        assert y1 <= 5
-        assert x2 >= 30
-        assert y2 >= 25
 
 
 class TestPolygonAnnotator:

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -323,7 +323,7 @@ class TestMaskAnnotator:
         assert blended_shapes == [(45, 60, 3)]
 
     def test_annotate_skips_all_false_mask_blend(self, monkeypatch):
-        """All-false masks should leave the image pixel-exact to the original."""
+        """All-false masks must skip blending — addWeighted must not be called."""
         height, width = 30, 40
         scene = np.random.default_rng(3).integers(
             0, 256, (height, width, 3), dtype=np.uint8
@@ -333,7 +333,10 @@ class TestMaskAnnotator:
             xyxy=[[5.0, 5.0, 20.0, 20.0]], mask=[mask], class_id=[0]
         )
 
+        call_count = []
+
         def add_weighted_spy(src1, alpha, src2, beta, gamma, dst=None, dtype=None):
+            call_count.append(1)
             return src2
 
         monkeypatch.setattr(cv2, "addWeighted", add_weighted_spy)
@@ -343,6 +346,7 @@ class TestMaskAnnotator:
         ).annotate(scene=scene.copy(), detections=detections)
 
         assert np.array_equal(result, scene)
+        assert len(call_count) == 0, "addWeighted called for all-false masks"
 
     def test_annotate_pixels_outside_roi_unchanged(self):
         """Pixels outside the blended ROI must be unchanged from the original scene."""

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -40,6 +40,19 @@ from supervision.draw.color import Color
 from supervision.geometry.core import Position
 from tests.helpers import _create_detections, assert_image_mostly_same
 
+try:
+    from supervision.detection.utils.masks import (
+        _compact_masks_to_roi,
+        _mask_to_roi,
+        _masks_to_roi,
+    )
+except ImportError:
+    from supervision.annotators.core import (  # type: ignore[no-redef]
+        _compact_masks_to_roi,
+        _mask_to_roi,
+        _masks_to_roi,
+    )
+
 
 @pytest.fixture
 def test_image() -> np.ndarray:
@@ -267,11 +280,14 @@ class TestMaskAnnotator:
         scene = np.random.default_rng(1).integers(
             0, 256, (height, width, 3), dtype=np.uint8
         )
-        mask = np.zeros((height, width), dtype=bool)
-        mask[10:20, 15:25] = True
-        mask[45:55, 60:75] = True
+        masks = np.zeros((2, height, width), dtype=bool)
+        masks[0, 10:20, 15:25] = True
+        masks[1, 45:55, 60:75] = True
+        # inclusive xyxy; floor(x2)+1 gives union ROI (15,10,75,55) → shape (45,60,3)
         detections = _create_detections(
-            xyxy=[[0.0, 0.0, 80.0, 70.0]], mask=[mask], class_id=[0]
+            xyxy=[[15.0, 10.0, 24.0, 19.0], [60.0, 45.0, 74.0, 54.0]],
+            mask=masks,
+            class_id=[0, 1],
         )
         original_add_weighted = cv2.addWeighted
         blended_shapes = []
@@ -320,7 +336,7 @@ class TestMaskAnnotator:
         assert blended_shapes == [(45, 60, 3)]
 
     def test_annotate_skips_all_false_mask_blend(self, monkeypatch):
-        """All-false masks should return an unchanged image without blending."""
+        """All-false masks should leave the image pixel-exact to the original."""
         height, width = 30, 40
         scene = np.random.default_rng(3).integers(
             0, 256, (height, width, 3), dtype=np.uint8
@@ -329,10 +345,8 @@ class TestMaskAnnotator:
         detections = _create_detections(
             xyxy=[[5.0, 5.0, 20.0, 20.0]], mask=[mask], class_id=[0]
         )
-        blended_shapes = []
 
         def add_weighted_spy(src1, alpha, src2, beta, gamma, dst=None, dtype=None):
-            blended_shapes.append(src1.shape)
             return src2
 
         monkeypatch.setattr(cv2, "addWeighted", add_weighted_spy)
@@ -342,7 +356,160 @@ class TestMaskAnnotator:
         ).annotate(scene=scene.copy(), detections=detections)
 
         assert np.array_equal(result, scene)
-        assert blended_shapes == []
+
+    def test_annotate_pixels_outside_roi_unchanged(self):
+        """Pixels outside the blended ROI must be unchanged from the original scene."""
+        height, width = 80, 90
+        rng = np.random.default_rng(42)
+        scene = rng.integers(0, 256, (height, width, 3), dtype=np.uint8)
+        # Two masks in the top-left region — ROI should be [10:55, 15:75]
+        masks = np.zeros((2, height, width), dtype=bool)
+        masks[0, 10:20, 15:25] = True
+        masks[1, 45:55, 60:75] = True
+        # inclusive xyxy; floor(x2)+1 gives ROI (15,10,75,55)
+        xyxy = np.array([[15.0, 10.0, 24.0, 19.0], [60.0, 45.0, 74.0, 54.0]])
+        detections = _create_detections(xyxy=xyxy.tolist(), mask=masks, class_id=[0, 1])
+        result = MaskAnnotator(opacity=0.5, color_lookup=ColorLookup.INDEX).annotate(
+            scene=scene.copy(), detections=detections
+        )
+        # Pixels strictly below ROI row-bound (y2=55) must be unchanged
+        assert np.array_equal(result[55:, :], scene[55:, :])
+        # Pixels strictly right of ROI col-bound (x2=75) must be unchanged
+        assert np.array_equal(result[:, 75:], scene[:, 75:])
+
+    def test_annotate_roi_parity_with_full_frame_blend(self):
+        """ROI blend must match reference blend within ±1 (uint8 rounding)."""
+        height, width = 60, 80
+        rng = np.random.default_rng(99)
+        scene = rng.integers(0, 256, (height, width, 3), dtype=np.uint8)
+        opacity = 0.5
+        # Single mask in bottom-right quadrant
+        masks = np.zeros((1, height, width), dtype=bool)
+        masks[0, 40:55, 50:70] = True
+        # inclusive xyxy; floor(x2)+1 gives ROI scene[40:55, 50:70]
+        xyxy = np.array([[50.0, 40.0, 69.0, 54.0]])
+        detections = _create_detections(xyxy=xyxy.tolist(), mask=masks, class_id=[0])
+
+        # ROI-only result (new optimized behavior)
+        result_roi = MaskAnnotator(
+            opacity=opacity, color=Color.RED, color_lookup=ColorLookup.INDEX
+        ).annotate(scene=scene.copy(), detections=detections)
+
+        # Reference: manually compute expected blend for masked pixels only
+        # RED in BGR = (0, 0, 255); blend = opacity*color + (1-opacity)*scene
+        roi_mask = masks[0]
+        colored = scene.copy()
+        colored[roi_mask] = (0, 0, 255)  # BGR RED
+        ref_blend = np.clip(
+            opacity * colored.astype(np.float32)
+            + (1 - opacity) * scene.astype(np.float32),
+            0,
+            255,
+        ).astype(np.uint8)
+
+        # Masked pixels must match reference within ±1 (uint8 rounding)
+        diff = np.abs(
+            result_roi[roi_mask].astype(np.int16) - ref_blend[roi_mask].astype(np.int16)
+        )
+        assert np.all(diff <= 1), f"Max pixel diff: {diff.max()}"
+
+
+class TestMaskROIHelpers:
+    """Tests for _mask_to_roi, _compact_masks_to_roi, _masks_to_roi helpers."""
+
+    def test_mask_to_roi_all_false_returns_none(self):
+        """All-false mask should return None."""
+        mask = np.zeros((10, 15), dtype=bool)
+        assert _mask_to_roi(mask) is None
+
+    def test_mask_to_roi_single_pixel_exclusive_bounds(self):
+        """Single true pixel at (row=3, col=5) gives bounds (5, 3, 6, 4)."""
+        mask = np.zeros((10, 15), dtype=bool)
+        mask[3, 5] = True
+        assert _mask_to_roi(mask) == (5, 3, 6, 4)
+
+    def test_mask_to_roi_boundary_row_col_zero(self):
+        """True pixel at top-left boundary should give (0, 0, 1, 1)."""
+        mask = np.zeros((10, 15), dtype=bool)
+        mask[0, 0] = True
+        assert _mask_to_roi(mask) == (0, 0, 1, 1)
+
+    def test_mask_to_roi_full_image(self):
+        """Full-image true mask should span the entire array."""
+        h, w = 8, 12
+        mask = np.ones((h, w), dtype=bool)
+        assert _mask_to_roi(mask) == (0, 0, w, h)
+
+    def test_mask_to_roi_region(self):
+        """Region [10:20, 15:25] in 80x90 mask gives exclusive bounds (15,10,25,20)."""
+        mask = np.zeros((80, 90), dtype=bool)
+        mask[10:20, 15:25] = True
+        assert _mask_to_roi(mask) == (15, 10, 25, 20)
+
+    def test_compact_masks_to_roi_empty_returns_none(self):
+        """Zero-length CompactMask should return None."""
+        masks = np.zeros((0, 10, 10), dtype=bool)
+        xyxy = np.empty((0, 4), dtype=np.float32)
+        cm = CompactMask.from_dense(masks, xyxy, image_shape=(10, 10))
+        assert _compact_masks_to_roi(cm, (10, 10)) is None
+
+    def test_compact_masks_to_roi_single_detection_coordinates(self):
+        """Single compact mask with known crop should give correct exclusive bounds."""
+        masks = np.zeros((1, 20, 20), dtype=bool)
+        masks[0, 5:10, 3:8] = True
+        xyxy = np.array([[3.0, 5.0, 7.0, 9.0]], dtype=np.float32)
+        cm = CompactMask.from_dense(masks, xyxy, image_shape=(20, 20))
+        result = _compact_masks_to_roi(cm, (20, 20))
+        assert result is not None
+        x1, y1, x2, y2 = result
+        # Bounding-box crop defines the extent; true pixels lie within [3:8, 5:10]
+        assert x1 <= 3
+        assert y1 <= 5
+        assert x2 >= 8
+        assert y2 >= 10
+
+    def test_compact_masks_to_roi_two_detections_union(self):
+        """Two disjoint compact masks union should span both regions."""
+        masks = np.zeros((2, 30, 40), dtype=bool)
+        masks[0, 2:8, 1:6] = True
+        masks[1, 15:25, 20:35] = True
+        xyxy = np.array(
+            [[1.0, 2.0, 5.0, 7.0], [20.0, 15.0, 34.0, 24.0]], dtype=np.float32
+        )
+        cm = CompactMask.from_dense(masks, xyxy, image_shape=(30, 40))
+        result = _compact_masks_to_roi(cm, (30, 40))
+        assert result is not None
+        x1, y1, x2, y2 = result
+        # Union must contain both regions
+        assert x1 <= 1
+        assert y1 <= 2
+        assert x2 >= 35
+        assert y2 >= 25
+
+    def test_masks_to_roi_empty_array_returns_none(self):
+        """Zero-element dense mask array (N=0) should return None."""
+        masks = np.zeros((0, 10, 10), dtype=bool)
+        assert _masks_to_roi(masks, (10, 10)) is None
+
+    def test_masks_to_roi_2d_array(self):
+        """2D boolean array (single mask) should work as union mask."""
+        mask = np.zeros((10, 15), dtype=bool)
+        mask[3:6, 7:11] = True
+        assert _masks_to_roi(mask, (10, 15)) == (7, 3, 11, 6)
+
+    def test_masks_to_roi_dense_with_xyxy_uses_box_union(self):
+        """Dense path with xyxy should return union of boxes (O(N) path)."""
+        masks = np.zeros((2, 30, 40), dtype=bool)
+        masks[0, 5:10, 5:10] = True
+        masks[1, 20:25, 25:30] = True
+        xyxy = np.array([[5.0, 5.0, 9.0, 9.0], [25.0, 20.0, 29.0, 24.0]])
+        result = _masks_to_roi(masks, (30, 40), xyxy)
+        assert result is not None
+        x1, y1, x2, y2 = result
+        assert x1 <= 5
+        assert y1 <= 5
+        assert x2 >= 30
+        assert y2 >= 25
 
 
 class TestPolygonAnnotator:
@@ -547,6 +714,32 @@ class TestPaintMasksByArea:
         compact_painted = canvas_compact.any(axis=-1)
         dense_painted = canvas_dense.any(axis=-1)
         assert np.all(dense_painted[compact_painted])
+
+    def test_canvas_origin_nonzero_paints_at_correct_position(self):
+        """Non-zero canvas_origin should offset mask coordinates into canvas."""
+        height, width = 30, 40
+        # Subcanvas covering region [10:25, 15:30] of the full image (15x15 px).
+        canvas = np.zeros((15, 15, 3), dtype=np.uint8)
+        # Mask in full-image coords: True at rows 12:18, cols 17:22.
+        # In canvas coords (origin=(15, 10)): rows 2:8, cols 2:7.
+        full_mask = np.zeros((height, width), dtype=bool)
+        full_mask[12:18, 17:22] = True
+        detections = Detections(
+            xyxy=np.array([[17.0, 12.0, 21.0, 17.0]]),
+            mask=full_mask[np.newaxis],
+            class_id=np.array([0]),
+        )
+        _paint_masks_by_area(
+            canvas,
+            detections,
+            Color.RED,
+            ColorLookup.INDEX,
+            canvas_origin=(15, 10),
+        )
+        # Pixels inside the mapped region should be BGR red (0, 0, 255)
+        assert np.all(canvas[2:8, 2:7] == (0, 0, 255))
+        # Pixels outside the painted region must remain zero
+        assert canvas[0, 0].tolist() == [0, 0, 0]
 
 
 class TestCompactMaskParity:

--- a/tests/detection/utils/test_masks.py
+++ b/tests/detection/utils/test_masks.py
@@ -4,13 +4,113 @@ import numpy as np
 import numpy.typing as npt
 import pytest
 
+from supervision.detection.compact_mask import CompactMask
 from supervision.detection.utils.masks import (
+    _compact_masks_to_roi,
+    _mask_to_roi,
+    _masks_to_roi,
     calculate_masks_centroids,
     contains_holes,
     contains_multiple_segments,
     filter_segments_by_distance,
     move_masks,
 )
+
+
+class TestMaskROIHelpers:
+    """Tests for _mask_to_roi, _compact_masks_to_roi, _masks_to_roi helpers."""
+
+    def test_mask_to_roi_all_false_returns_none(self):
+        """All-false mask should return None."""
+        mask = np.zeros((10, 15), dtype=bool)
+        assert _mask_to_roi(mask) is None
+
+    def test_mask_to_roi_single_pixel_exclusive_bounds(self):
+        """Single true pixel at (row=3, col=5) gives bounds (5, 3, 6, 4)."""
+        mask = np.zeros((10, 15), dtype=bool)
+        mask[3, 5] = True
+        assert _mask_to_roi(mask) == (5, 3, 6, 4)
+
+    def test_mask_to_roi_boundary_row_col_zero(self):
+        """True pixel at top-left boundary should give (0, 0, 1, 1)."""
+        mask = np.zeros((10, 15), dtype=bool)
+        mask[0, 0] = True
+        assert _mask_to_roi(mask) == (0, 0, 1, 1)
+
+    def test_mask_to_roi_full_image(self):
+        """Full-image true mask should span the entire array."""
+        h, w = 8, 12
+        mask = np.ones((h, w), dtype=bool)
+        assert _mask_to_roi(mask) == (0, 0, w, h)
+
+    def test_mask_to_roi_region(self):
+        """Region [10:20, 15:25] in 80x90 mask gives exclusive bounds (15,10,25,20)."""
+        mask = np.zeros((80, 90), dtype=bool)
+        mask[10:20, 15:25] = True
+        assert _mask_to_roi(mask) == (15, 10, 25, 20)
+
+    def test_compact_masks_to_roi_empty_returns_none(self):
+        """Zero-length CompactMask should return None."""
+        masks = np.zeros((0, 10, 10), dtype=bool)
+        xyxy = np.empty((0, 4), dtype=np.float32)
+        cm = CompactMask.from_dense(masks, xyxy, image_shape=(10, 10))
+        assert _compact_masks_to_roi(cm, (10, 10)) is None
+
+    def test_compact_masks_to_roi_single_detection_coordinates(self):
+        """Single compact mask with known crop should give correct exclusive bounds."""
+        masks = np.zeros((1, 20, 20), dtype=bool)
+        masks[0, 5:10, 3:8] = True
+        xyxy = np.array([[3.0, 5.0, 7.0, 9.0]], dtype=np.float32)
+        cm = CompactMask.from_dense(masks, xyxy, image_shape=(20, 20))
+        result = _compact_masks_to_roi(cm, (20, 20))
+        assert result is not None
+        x1, y1, x2, y2 = result
+        assert x1 <= 3
+        assert y1 <= 5
+        assert x2 >= 8
+        assert y2 >= 10
+
+    def test_compact_masks_to_roi_two_detections_union(self):
+        """Two disjoint compact masks union should span both regions."""
+        masks = np.zeros((2, 30, 40), dtype=bool)
+        masks[0, 2:8, 1:6] = True
+        masks[1, 15:25, 20:35] = True
+        xyxy = np.array(
+            [[1.0, 2.0, 5.0, 7.0], [20.0, 15.0, 34.0, 24.0]], dtype=np.float32
+        )
+        cm = CompactMask.from_dense(masks, xyxy, image_shape=(30, 40))
+        result = _compact_masks_to_roi(cm, (30, 40))
+        assert result is not None
+        x1, y1, x2, y2 = result
+        assert x1 <= 1
+        assert y1 <= 2
+        assert x2 >= 35
+        assert y2 >= 25
+
+    def test_masks_to_roi_empty_array_returns_none(self):
+        """Zero-element dense mask array (N=0) should return None."""
+        masks = np.zeros((0, 10, 10), dtype=bool)
+        assert _masks_to_roi(masks, (10, 10)) is None
+
+    def test_masks_to_roi_2d_array(self):
+        """2D boolean array (single mask) should work as union mask."""
+        mask = np.zeros((10, 15), dtype=bool)
+        mask[3:6, 7:11] = True
+        assert _masks_to_roi(mask, (10, 15)) == (7, 3, 11, 6)
+
+    def test_masks_to_roi_dense_with_xyxy_uses_box_union(self):
+        """Dense path with xyxy should return union of boxes (O(N) path)."""
+        masks = np.zeros((2, 30, 40), dtype=bool)
+        masks[0, 5:10, 5:10] = True
+        masks[1, 20:25, 25:30] = True
+        xyxy = np.array([[5.0, 5.0, 9.0, 9.0], [25.0, 20.0, 29.0, 24.0]])
+        result = _masks_to_roi(masks, (30, 40), xyxy)
+        assert result is not None
+        x1, y1, x2, y2 = result
+        assert x1 <= 5
+        assert y1 <= 5
+        assert x2 >= 30
+        assert y2 >= 25
 
 
 @pytest.mark.parametrize(

--- a/tests/detection/utils/test_masks.py
+++ b/tests/detection/utils/test_masks.py
@@ -112,6 +112,28 @@ class TestMaskROIHelpers:
         assert x2 >= 30
         assert y2 >= 25
 
+    def test_masks_to_roi_dense_with_xyxy_loose_box_returns_box_union(self):
+        """Loose xyxy (larger than pixel region) returns box union, not tight bounds."""
+        masks = np.zeros((1, 30, 40), dtype=bool)
+        masks[0, 10:12, 10:12] = True  # tiny 2x2 pixel region
+        # box is much larger than the pixel region
+        xyxy = np.array([[2.0, 2.0, 20.0, 20.0]])
+        result = _masks_to_roi(masks, (30, 40), xyxy)
+        assert result is not None
+        x1, y1, x2, y2 = result
+        # fast-path returns box union (conservative bound), not tight pixel bound
+        assert x1 <= 2
+        assert y1 <= 2
+        assert x2 >= 21  # floor(20.0) + 1
+        assert y2 >= 21
+
+    def test_masks_to_roi_dense_with_xyxy_all_false_returns_none(self):
+        """All-false masks with xyxy provided should still return None."""
+        masks = np.zeros((2, 30, 40), dtype=bool)
+        xyxy = np.array([[5.0, 5.0, 20.0, 20.0], [10.0, 10.0, 25.0, 25.0]])
+        result = _masks_to_roi(masks, (30, 40), xyxy)
+        assert result is None
+
 
 @pytest.mark.parametrize(
     ("masks", "offset", "resolution_wh", "expected_result", "exception"),


### PR DESCRIPTION
This pull request introduces a significant optimization to the `MaskAnnotator` class, ensuring that mask blending is limited to only the region of interest (ROI) touched by the mask(s), rather than always blending the full image. This change improves annotation speed, especially for large images with sparse masks, and reduces unnecessary computation. The update includes supporting utility functions, test coverage for the new behavior, and improved documentation and reporting in the benchmark script.

**Mask annotation ROI optimization:**
- Updated `MaskAnnotator.annotate` to blend only the minimal bounding rectangle (ROI) covering all true mask pixels, both for dense and compact masks, instead of the entire image. This is achieved by computing the ROI with new helper functions and passing the ROI to the blending operation.
- Refactored the internal `_paint_masks_by_area` function to support painting into a subregion of the canvas with a new `canvas_origin` parameter, aligning mask coordinates with the ROI. [[1]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2R374) [[2]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2R392-R393) [[3]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2R406-R407) [[4]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2L415-R504)

**Utility functions for ROI calculation:**
- Added `_mask_to_roi`, `_compact_masks_to_roi`, and `_masks_to_roi` functions to compute the minimal bounding box for true mask pixels in dense and compact masks.

**Testing:**
- Added new tests in `tests/annotators/test_core.py` to verify that blending occurs only within the mask ROI for both dense and compact masks, and that no blending occurs when masks are all-false.

**Documentation and reporting:**
- Improved docstrings and comments to clarify the new ROI-based blending logic.
- Updated the benchmark script and table output to clarify that annotation speedup is due to ROI-only blending, and improved column naming for clarity. [[1]](diffhunk://#diff-62ee0e529e672043d6daff91d04c62ef2e9ac794df6282a4a8919143e44dbb92L5-R7) [[2]](diffhunk://#diff-62ee0e529e672043d6daff91d04c62ef2e9ac794df6282a4a8919143e44dbb92L77-R79) [[3]](diffhunk://#diff-62ee0e529e672043d6daff91d04c62ef2e9ac794df6282a4a8919143e44dbb92L959-R961) [[4]](diffhunk://#diff-62ee0e529e672043d6daff91d04c62ef2e9ac794df6282a4a8919143e44dbb92L1040-R1043)