### PR TITLE
perf: avoid compact mask materialization in polygon annotator

### DIFF
--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from functools import lru_cache
 from math import sqrt
 from typing import Any, cast
@@ -354,6 +355,45 @@ class OrientedBoxAnnotator(BaseAnnotator):
 
 
 # --- Shared mask-painting utilities ---
+def _iter_mask_crops(
+    detections: Detections,
+) -> Iterator[tuple[int, npt.NDArray[np.bool_], npt.NDArray[np.int32] | None]]:
+    """Yield ``(detection_idx, mask_or_crop, offset_or_None)`` for each mask.
+
+    Encapsulates the ``CompactMask`` vs dense dispatch so individual annotators
+    do not need inline ``isinstance`` checks. For ``CompactMask`` inputs yields
+    the bbox crop and its ``(x1, y1)`` image-space origin; for dense masks
+    yields the full-frame boolean slice with ``offset=None``.
+
+    Args:
+        detections: Object detections whose masks to iterate.
+
+    Yields:
+        Tuple of ``(detection_idx, mask_or_crop, offset_or_None)``.
+        ``mask_or_crop`` is boolean (crop-sized for ``CompactMask``, full-frame
+        for dense). ``offset_or_None`` is an int32 ``(x1, y1)`` array for
+        crop→image translation, or ``None`` for dense masks.
+    """
+    masks = detections.mask
+    if masks is None:
+        return
+    # TODO: replace isinstance dispatch with a MaskLike Protocol (separate PR)
+    compact_mask = masks if isinstance(masks, CompactMask) else None
+    for detection_idx in range(len(detections)):
+        if compact_mask is None:
+            yield (
+                detection_idx,
+                cast(npt.NDArray[np.bool_], masks[detection_idx]),
+                None,
+            )
+        else:
+            yield (
+                detection_idx,
+                compact_mask.crop(detection_idx),
+                compact_mask.offsets[detection_idx],
+            )
+
+
 def _paint_masks_by_area(
     canvas: npt.NDArray[np.uint8],
     detections: Detections,
@@ -610,6 +650,14 @@ class PolygonAnnotator(BaseAnnotator):
 
             ```
 
+        Note:
+            When `detections.mask` is a `CompactMask`, each detection's polygon
+            is decoded from a bbox-sized crop (O(crop_area)) rather than a
+            full-frame ``(H, W)`` allocation (O(H·W)). Polygon coordinates are
+            shifted from crop-local space to image space via the stored
+            ``(x1, y1)`` bbox origin. Pixels outside the declared ``xyxy`` box
+            are not represented in compact storage and will not be drawn.
+
         ![polygon-annotator-example](https://media.roboflow.com/
         supervision-annotator-examples/polygon-annotator-example-purple.png)
         """
@@ -618,15 +666,7 @@ class PolygonAnnotator(BaseAnnotator):
         if detections.mask is None:
             return scene
 
-        masks = detections.mask
-        compact_mask = masks if isinstance(masks, CompactMask) else None
-        for detection_idx in range(len(detections)):
-            if compact_mask is None:
-                mask = cast(npt.NDArray[np.bool_], masks[detection_idx])
-                offset = None
-            else:
-                mask = compact_mask.crop(detection_idx)
-                offset = compact_mask.offsets[detection_idx]
+        for detection_idx, mask, offset in _iter_mask_crops(detections):
             color = resolve_color(
                 color=self.color,
                 detections=detections,
@@ -637,6 +677,7 @@ class PolygonAnnotator(BaseAnnotator):
             )
             for polygon in mask_to_polygons(mask=mask):
                 if offset is not None:
+                    # translate crop-local polygon to image space via (x1, y1) origin
                     polygon = polygon + offset
                 scene = draw_polygon(
                     scene=scene,

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -585,8 +585,15 @@ class PolygonAnnotator(BaseAnnotator):
         if detections.mask is None:
             return scene
 
+        masks = detections.mask
+        compact_mask = masks if isinstance(masks, CompactMask) else None
         for detection_idx in range(len(detections)):
-            mask = cast(npt.NDArray[np.bool_], detections.mask[detection_idx])
+            if compact_mask is None:
+                mask = cast(npt.NDArray[np.bool_], masks[detection_idx])
+                offset = None
+            else:
+                mask = compact_mask.crop(detection_idx)
+                offset = compact_mask.offsets[detection_idx]
             color = resolve_color(
                 color=self.color,
                 detections=detections,
@@ -596,6 +603,8 @@ class PolygonAnnotator(BaseAnnotator):
                 else custom_color_lookup,
             )
             for polygon in mask_to_polygons(mask=mask):
+                if offset is not None:
+                    polygon = polygon + offset
                 scene = draw_polygon(
                     scene=scene,
                     polygon=cast(npt.NDArray[np.int_], polygon),

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -291,6 +291,43 @@ class TestPolygonAnnotator:
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert_image_mostly_same(test_image, result, similarity_threshold=0.85)
 
+    def test_compact_mask_uses_crops_and_matches_dense_mask(self, monkeypatch):
+        """CompactMask polygons use crops without full-frame mask indexing."""
+        height, width = 80, 90
+        scene = np.zeros((height, width, 3), dtype=np.uint8)
+        masks = np.zeros((3, height, width), dtype=bool)
+        masks[0, 10:20, 15:30] = True
+        masks[0, 32:45, 40:55] = True
+        masks[1] = False
+        masks[2, 50:70, 5:25] = True
+        xyxy = np.array(
+            [[15, 10, 54, 44], [60, 5, 70, 15], [5, 50, 24, 69]],
+            dtype=np.float32,
+        )
+        dense = Detections(xyxy=xyxy, mask=masks, class_id=np.array([0, 1, 2]))
+        compact = Detections(
+            xyxy=xyxy,
+            mask=CompactMask.from_dense(masks, xyxy, (height, width)),
+            class_id=np.array([0, 1, 2]),
+        )
+        annotator = PolygonAnnotator(
+            color=Color.WHITE, thickness=1, color_lookup=ColorLookup.INDEX
+        )
+        expected = annotator.annotate(scene=scene.copy(), detections=dense)
+
+        original_getitem = CompactMask.__getitem__
+
+        def fail_int_index(self, index):
+            if isinstance(index, (int, np.integer)):
+                raise AssertionError("PolygonAnnotator must use CompactMask.crop")
+            return original_getitem(self, index)
+
+        monkeypatch.setattr(CompactMask, "__getitem__", fail_int_index)
+        result = annotator.annotate(scene=scene.copy(), detections=compact)
+
+        assert not np.array_equal(result, scene), "annotator painted nothing"
+        np.testing.assert_array_equal(result, expected)
+
 
 class TestColorAnnotator:
     """Tests for ColorAnnotator class"""

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -464,7 +464,11 @@ class TestPolygonAnnotator:
                 raise AssertionError("PolygonAnnotator must use CompactMask.crop")
             return original_getitem(self, index)
 
+        def fail_to_dense(self):
+            raise AssertionError("PolygonAnnotator must not call CompactMask.to_dense")
+
         monkeypatch.setattr(CompactMask, "__getitem__", fail_int_index)
+        monkeypatch.setattr(CompactMask, "to_dense", fail_to_dense)
         result = annotator.annotate(scene=scene.copy(), detections=compact)
 
         assert not np.array_equal(result, scene), "annotator painted nothing"

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -470,6 +470,119 @@ class TestPolygonAnnotator:
         assert not np.array_equal(result, scene), "annotator painted nothing"
         np.testing.assert_array_equal(result, expected)
 
+    def test_annotate_with_empty_compact_mask(self):
+        """N=0 CompactMask returns scene unchanged without error."""
+        height, width = 60, 80
+        scene = np.zeros((height, width, 3), dtype=np.uint8)
+        empty_masks = np.zeros((0, height, width), dtype=bool)
+        xyxy = np.zeros((0, 4), dtype=np.float32)
+        detections = Detections(
+            xyxy=xyxy,
+            mask=CompactMask.from_dense(empty_masks, xyxy, (height, width)),
+            class_id=np.array([], dtype=int),
+        )
+        annotator = PolygonAnnotator(color=Color.WHITE, color_lookup=ColorLookup.INDEX)
+        result = annotator.annotate(scene=scene.copy(), detections=detections)
+        np.testing.assert_array_equal(result, scene)
+
+    def test_annotate_with_all_false_compact_mask_unchanged(self):
+        """All-False CompactMask crop (no contours) leaves scene pixels unchanged.
+
+        A detection whose mask is entirely False produces no polygons; the
+        annotator must not paint any pixels for that detection.
+        """
+        height, width = 60, 80
+        scene = np.zeros((height, width, 3), dtype=np.uint8)
+        masks = np.zeros((1, height, width), dtype=bool)
+        xyxy = np.array([[10.0, 10.0, 50.0, 50.0]], dtype=np.float32)
+        detections = Detections(
+            xyxy=xyxy,
+            mask=CompactMask.from_dense(masks, xyxy, (height, width)),
+            class_id=np.array([0]),
+        )
+        annotator = PolygonAnnotator(color=Color.WHITE, color_lookup=ColorLookup.INDEX)
+        result = annotator.annotate(scene=scene.copy(), detections=detections)
+        np.testing.assert_array_equal(result, scene)
+
+    def test_annotate_with_single_compact_mask_detection(self):
+        """N=1 CompactMask detection annotates the same as dense mask."""
+        height, width = 60, 80
+        scene = np.zeros((height, width, 3), dtype=np.uint8)
+        mask = np.zeros((height, width), dtype=bool)
+        mask[20:40, 15:55] = True
+        xyxy = np.array([[15.0, 20.0, 54.0, 39.0]], dtype=np.float32)
+        dense = Detections(xyxy=xyxy, mask=np.array([mask]), class_id=np.array([0]))
+        compact = Detections(
+            xyxy=xyxy,
+            mask=CompactMask.from_dense(np.array([mask]), xyxy, (height, width)),
+            class_id=np.array([0]),
+        )
+        annotator = PolygonAnnotator(
+            color=Color.WHITE, thickness=1, color_lookup=ColorLookup.INDEX
+        )
+        expected = annotator.annotate(scene=scene.copy(), detections=dense)
+        result = annotator.annotate(scene=scene.copy(), detections=compact)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_annotate_compact_mask_float_xyxy_truncation(self):
+        """Float xyxy with sub-pixel values are truncated to int before crop decode.
+
+        CompactMask stores bbox origins as int32 (via truncation); PolygonAnnotator
+        must produce the same output whether xyxy is integral or has fractional parts.
+        """
+        height, width = 60, 80
+        scene = np.zeros((height, width, 3), dtype=np.uint8)
+        mask = np.zeros((height, width), dtype=bool)
+        mask[10:30, 5:45] = True
+        xyxy_int = np.array([[5.0, 10.0, 44.0, 29.0]], dtype=np.float32)
+        xyxy_float = np.array([[5.7, 10.9, 44.3, 29.1]], dtype=np.float32)
+        compact_int = Detections(
+            xyxy=xyxy_int,
+            mask=CompactMask.from_dense(np.array([mask]), xyxy_int, (height, width)),
+            class_id=np.array([0]),
+        )
+        compact_float = Detections(
+            xyxy=xyxy_float,
+            mask=CompactMask.from_dense(np.array([mask]), xyxy_float, (height, width)),
+            class_id=np.array([0]),
+        )
+        annotator = PolygonAnnotator(
+            color=Color.WHITE, thickness=1, color_lookup=ColorLookup.INDEX
+        )
+        result_int = annotator.annotate(scene=scene.copy(), detections=compact_int)
+        result_float = annotator.annotate(scene=scene.copy(), detections=compact_float)
+        np.testing.assert_array_equal(result_int, result_float)
+
+    def test_compact_mask_disjoint_contours_offset_correct(self):
+        """Disjoint-contour mask: both polygon blobs translate to correct image coords.
+
+        Verifies coordinate-level correctness of crop→image offset for a mask
+        with two separate blobs. After annotation, boundary pixels of each blob
+        must be painted; pixels between the blobs must remain unpainted.
+        """
+        height, width = 80, 90
+        scene = np.zeros((height, width, 3), dtype=np.uint8)
+        mask = np.zeros((height, width), dtype=bool)
+        mask[10:20, 15:30] = True
+        mask[32:45, 40:55] = True
+        xyxy = np.array([[15.0, 10.0, 54.0, 44.0]], dtype=np.float32)
+        detections = Detections(
+            xyxy=xyxy,
+            mask=CompactMask.from_dense(np.array([mask]), xyxy, (height, width)),
+            class_id=np.array([0]),
+        )
+        annotator = PolygonAnnotator(
+            color=Color.WHITE, thickness=1, color_lookup=ColorLookup.INDEX
+        )
+        result = annotator.annotate(scene=scene.copy(), detections=detections)
+
+        # Boundary of blob 1 in image space — must be painted
+        assert np.any(result[10:20, 15:30] != 0), "blob 1 boundary not painted"
+        # Boundary of blob 2 in image space — must be painted
+        assert np.any(result[32:45, 40:55] != 0), "blob 2 boundary not painted"
+        # Gap between blobs — no polygon pixels expected here
+        assert np.all(result[21:31, :] == 0), "gap between blobs has stray pixels"
+
 
 class TestColorAnnotator:
     """Tests for ColorAnnotator class"""
@@ -681,6 +794,12 @@ class TestCompactMaskParity:
             pytest.param(
                 lambda: MaskAnnotator(opacity=1.0, color_lookup=ColorLookup.INDEX),
                 id="mask",
+            ),
+            pytest.param(
+                lambda: PolygonAnnotator(
+                    color=Color.WHITE, thickness=1, color_lookup=ColorLookup.INDEX
+                ),
+                id="polygon",
             ),
             pytest.param(
                 lambda: HaloAnnotator(kernel_size=15, color_lookup=ColorLookup.INDEX),


### PR DESCRIPTION
This pull request enhances the handling and testing of compact mask annotations in the `PolygonAnnotator`. The main change is ensuring that when a `CompactMask` is used, the annotation logic utilizes cropped masks and applies the correct offset, instead of relying on dense mask indexing. Additionally, a new test verifies this behavior and ensures compatibility between dense and compact masks.

**Improvements to mask annotation logic:**

* Updated `annotate` in `core.py` to detect when a `CompactMask` is used, apply the appropriate crop for each detection, and add the offset to polygons before drawing. This ensures annotations are correctly positioned for compact masks. [[1]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2R588-R596) [[2]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2R606-R607)

**Testing and validation:**

* Added a test `test_compact_mask_uses_crops_and_matches_dense_mask` to verify that the annotator uses `CompactMask.crop` (not dense mask indexing) and that the output matches the dense mask annotation. The test also ensures that using integer indexing on `CompactMask` raises an error, enforcing the correct usage pattern.