### PR TITLE
fix: replace np.cross with explicit 2-D determinant (NumPy 2.0 deprecation)

### DIFF
--- a/src/supervision/detection/utils/internal.py
+++ b/src/supervision/detection/utils/internal.py
@@ -669,6 +669,10 @@ def cross_product(
         ]
     )
     vector_start = np.array([vector.start.x, vector.start.y])
+    # Explicit 2-D cross product (scalar z-component) to avoid
+    # np.cross DeprecationWarning on NumPy >=2.0 (issue #2384).
+    diff = anchors - vector_start
     return cast(
-        npt.NDArray[np.number], np.cross(vector_at_zero, anchors - vector_start)
+        npt.NDArray[np.number],
+        vector_at_zero[0] * diff[..., 1] - vector_at_zero[1] * diff[..., 0],
     )

--- a/src/supervision/geometry/utils.py
+++ b/src/supervision/geometry/utils.py
@@ -43,7 +43,9 @@ def get_polygon_center(polygon: npt.NDArray[np.float64]) -> Point:
     shift_polygon = np.roll(polygon, -1, axis=0)
     # Explicit 2-D determinant: avoids np.cross DeprecationWarning on NumPy >=2.0
     # which no longer supports 2-D input vectors (issue #2384).
-    signed_areas = (polygon[:, 0] * shift_polygon[:, 1] - polygon[:, 1] * shift_polygon[:, 0]) / 2
+    signed_areas = (
+        polygon[:, 0] * shift_polygon[:, 1] - polygon[:, 1] * shift_polygon[:, 0]
+    ) / 2
     if signed_areas.sum() == 0:
         center = np.mean(polygon, axis=0).round()
         return Point(x=center[0], y=center[1])

--- a/src/supervision/geometry/utils.py
+++ b/src/supervision/geometry/utils.py
@@ -41,7 +41,9 @@ def get_polygon_center(polygon: npt.NDArray[np.float64]) -> Point:
         raise ValueError("Polygon must have at least one vertex.")
 
     shift_polygon = np.roll(polygon, -1, axis=0)
-    signed_areas = np.cross(polygon, shift_polygon) / 2
+    # Explicit 2-D determinant: avoids np.cross DeprecationWarning on NumPy >=2.0
+    # which no longer supports 2-D input vectors (issue #2384).
+    signed_areas = (polygon[:, 0] * shift_polygon[:, 1] - polygon[:, 1] * shift_polygon[:, 0]) / 2
     if signed_areas.sum() == 0:
         center = np.mean(polygon, axis=0).round()
         return Point(x=center[0], y=center[1])


### PR DESCRIPTION
## What

Replace two `np.cross()` calls on 2-D vectors with the explicit scalar z-component determinant formula to eliminate the NumPy 2.0 `DeprecationWarning`.

## Why

NumPy 2.0 deprecated `np.cross()` for arrays with size-2 in their last dimension — support will be removed in a future release. With `supervision` allowing `numpy>=1.21.2`, users on the current NumPy line hit this warning on every call that goes through `LineZone.trigger` or `get_polygon_center`.

Affected sites (both on `develop`):
- `src/supervision/geometry/utils.py:44` — `get_polygon_center` signed-area computation
- `src/supervision/detection/utils/internal.py:673` — `cross_product` helper called three times per `LineZone.trigger` call

## Changes

Both `np.cross(a, b)` calls are replaced with the equivalent 2-D determinant:
```python
# before
np.cross(a, b)          # DeprecationWarning on NumPy 2.0+

# after — equivalent, no warning
a[0] * b[1] - a[1] * b[0]   # scalar form
a[:, 0] * b[:, 1] - a[:, 1] * b[:, 0]  # vectorized form
```

## Testing

- Manual verification: zero `DeprecationWarning`s emitted from both call sites on NumPy 2.3.1
- 95 existing tests pass: `tests/detection/test_line_counter.py`, `tests/detection/test_polygonzone.py`, `tests/geometry/`
- Numerical correctness verified against the expected determinant values