### PR TITLE
fix(metrics): replace np.unique matching with greedy algorithm

### DIFF
--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -1518,7 +1518,7 @@ class MeanAveragePrecision:
                 target_idx = matched_indices[0]
                 pred_idx = matched_indices[1]
                 iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values)
+                order = np.argsort(-iou_values, kind="stable")
                 matched_targets: set[int] = set()
                 matched_preds: set[int] = set()
                 for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):

--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -25,6 +25,7 @@ from supervision.detection.utils.iou_and_nms import (
     oriented_box_iou_batch,
 )
 from supervision.metrics.core import MetricTarget
+from supervision.metrics.utils.matching import _greedy_match
 
 
 def _assert_supported_target(metric_target: MetricTarget) -> None:
@@ -1514,18 +1515,8 @@ class MeanAveragePrecision:
         for i, iou_level in enumerate(iou_thresholds):
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
-            if matched_indices[0].shape[0]:
-                target_idx = matched_indices[0]
-                pred_idx = matched_indices[1]
-                iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values, kind="stable")
-                matched_targets: set[int] = set()
-                matched_preds: set[int] = set()
-                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
-                    if t not in matched_targets and p not in matched_preds:
-                        matched_targets.add(t)
-                        matched_preds.add(p)
-                        correct[p, i] = True
+            for t, p in _greedy_match(iou, matched_indices):
+                correct[p, i] = True
         result: npt.NDArray[np.bool_] = correct
         return result
 

--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -1515,16 +1515,17 @@ class MeanAveragePrecision:
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
             if matched_indices[0].shape[0]:
-                combined_indices = np.stack(matched_indices, axis=1)
-                iou_values = iou[matched_indices][:, None]
-                matches = np.hstack([combined_indices, iou_values])
-
-                if matched_indices[0].shape[0] > 1:
-                    matches = matches[matches[:, 2].argsort()[::-1]]
-                    matches = matches[np.unique(matches[:, 1], return_index=True)[1]]
-                    matches = matches[np.unique(matches[:, 0], return_index=True)[1]]
-
-                correct[matches[:, 1].astype(int), i] = True
+                target_idx = matched_indices[0]
+                pred_idx = matched_indices[1]
+                iou_values = iou[matched_indices]
+                order = np.argsort(-iou_values)
+                matched_targets: set[int] = set()
+                matched_preds: set[int] = set()
+                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
+                    if t not in matched_targets and p not in matched_preds:
+                        matched_targets.add(t)
+                        matched_preds.add(p)
+                        correct[p, i] = True
         result: npt.NDArray[np.bool_] = correct
         return result
 

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -348,16 +348,17 @@ class F1Score(Metric["F1ScoreResult"]):
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
             if matched_indices[0].shape[0]:
-                combined_indices = np.stack(matched_indices, axis=1)
-                iou_values = iou[matched_indices][:, None]
-                matches = np.hstack([combined_indices, iou_values])
-
-                if matched_indices[0].shape[0] > 1:
-                    matches = matches[matches[:, 2].argsort()[::-1]]
-                    matches = matches[np.unique(matches[:, 1], return_index=True)[1]]
-                    matches = matches[np.unique(matches[:, 0], return_index=True)[1]]
-
-                correct[matches[:, 1].astype(int), i] = True
+                target_idx = matched_indices[0]
+                pred_idx = matched_indices[1]
+                iou_values = iou[matched_indices]
+                order = np.argsort(-iou_values)
+                matched_targets: set[int] = set()
+                matched_preds: set[int] = set()
+                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
+                    if t not in matched_targets and p not in matched_preds:
+                        matched_targets.add(t)
+                        matched_preds.add(p)
+                        correct[p, i] = True
 
         result_correct: npt.NDArray[np.bool_] = correct
         return result_correct

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -17,6 +17,7 @@ from supervision.detection.utils.iou_and_nms import (
 )
 from supervision.draw.color import LEGACY_COLOR_PALETTE
 from supervision.metrics.core import AveragingMethod, Metric, MetricTarget
+from supervision.metrics.utils.matching import _greedy_match
 from supervision.metrics.utils.object_size import (
     ObjectSizeCategory,
     get_detection_size_category,
@@ -347,18 +348,8 @@ class F1Score(Metric["F1ScoreResult"]):
         for i, iou_level in enumerate(iou_thresholds):
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
-            if matched_indices[0].shape[0]:
-                target_idx = matched_indices[0]
-                pred_idx = matched_indices[1]
-                iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values, kind="stable")
-                matched_targets: set[int] = set()
-                matched_preds: set[int] = set()
-                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
-                    if t not in matched_targets and p not in matched_preds:
-                        matched_targets.add(t)
-                        matched_preds.add(p)
-                        correct[p, i] = True
+            for t, p in _greedy_match(iou, matched_indices):
+                correct[p, i] = True
 
         result_correct: npt.NDArray[np.bool_] = correct
         return result_correct

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -351,7 +351,7 @@ class F1Score(Metric["F1ScoreResult"]):
                 target_idx = matched_indices[0]
                 pred_idx = matched_indices[1]
                 iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values)
