### PR TITLE
feat: declare annotator mask requirements

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ date_modified: 2026-06-25
     Users on Python 3.9 should upgrade their environment before updating supervision.
 
 ### Added
+- `BaseAnnotator.requires_mask` — class-level `bool` flag on all annotators; `True` for `MaskAnnotator`, `PolygonAnnotator`, and `HaloAnnotator`; `False` for all others. Integrations can inspect this before materializing expensive mask payloads ([#2370](https://github.com/roboflow/supervision/pull/2370))
 - `CompactMask.from_coco_rle` — efficient COCO RLE ingestion into crop-scoped compact mask format without materializing dense `(N, H, W)` arrays ([#2367](https://github.com/roboflow/supervision/pull/2367))
 - `Detections.from_inference(compact_masks=True)` — opt-in compact mask representation for Roboflow/Inference segmentation results; masks are cropped to detector bounding boxes ([#2367](https://github.com/roboflow/supervision/pull/2367))
 

--- a/src/supervision/annotators/base.py
+++ b/src/supervision/annotators/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar
+from typing import Any
 
 from supervision.detection.core import Detections
 
@@ -12,7 +12,7 @@ class BaseAnnotator(ABC):
             this annotator. Check this before materializing expensive mask payloads.
     """
 
-    requires_mask: ClassVar[bool] = False
+    requires_mask: bool = False
 
     @abstractmethod
     def annotate(

--- a/src/supervision/annotators/base.py
+++ b/src/supervision/annotators/base.py
@@ -1,10 +1,19 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, ClassVar
 
 from supervision.detection.core import Detections
 
 
 class BaseAnnotator(ABC):
+    """Base class for annotators that consume :class:`Detections`.
+
+    Attributes:
+        requires_mask: Whether integrations must provide ``Detections.mask`` for
+            this annotator. Check this before materializing expensive mask payloads.
+    """
+
+    requires_mask: ClassVar[bool] = False
+
     @abstractmethod
     def annotate(
         self, scene: Any, detections: Detections, *args: Any, **kwargs: Any

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterator
 from functools import lru_cache
 from math import sqrt
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import cv2
 import numpy as np
@@ -3193,7 +3193,8 @@ class ComparisonAnnotator:
     Otherwise, uses the bounding box data.
     """
 
-    requires_mask = False
+    # Not a BaseAnnotator subclass — duck-typing callers can still check requires_mask
+    requires_mask: ClassVar[bool] = False
 
     def __init__(
         self,

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -432,6 +432,8 @@ class MaskAnnotator(BaseAnnotator):
         This annotator uses `sv.Detections.mask`.
     """
 
+    requires_mask = True
+
     def __init__(
         self,
         color: Color | ColorPalette | str = ColorPalette.DEFAULT,
@@ -519,6 +521,8 @@ class PolygonAnnotator(BaseAnnotator):
 
         This annotator uses `sv.Detections.mask`.
     """
+
+    requires_mask = True
 
     def __init__(
         self,
@@ -706,6 +710,8 @@ class HaloAnnotator(BaseAnnotator):
 
         This annotator uses `sv.Detections.mask`.
     """
+
+    requires_mask = True
 
     def __init__(
         self,
@@ -3064,6 +3070,8 @@ class ComparisonAnnotator:
     Otherwise, if present, uses a mask.
     Otherwise, uses the bounding box data.
     """
+
+    requires_mask = False
 
     def __init__(
         self,

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -3,6 +3,7 @@ Tests for supervision/annotators/core.py
 """
 
 import warnings
+from collections.abc import Iterator
 
 import cv2
 import numpy as np
@@ -43,7 +44,9 @@ from supervision.geometry.core import Position
 from tests.helpers import _create_detections, assert_image_mostly_same
 
 
-def _get_concrete_annotator_subclasses(cls):
+def _get_concrete_annotator_subclasses(
+    cls: type[BaseAnnotator],
+) -> Iterator[type[BaseAnnotator]]:
     """Recursively yield non-abstract BaseAnnotator subclasses."""
     for sub in cls.__subclasses__():
         if not getattr(sub, "__abstractmethods__", None):
@@ -94,6 +97,15 @@ class TestAnnotatorMaskPolicy:
     def test_all_subclasses_have_bool_requires_mask(self, annotator_class):
         """Every concrete BaseAnnotator subclass declares requires_mask as a bool."""
         assert isinstance(annotator_class.requires_mask, bool)
+
+    def test_exact_mask_requiring_annotator_set(self):
+        """Only MaskAnnotator, PolygonAnnotator, HaloAnnotator require masks."""
+        mask_true = {
+            cls
+            for cls in _get_concrete_annotator_subclasses(BaseAnnotator)
+            if cls.requires_mask is True
+        }
+        assert mask_true == {MaskAnnotator, PolygonAnnotator, HaloAnnotator}
 
 
 @pytest.fixture

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -42,6 +42,39 @@ from supervision.geometry.core import Position
 from tests.helpers import _create_detections, assert_image_mostly_same
 
 
+class TestAnnotatorMaskPolicy:
+    """Tests for annotator mask materialization policy metadata."""
+
+    @pytest.mark.parametrize(
+        "annotator",
+        [
+            pytest.param(MaskAnnotator(), id="mask"),
+            pytest.param(PolygonAnnotator(), id="polygon"),
+            pytest.param(HaloAnnotator(), id="halo"),
+        ],
+    )
+    def test_mask_required_annotators_declare_mask_requirement(self, annotator):
+        """Annotators that require detections.mask expose the requirement."""
+        assert annotator.requires_mask is True
+
+    @pytest.mark.parametrize(
+        "annotator",
+        [
+            pytest.param(BoxAnnotator(), id="box"),
+            pytest.param(LabelAnnotator(), id="label"),
+            pytest.param(CircleAnnotator(), id="circle"),
+            pytest.param(EllipseAnnotator(), id="ellipse"),
+            pytest.param(TraceAnnotator(), id="trace"),
+            pytest.param(BackgroundOverlayAnnotator(), id="overlay"),
+            pytest.param(BackgroundOverlayAnnotator(force_box=True), id="overlay-box"),
+            pytest.param(ComparisonAnnotator(), id="comparison"),
+        ],
+    )
+    def test_mask_optional_annotators_declare_no_mask_requirement(self, annotator):
+        """Mask-optional annotators do not require mask materialization."""
+        assert annotator.requires_mask is False
+
+
 @pytest.fixture
 def test_image() -> np.ndarray:
     """Create a simple blank test image fixture"""

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -8,6 +8,7 @@ import cv2
 import numpy as np
 import pytest
 
+from supervision.annotators.base import BaseAnnotator
 from supervision.annotators.core import (
     BackgroundOverlayAnnotator,
     BlurAnnotator,
@@ -21,6 +22,7 @@ from supervision.annotators.core import (
     EllipseAnnotator,
     HaloAnnotator,
     HeatMapAnnotator,
+    IconAnnotator,
     LabelAnnotator,
     MaskAnnotator,
     OrientedBoxAnnotator,
@@ -41,6 +43,14 @@ from supervision.geometry.core import Position
 from tests.helpers import _create_detections, assert_image_mostly_same
 
 
+def _get_concrete_annotator_subclasses(cls):
+    """Recursively yield non-abstract BaseAnnotator subclasses."""
+    for sub in cls.__subclasses__():
+        if not getattr(sub, "__abstractmethods__", None):
+            yield sub
+        yield from _get_concrete_annotator_subclasses(sub)
+
+
 class TestAnnotatorMaskPolicy:
     """Tests for annotator mask materialization policy metadata."""
 
@@ -54,7 +64,7 @@ class TestAnnotatorMaskPolicy:
     )
     def test_mask_required_annotators_declare_mask_requirement(self, annotator):
         """Annotators that require detections.mask expose the requirement."""
-        assert annotator.requires_mask is True
+        assert type(annotator).requires_mask is True
 
     @pytest.mark.parametrize(
         "annotator",
@@ -63,6 +73,7 @@ class TestAnnotatorMaskPolicy:
             pytest.param(LabelAnnotator(), id="label"),
             pytest.param(CircleAnnotator(), id="circle"),
             pytest.param(EllipseAnnotator(), id="ellipse"),
+            pytest.param(IconAnnotator(), id="icon"),
             pytest.param(TraceAnnotator(), id="trace"),
             pytest.param(BackgroundOverlayAnnotator(), id="overlay"),
             pytest.param(BackgroundOverlayAnnotator(force_box=True), id="overlay-box"),
@@ -71,7 +82,18 @@ class TestAnnotatorMaskPolicy:
     )
     def test_mask_optional_annotators_declare_no_mask_requirement(self, annotator):
         """Mask-optional annotators do not require mask materialization."""
-        assert annotator.requires_mask is False
+        assert type(annotator).requires_mask is False
+
+    @pytest.mark.parametrize(
+        "annotator_class",
+        [
+            pytest.param(cls, id=cls.__name__)
+            for cls in _get_concrete_annotator_subclasses(BaseAnnotator)
+        ],
+    )
+    def test_all_subclasses_have_bool_requires_mask(self, annotator_class):
+        """Every concrete BaseAnnotator subclass declares requires_mask as a bool."""
+        assert isinstance(annotator_class.requires_mask, bool)
 
 
 @pytest.fixture


### PR DESCRIPTION
This pull request introduces a standardized way for annotator classes to declare whether they require the `Detections.mask` attribute, which helps integrations avoid unnecessary computation when mask data is not needed. It does this by adding a `requires_mask` class variable to the base annotator class and setting it appropriately in each annotator. Comprehensive tests are also included to ensure the correct policy is declared by all annotators.

**Annotator mask requirement policy:**

* Added a `requires_mask` class variable to `BaseAnnotator` to indicate whether an annotator requires `Detections.mask`. This allows integrations to check mask requirements before materializing mask payloads.
* Set `requires_mask = True` for `MaskAnnotator`, `PolygonAnnotator`, and `HaloAnnotator`, indicating these annotators require mask data. [[1]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2R435-R436) [[2]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2R525-R526) [[3]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2R714-R715)
* Set `requires_mask = False` for `ComparisonAnnotator` to explicitly indicate it does not require mask data.

**Testing:**

* Added `TestAnnotatorMaskPolicy` tests to verify that all annotators correctly declare their mask requirement policy via the `requires_mask` attribute.