### PR TITLE
  fix(annotators): clip CropAnnotator boxes to the scene before cropping

### DIFF
--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -3019,17 +3019,21 @@ class CropAnnotator(BaseAnnotator):
         """
         if not isinstance(scene, np.ndarray):
             return scene
-        crops = [
-            crop_image(image=scene, xyxy=xyxy) for xyxy in detections.xyxy.astype(int)
-        ]
-        resized_crops = [
-            scale_image(image=crop, scale_factor=self.scale_factor) for crop in crops
-        ]
+        image_height, image_width = scene.shape[:2]
+        clipped_xyxy: npt.NDArray[np.int32] = clip_boxes(
+            xyxy=detections.xyxy,
+            resolution_wh=(image_width, image_height),
+        ).astype(int)
         anchors: npt.NDArray[np.int32] = detections.get_anchors_coordinates(
             anchor=self.position
         ).astype(int)
 
-        for idx, (resized_crop, anchor) in enumerate(zip(resized_crops, anchors)):
+        for idx, (xyxy, anchor) in enumerate(zip(clipped_xyxy, anchors)):
+            x_min, y_min, x_max, y_max = xyxy
+            if x_max - x_min <= 0 or y_max - y_min <= 0:
+                continue
+            crop = crop_image(image=scene, xyxy=xyxy)
+            resized_crop = scale_image(image=crop, scale_factor=self.scale_factor)
             crop_wh = resized_crop.shape[1], resized_crop.shape[0]
             (x1, y1), (x2, y2) = self.calculate_crop_coordinates(
                 anchor=anchor, crop_wh=crop_wh, position=self.position

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -1323,6 +1323,58 @@ class TestCropAnnotator:
         result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
         assert not np.array_equal(gradient_image, result)
 
+    @pytest.mark.parametrize(
+        "xyxy",
+        [
+            pytest.param([-5, 20, 40, 60], id="negative-x-min"),
+            pytest.param([20, -5, 60, 40], id="negative-y-min"),
+            pytest.param([-10, -10, 30, 30], id="negative-x-and-y-min"),
+            pytest.param([60, 20, 140, 60], id="past-right-edge"),
+            pytest.param([-20, -20, 140, 140], id="larger-than-scene"),
+        ],
+    )
+    def test_annotate_with_box_crossing_scene_border(
+        self, gradient_image, xyxy: list[int]
+    ) -> None:
+        """Boxes extending past the scene border are clipped instead of raising"""
+        detections = _create_detections(xyxy=[xyxy], class_id=[0])
+        annotator = CropAnnotator()
+
+        result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
+
+        assert result.shape == gradient_image.shape
+
+    @pytest.mark.parametrize(
+        "xyxy",
+        [
+            pytest.param([150, 150, 200, 200], id="fully-outside"),
+            pytest.param([-50, -50, -10, -10], id="fully-negative"),
+            pytest.param([30, 20, 30, 60], id="zero-width"),
+            pytest.param([30, 30, 30, 30], id="zero-area"),
+        ],
+    )
+    def test_annotate_skips_boxes_empty_after_clipping(
+        self, gradient_image, xyxy: list[int]
+    ) -> None:
+        """Boxes with no visible area are skipped instead of raising cv2.error"""
+        detections = _create_detections(xyxy=[xyxy], class_id=[0])
+        annotator = CropAnnotator()
+
+        result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
+
+        assert np.array_equal(gradient_image, result)
+
+    def test_annotate_mixed_valid_and_degenerate_boxes(self, gradient_image) -> None:
+        """A degenerate box does not prevent valid boxes from being drawn"""
+        detections = _create_detections(
+            xyxy=[[150, 150, 200, 200], [10, 10, 90, 90]], class_id=[0, 1]
+        )
+        annotator = CropAnnotator()
+
+        result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
+
+        assert not np.array_equal(gradient_image, result)
+
 
 class TestBackgroundOverlayAnnotator:
     """Tests for BackgroundOverlayAnnotator class"""


### PR DESCRIPTION
<details>
  <summary>Before submitting</summary>

  - [x] Self-reviewed the code  
  - [ ] Updated documentation, follow Google-style
  (https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
  - [ ] Added docs entry for autogeneration (if new functions/classes)
  - [x] Added/updated tests
  - [x] All tests pass locally  

  </details>

  Description
  
  CropAnnotator.annotate passed raw detection coordinates into crop_image, which
  slices with plain numpy indexing. A negative x_min or y_min wraps around and
  produces an empty crop, and scale_image then feeds the zero-size image to
  cv2.resize, which raises cv2.error. Boxes fully outside the frame and
  zero-width or zero-area boxes crash the same way, so one degenerate detection
  aborts annotation of the whole frame.

  This PR clips boxes to the scene with the existing clip_boxes helper,
  mirroring BlurAnnotator and PixelateAnnotator, and skips boxes that are empty
  after clipping. Skipped boxes keep their detection index, so color lookup
  stays aligned with the original detections.

  For every input the old code handled without crashing, the output is
  pixel-identical (verified byte-for-byte for in-bounds and
  right/bottom-overshoot boxes). The only behavior change besides removing the
  crash: a fully negative box such as [-50, -50, -10, -10] previously wrapped
  around and silently pasted a crop of an unrelated image region; it is now
  skipped.
  
  Type of Change

  - 🐛 Bug fix (non-breaking change which fixes an issue)

  Motivation and Context

  Boxes at or beyond the frame border arise from supported workflows:
  sv.pad_boxes produces negative coordinates for boxes near the frame edge, the
  from_vlm connectors pass model coordinates through unclamped, and boxes land
  fully outside the frame when detections computed at one resolution are
  annotated onto another. The sibling annotators that slice the scene the same
  way (BlurAnnotator, PixelateAnnotator) already clip; CropAnnotator was the
  only one that did not.
  
  Closes #2390

  Changes Made

  - Clip boxes to the scene in CropAnnotator.annotate using the existing
  clip_boxes helper before cropping
  - Skip boxes whose width or height is zero after clipping instead of feeding
  empty crops to cv2.resize
  - Move crop and scale into the per-detection loop so a degenerate box no
  longer prevents valid boxes from being drawn
  - Add regression tests: five border-crossing boxes annotate without raising,
  four degenerate boxes are skipped leaving the scene unchanged, and a mixed
  valid/degenerate case still draws the valid box
  
  Testing

  - [x] I have tested this code locally
  - [x] I have added unit tests that prove my fix is effective or that my
  feature works
  - [x] All new and existing tests pass

  The new tests fail on current develop with cv2.error (7 failing cases) and
  pass with the fix (13/13 in TestCropAnnotator). Full suite: 2459 passed, 1
  skipped, including under pytest --cov=supervision.

  Reproduce the original crash on develop:
```py
  import numpy as np  
  import supervision as sv

  image = np.zeros((100, 100, 3), dtype=np.uint8)
  detections = sv.Detections(
      xyxy=np.array([[-5, 20, 40, 60]], dtype=np.float32),
      class_id=np.array([0]),   
  )

  sv.BlurAnnotator().annotate(image.copy(), detections)   # works
  sv.CropAnnotator().annotate(image.copy(), detections)   # cv2.error before 
  this PR
```  
  Google Colab (optional)

  Colab link: N/A

  Screenshots/Videos (optional)

  N/A

  Additional Notes

  No public API changes and no new dependencies. crop_image itself still returns
  a silently empty array for out-of-bounds input; clamping it was left out of
  scope to keep this PR minimal, since callers other than CropAnnotator already
  clip.
  