+                order = np.argsort(-iou_values, kind="stable")
                 matched_targets: set[int] = set()
                 matched_preds: set[int] = set()
                 for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):

--- a/src/supervision/metrics/mean_average_recall.py
+++ b/src/supervision/metrics/mean_average_recall.py
@@ -531,16 +531,17 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
             if matched_indices[0].shape[0]:
-                combined_indices = np.stack(matched_indices, axis=1)
-                iou_values = iou[matched_indices][:, None]
-                matches = np.hstack([combined_indices, iou_values])
-
-                if matched_indices[0].shape[0] > 1:
-                    matches = matches[matches[:, 2].argsort()[::-1]]
-                    matches = matches[np.unique(matches[:, 1], return_index=True)[1]]
-                    matches = matches[np.unique(matches[:, 0], return_index=True)[1]]
-
-                correct[matches[:, 1].astype(int), i] = True
+                target_idx = matched_indices[0]
+                pred_idx = matched_indices[1]
+                iou_values = iou[matched_indices]
+                order = np.argsort(-iou_values)
+                matched_targets: set[int] = set()
+                matched_preds: set[int] = set()
+                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
+                    if t not in matched_targets and p not in matched_preds:
+                        matched_targets.add(t)
+                        matched_preds.add(p)
+                        correct[p, i] = True
         result_correct: npt.NDArray[np.bool_] = correct
         return result_correct
 

--- a/src/supervision/metrics/mean_average_recall.py
+++ b/src/supervision/metrics/mean_average_recall.py
@@ -17,6 +17,7 @@ from supervision.detection.utils.iou_and_nms import (
 )
 from supervision.draw.color import LEGACY_COLOR_PALETTE
 from supervision.metrics.core import Metric, MetricTarget
+from supervision.metrics.utils.matching import _greedy_match
 from supervision.metrics.utils.object_size import (
     ObjectSizeCategory,
     get_detection_size_category,
@@ -530,18 +531,8 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
         for i, iou_level in enumerate(iou_thresholds):
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
-            if matched_indices[0].shape[0]:
-                target_idx = matched_indices[0]
-                pred_idx = matched_indices[1]
-                iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values, kind="stable")
-                matched_targets: set[int] = set()
-                matched_preds: set[int] = set()
-                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
-                    if t not in matched_targets and p not in matched_preds:
-                        matched_targets.add(t)
-                        matched_preds.add(p)
-                        correct[p, i] = True
+            for t, p in _greedy_match(iou, matched_indices):
+                correct[p, i] = True
         result_correct: npt.NDArray[np.bool_] = correct
         return result_correct
 

--- a/src/supervision/metrics/mean_average_recall.py
+++ b/src/supervision/metrics/mean_average_recall.py
@@ -534,7 +534,7 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
                 target_idx = matched_indices[0]
                 pred_idx = matched_indices[1]
                 iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values)
+                order = np.argsort(-iou_values, kind="stable")
                 matched_targets: set[int] = set()
                 matched_preds: set[int] = set()
                 for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -356,7 +356,7 @@ class Precision(Metric["PrecisionResult"]):
                 target_idx = matched_indices[0]
                 pred_idx = matched_indices[1]
                 iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values)
+                order = np.argsort(-iou_values, kind="stable")
                 matched_targets: set[int] = set()
                 matched_preds: set[int] = set()
                 for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -353,16 +353,17 @@ class Precision(Metric["PrecisionResult"]):
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
             if matched_indices[0].shape[0]:
