### PR TITLE
fix(pre-commit): pin mypy hook python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
     rev: v1.20.2
     hooks:
       - id: mypy
+        language_version: python3.11
         additional_dependencies:
           - "numpy>=2.0"
           - "types-PyYAML"


### PR DESCRIPTION
This pull request makes a small configuration update to the pre-commit hook for `mypy` to specify the Python version.

* The `mypy` pre-commit hook in `.pre-commit-config.yaml` now explicitly uses `python3.11` as its `language_version`.