-                combined_indices = np.stack(matched_indices, axis=1)
-                iou_values = iou[matched_indices][:, None]
-                matches = np.hstack([combined_indices, iou_values])
-
-                if matched_indices[0].shape[0] > 1:
-                    matches = matches[matches[:, 2].argsort()[::-1]]
-                    matches = matches[np.unique(matches[:, 1], return_index=True)[1]]
-                    matches = matches[np.unique(matches[:, 0], return_index=True)[1]]
-
-                correct[matches[:, 1].astype(int), i] = True
+                target_idx = matched_indices[0]
+                pred_idx = matched_indices[1]
+                iou_values = iou[matched_indices]
+                order = np.argsort(-iou_values)
+                matched_targets: set[int] = set()
+                matched_preds: set[int] = set()
+                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
+                    if t not in matched_targets and p not in matched_preds:
+                        matched_targets.add(t)
+                        matched_preds.add(p)
+                        correct[p, i] = True
         result_correct: npt.NDArray[np.bool_] = correct
         return result_correct
 

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -17,6 +17,7 @@ from supervision.detection.utils.iou_and_nms import (
 )
 from supervision.draw.color import LEGACY_COLOR_PALETTE
 from supervision.metrics.core import AveragingMethod, Metric, MetricTarget
+from supervision.metrics.utils.matching import _greedy_match
 from supervision.metrics.utils.object_size import (
     ObjectSizeCategory,
     get_detection_size_category,
@@ -352,18 +353,8 @@ class Precision(Metric["PrecisionResult"]):
         for i, iou_level in enumerate(iou_thresholds):
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
-            if matched_indices[0].shape[0]:
-                target_idx = matched_indices[0]
-                pred_idx = matched_indices[1]
-                iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values, kind="stable")
-                matched_targets: set[int] = set()
-                matched_preds: set[int] = set()
-                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
-                    if t not in matched_targets and p not in matched_preds:
-                        matched_targets.add(t)
-                        matched_preds.add(p)
-                        correct[p, i] = True
+            for t, p in _greedy_match(iou, matched_indices):
+                correct[p, i] = True
         result_correct: npt.NDArray[np.bool_] = correct
         return result_correct
 

--- a/src/supervision/metrics/recall.py
+++ b/src/supervision/metrics/recall.py
@@ -305,7 +305,7 @@ class Recall(Metric["RecallResult"]):
                 target_idx = matched_indices[0]
                 pred_idx = matched_indices[1]
                 iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values)
+                order = np.argsort(-iou_values, kind="stable")
                 matched_targets: set[int] = set()
                 matched_preds: set[int] = set()
                 for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):

--- a/src/supervision/metrics/recall.py
+++ b/src/supervision/metrics/recall.py
@@ -302,16 +302,17 @@ class Recall(Metric["RecallResult"]):
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
             if matched_indices[0].shape[0]:
-                combined_indices = np.stack(matched_indices, axis=1)
-                iou_values = iou[matched_indices][:, None]
-                matches = np.hstack([combined_indices, iou_values])
-
-                if matched_indices[0].shape[0] > 1:
-                    matches = matches[matches[:, 2].argsort()[::-1]]
-                    matches = matches[np.unique(matches[:, 1], return_index=True)[1]]
-                    matches = matches[np.unique(matches[:, 0], return_index=True)[1]]
-
-                correct[matches[:, 1].astype(int), i] = True
+                target_idx = matched_indices[0]
+                pred_idx = matched_indices[1]
+                iou_values = iou[matched_indices]
+                order = np.argsort(-iou_values)
+                matched_targets: set[int] = set()
+                matched_preds: set[int] = set()
+                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
+                    if t not in matched_targets and p not in matched_preds:
+                        matched_targets.add(t)
+                        matched_preds.add(p)
+                        correct[p, i] = True
         result_correct: npt.NDArray[np.bool_] = correct
         return result_correct
 

--- a/src/supervision/metrics/recall.py
+++ b/src/supervision/metrics/recall.py
@@ -17,6 +17,7 @@ from supervision.detection.utils.iou_and_nms import (
 )
 from supervision.draw.color import LEGACY_COLOR_PALETTE
 from supervision.metrics.core import AveragingMethod, Metric, MetricTarget
+from supervision.metrics.utils.matching import _greedy_match
 from supervision.metrics.utils.object_size import (
     ObjectSizeCategory,
     get_detection_size_category,
@@ -301,18 +302,8 @@ class Recall(Metric["RecallResult"]):
         for i, iou_level in enumerate(iou_thresholds):
             matched_indices = np.where((iou >= iou_level) & correct_class)
 
-            if matched_indices[0].shape[0]:
-                target_idx = matched_indices[0]
-                pred_idx = matched_indices[1]
-                iou_values = iou[matched_indices]
-                order = np.argsort(-iou_values, kind="stable")
-                matched_targets: set[int] = set()
-                matched_preds: set[int] = set()
-                for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
-                    if t not in matched_targets and p not in matched_preds:
-                        matched_targets.add(t)
-                        matched_preds.add(p)
-                        correct[p, i] = True
+            for t, p in _greedy_match(iou, matched_indices):
+                correct[p, i] = True
         result_correct: npt.NDArray[np.bool_] = correct
         return result_correct
 

--- a/src/supervision/metrics/utils/matching.py
+++ b/src/supervision/metrics/utils/matching.py
@@ -1,0 +1,26 @@
+from collections.abc import Iterator
+
+import numpy as np
+import numpy.typing as npt
+
+
+def _greedy_match(
+    iou: npt.NDArray[np.float32],
+    matched_indices: tuple[npt.NDArray[np.intp], ...],
+) -> Iterator[tuple[int, int]]:
+    """Yield (target_idx, pred_idx) pairs in greedy highest-IoU-first one-to-one order.
+
+    Candidate pairs are sorted by descending IoU and assigned one-to-one: a pair
+    is accepted only when neither the target nor the prediction has been matched.
+    """
+    target_idx = matched_indices[0]
+    pred_idx = matched_indices[1]
+    iou_values = iou[matched_indices]
+    order = np.argsort(-iou_values, kind="stable")
+    matched_targets: set[int] = set()
+    matched_preds: set[int] = set()
+    for t, p in zip(target_idx[order].tolist(), pred_idx[order].tolist()):
+        if t not in matched_targets and p not in matched_preds:
+            matched_targets.add(t)
+            matched_preds.add(p)
+            yield t, p

--- a/src/supervision/metrics/utils/matching.py
+++ b/src/supervision/metrics/utils/matching.py
@@ -12,6 +12,13 @@ def _greedy_match(
 
     Candidate pairs are sorted by descending IoU and assigned one-to-one: a pair
     is accepted only when neither the target nor the prediction has been matched.
+
+    Examples:
+        >>> import numpy as np
+        >>> iou = np.array([[1.0, 0.667], [0.333, 0.538]], dtype=np.float32)
+        >>> matched_indices = np.where(iou >= 0.5)
+        >>> list(_greedy_match(iou, matched_indices))
+        [(0, 0), (1, 1)]
     """
     target_idx = matched_indices[0]
     pred_idx = matched_indices[1]

--- a/tests/metrics/test_detection.py
+++ b/tests/metrics/test_detection.py
@@ -1613,6 +1613,24 @@ class TestDetectionMetrics:
         )
         assert cm.metric_target == MetricTarget.BOXES
 
+    def test_greedy_matching_two_valid_pairs(self):
+        """Greedy matching finds both TPs; np.unique style missed the second pair."""
+        preds = Detections(
+            xyxy=np.array([[40, 60, 380, 470], [108, 60, 448, 470]], dtype=np.float32),
+            confidence=np.array([0.95, 0.90]),
+            class_id=np.array([0, 0]),
+        )
+        targets = Detections(
+            xyxy=np.array([[40, 60, 380, 470], [210, 60, 550, 470]], dtype=np.float32),
+            class_id=np.array([0, 0]),
+        )
+
+        result = MeanAveragePrecision.from_detections(
+            predictions=[preds], targets=[targets]
+        )
+
+        assert result.map50 == pytest.approx(1.0, abs=0.01)
+
 
 class TestSplitDetectionsByOutcome:
     """Tests for _split_detections_by_outcome matching and filtering logic."""

--- a/tests/metrics/test_f1_score.py
+++ b/tests/metrics/test_f1_score.py
@@ -386,3 +386,23 @@ class TestF1Score:
         # Weighted average: 5/6
         expected_f1 = 5.0 / 6.0
         assert_almost_equal(result.f1_50, expected_f1)
+
+    def test_greedy_matching_two_valid_pairs(self):
+        """Greedy matching finds both TPs; np.unique style missed the second pair.
+
+        IoU matrix: [[1.0, 0.667], [0.333, 0.538]]. At iou>=0.5 the optimal
+        assignment is T0<->P0 and T1<->P1 (2 TPs, F1=1.0).
+        """
+        preds = Detections(
+            xyxy=np.array([[40, 60, 380, 470], [108, 60, 448, 470]], dtype=np.float32),
+            confidence=np.array([0.95, 0.90]),
+            class_id=np.array([0, 0]),
+        )
+        targets = Detections(
+            xyxy=np.array([[40, 60, 380, 470], [210, 60, 550, 470]], dtype=np.float32),
+            class_id=np.array([0, 0]),
+        )
+
+        result = F1Score().update(preds, targets).compute()
+
+        assert result.f1_50 == 1.0

--- a/tests/metrics/test_mean_average_recall.py
+++ b/tests/metrics/test_mean_average_recall.py
@@ -665,3 +665,27 @@ def test_dataset_split_integration(yolo_dataset_two_classes) -> None:
     # mAR@1 should be significantly lower than mAR@10 for multi-object images
     # This validates that K limits detections per image (not per class)
     assert result.mAR_at_1 < result.mAR_at_10
+
+
+def test_greedy_matching_two_valid_pairs():
+    """Greedy matching finds both TPs; np.unique style missed the second pair.
+
+    IoU matrix: [[1.0, 0.667], [0.333, 0.538]]. At iou>=0.5 the optimal
+    assignment is T0<->P0 and T1<->P1. mAR@100 at iou=0.5 is 1.0.
+    """
+    preds = Detections(
+        xyxy=np.array([[40, 60, 380, 470], [108, 60, 448, 470]], dtype=np.float32),
+        confidence=np.array([0.95, 0.90]),
+        class_id=np.array([0, 0]),
+    )
+    targets = Detections(
+        xyxy=np.array([[40, 60, 380, 470], [210, 60, 550, 470]], dtype=np.float32),
+        class_id=np.array([0, 0]),
+    )
+
+    result = MeanAverageRecall().update(preds, targets).compute()
+
+    # At iou=0.5 both pairs match (recall=1.0); IoU(T1,P1)=0.538 < 0.55 so only
+    # the first threshold has 2 TPs. mAR@100 = (1.0 + 0.5*9) / 10 = 0.55.
+    # The buggy np.unique algorithm gave 0.5 (only 1 TP even at iou=0.5).
+    assert result.mAR_at_100 == pytest.approx(0.55)

--- a/tests/metrics/test_precision.py
+++ b/tests/metrics/test_precision.py
@@ -315,3 +315,23 @@ class TestPrecision:
         # Perfect match should give 1.0 regardless of averaging method
         assert result.precision_at_50 == 1.0
         assert result.averaging_method == averaging_method
+
+    def test_greedy_matching_two_valid_pairs(self):
+        """Greedy matching finds both TPs; np.unique style missed the second pair.
+
+        IoU matrix: [[1.0, 0.667], [0.333, 0.538]]. At iou>=0.5 the optimal
+        assignment is T0<->P0 and T1<->P1 (2 TPs, precision=1.0).
+        """
+        preds = Detections(
+            xyxy=np.array([[40, 60, 380, 470], [108, 60, 448, 470]], dtype=np.float32),
+            confidence=np.array([0.95, 0.90]),
+            class_id=np.array([0, 0]),
+        )
+        targets = Detections(
+            xyxy=np.array([[40, 60, 380, 470], [210, 60, 550, 470]], dtype=np.float32),
+            class_id=np.array([0, 0]),
+        )
+
+        result = Precision().update(preds, targets).compute()
+
+        assert result.precision_at_50 == 1.0

--- a/tests/metrics/test_recall.py
+++ b/tests/metrics/test_recall.py
@@ -282,3 +282,23 @@ class TestRecall:
 
         # Macro average: (0.5 + 1.0) / 2 = 0.75
         assert result.recall_at_50 == 0.75
+
+    def test_greedy_matching_two_valid_pairs(self):
+        """Greedy matching finds both TPs; np.unique style missed the second pair.
+
+        IoU matrix: [[1.0, 0.667], [0.333, 0.538]]. At iou>=0.5 the optimal
+        assignment is T0<->P0 and T1<->P1 (2 TPs, recall=1.0).
+        """
+        preds = Detections(
+            xyxy=np.array([[40, 60, 380, 470], [108, 60, 448, 470]], dtype=np.float32),
+            confidence=np.array([0.95, 0.90]),
+            class_id=np.array([0, 0]),
+        )
+        targets = Detections(
+            xyxy=np.array([[40, 60, 380, 470], [210, 60, 550, 470]], dtype=np.float32),
+            class_id=np.array([0, 0]),
+        )
+
+        result = Recall().update(preds, targets).compute()
+
+        assert result.recall_at_50 == 1.0


### PR DESCRIPTION
The two-pass np.unique deduplication in _match_detection_batch dropped valid TP assignments when a prediction's best-IoU target was already claimed by a higher-confidence prediction. The greedy one-pass algorithm (sort by IoU desc, assign if neither target nor pred already matched) was already used in _split_detections_by_outcome and ConfusionMatrix.evaluate_detection_batch but missing from Recall, F1Score, Precision, MeanAverageRecall, and MeanAveragePrecision.

- Fix all five _match_detection_batch implementations
- Add regression tests reproducing the issue #2378 example in each affected metric class (IoU matrix [[1.0, 0.667], [0.333, 0.538]])

---

resolves #2378
