### PR TITLE
fix(annotators): clip crops, fix heatmap wrap, release capture

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,9 @@ date_modified: 2026-06-25
     Users on Python 3.9 should upgrade their environment before updating supervision.
 
 ### Fixed
+- Fixed [#2393](https://github.com/roboflow/supervision/pull/2393): `sv.CropAnnotator.annotate` no longer raises `cv2.error` when detections extend outside the scene; out-of-bounds boxes are clipped to scene bounds and zero-area results are skipped silently.
+- Fixed [#2393](https://github.com/roboflow/supervision/pull/2393): `sv.HeatMapAnnotator.annotate` no longer blanks the hottest region when the per-pixel hit count exceeds 255; the heat mask is now derived from the float32 accumulator directly, avoiding uint8 wrap-around.
+- Fixed [#2393](https://github.com/roboflow/supervision/pull/2393): `sv.get_video_frames_generator` now releases the underlying `cv2.VideoCapture` via `try/finally`, so the decoder is freed when a consumer breaks out of iteration early rather than waiting for garbage collection.
 - Fixed [#2382](https://github.com/roboflow/supervision/pull/2382): `sv.Detections.get_anchors_coordinates` now uses oriented bounding box corners (`data["xyxyxyxy"]`) when OBB data is present, instead of falling back to the axis-aligned envelope. Anchors on rotated detections now lie on the oriented body rather than drifting to the envelope. Non-OBB detections and `Position.CENTER_OF_MASS` (which requires a mask) are unaffected.
 
 ### Added

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -2996,6 +2996,12 @@ class CropAnnotator(BaseAnnotator):
         Returns:
             The annotated image.
 
+        Note:
+            Detections whose bounding boxes extend partially outside `scene` are
+            clipped to scene bounds before cropping. Detections fully outside the
+            scene collapse to zero area after clipping and are skipped without
+            raising an error.
+
         Examples:
             ```pycon
             >>> import numpy as np

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -2373,10 +2373,9 @@ class HeatMapAnnotator(BaseAnnotator):
         hsv = np.full(scene.shape, 255, dtype=np.uint8)
         hsv[..., 0] = heat_hue
         heat_bgr = cv2.cvtColor(hsv, cv2.COLOR_HSV2BGR)
-        mask_bool = np.repeat((heat_mask > 0)[:, :, np.newaxis], 3, axis=2)
-        scene[mask_bool] = cv2.addWeighted(
-            heat_bgr, self.opacity, scene, 1 - self.opacity, 0
-        )[mask_bool]
+        mask2d = heat_mask > 0
+        blended = cv2.addWeighted(heat_bgr, self.opacity, scene, 1 - self.opacity, 0)
+        scene[mask2d] = blended[mask2d]
         return scene
 
 
@@ -3023,10 +3022,10 @@ class CropAnnotator(BaseAnnotator):
         clipped_xyxy: npt.NDArray[np.int32] = clip_boxes(
             xyxy=detections.xyxy,
             resolution_wh=(image_width, image_height),
-        ).astype(int)
+        ).astype(np.int32)
         anchors: npt.NDArray[np.int32] = detections.get_anchors_coordinates(
             anchor=self.position
-        ).astype(int)
+        ).astype(np.int32)
 
         for idx, (xyxy, anchor) in enumerate(zip(clipped_xyxy, anchors)):
             crop_x1, crop_y1, crop_x2, crop_y2 = xyxy

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -44,9 +44,9 @@ from supervision.utils.conversion import (
     ensure_pil_image_for_class_method,
 )
 from supervision.utils.image import (
+    _overlay_image,
     crop_image,
     letterbox_image,
-    overlay_image,
     scale_image,
 )
 from supervision.utils.logger import _get_logger
@@ -2010,7 +2010,7 @@ class IconAnnotator(BaseAnnotator):
             x = int(xy[detection_idx, 0] - icon_w / 2 + self.offset_xy[0])
             y = int(xy[detection_idx, 1] - icon_h / 2 + self.offset_xy[1])
 
-            scene[:] = overlay_image(scene, icon, (x, y))
+            scene[:] = _overlay_image(scene, icon, (x, y))
         return scene
 
     @lru_cache
@@ -2373,7 +2373,7 @@ class HeatMapAnnotator(BaseAnnotator):
         hsv = np.full(scene.shape, 255, dtype=np.uint8)
         hsv[..., 0] = heat_hue
         heat_bgr = cv2.cvtColor(hsv, cv2.COLOR_HSV2BGR)
-        mask_bool = cv2.cvtColor(heat_mask.astype(np.uint8), cv2.COLOR_GRAY2BGR) > 0
+        mask_bool = np.repeat((heat_mask > 0)[:, :, np.newaxis], 3, axis=2)
         scene[mask_bool] = cv2.addWeighted(
             heat_bgr, self.opacity, scene, 1 - self.opacity, 0
         )[mask_bool]
@@ -3019,22 +3019,26 @@ class CropAnnotator(BaseAnnotator):
         """
         if not isinstance(scene, np.ndarray):
             return scene
-        crops = [
-            crop_image(image=scene, xyxy=xyxy) for xyxy in detections.xyxy.astype(int)
-        ]
-        resized_crops = [
-            scale_image(image=crop, scale_factor=self.scale_factor) for crop in crops
-        ]
+        image_height, image_width = scene.shape[:2]
+        clipped_xyxy: npt.NDArray[np.int32] = clip_boxes(
+            xyxy=detections.xyxy,
+            resolution_wh=(image_width, image_height),
+        ).astype(int)
         anchors: npt.NDArray[np.int32] = detections.get_anchors_coordinates(
             anchor=self.position
         ).astype(int)
 
-        for idx, (resized_crop, anchor) in enumerate(zip(resized_crops, anchors)):
+        for idx, (xyxy, anchor) in enumerate(zip(clipped_xyxy, anchors)):
+            crop_x1, crop_y1, crop_x2, crop_y2 = xyxy
+            if crop_x2 <= crop_x1 or crop_y2 <= crop_y1:
+                continue
+            crop = crop_image(image=scene, xyxy=xyxy)
+            resized_crop = scale_image(image=crop, scale_factor=self.scale_factor)
             crop_wh = resized_crop.shape[1], resized_crop.shape[0]
             (x1, y1), (x2, y2) = self.calculate_crop_coordinates(
                 anchor=anchor, crop_wh=crop_wh, position=self.position
             )
-            scene = overlay_image(image=scene, overlay=resized_crop, anchor=(x1, y1))
+            scene = _overlay_image(image=scene, overlay=resized_crop, anchor=(x1, y1))
             color = resolve_color(
                 color=self.border_color,
                 detections=detections,

--- a/src/supervision/detection/line_zone.py
+++ b/src/supervision/detection/line_zone.py
@@ -15,7 +15,7 @@ from supervision.detection.utils.internal import cross_product
 from supervision.draw.color import Color
 from supervision.draw.utils import draw_rectangle, draw_text
 from supervision.geometry.core import Point, Position, Rect, Vector
-from supervision.utils.image import overlay_image
+from supervision.utils.image import _overlay_image
 from supervision.utils.internal import SupervisionWarnings
 
 TEXT_MARGIN = 10
@@ -630,7 +630,7 @@ class LineZoneAnnotator:
             label_dimension=label_image.shape[0],
         )
 
-        frame = overlay_image(frame, label_image, label_anchor)
+        frame = _overlay_image(frame, label_image, label_anchor)
 
         return frame
 

--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -328,6 +328,19 @@ def overlay_image(
 
         ```
     """
+    return _overlay_image(image=image, overlay=overlay, anchor=anchor)
+
+
+def _overlay_image(
+    image: npt.NDArray[np.uint8],
+    overlay: npt.NDArray[np.uint8],
+    anchor: tuple[int, int],
+) -> npt.NDArray[np.uint8]:
+    """Overlay `overlay` onto `image` at `anchor`, clipping to scene bounds.
+
+    Non-deprecated internal implementation backing the public `overlay_image`.
+    Kept separate so library-internal callers do not emit a deprecation warning.
+    """
     scene_height, scene_width = image.shape[:2]
     image_height, image_width = overlay.shape[:2]
     anchor_x, anchor_y = anchor

--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -300,6 +300,9 @@ def overlay_image(
     anchor: tuple[int, int],
 ) -> npt.NDArray[np.uint8]:
     """
+    Deprecated since 0.27.0; removal in 0.31.0. Use `_overlay_image` for
+    internal callers, or avoid calling `overlay_image` directly in external code.
+
     Overlay image onto scene at specified anchor point. Handles cases where
     overlay position is partially or completely outside scene bounds.
 

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -261,6 +261,10 @@ def get_video_frames_generator(
         A generator that yields the
             frames of the video.
 
+    Note:
+        The underlying `cv2.VideoCapture` is always released when the generator
+        is exhausted or closed, even if the consumer breaks out of iteration early.
+
     Examples:
         ```python
         import supervision as sv

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -273,18 +273,20 @@ def get_video_frames_generator(
         source_path, start, end, iterative_seek
     )
     frame_position = start
-    while True:
-        success, frame = video.read()
-        if not success or frame_position >= end:
-            break
-        if frame is not None:
-            yield cast(npt.NDArray[np.uint8], frame)
-        for _ in range(stride - 1):
-            success = video.grab()
-            if not success:
+    try:
+        while True:
+            success, frame = video.read()
+            if not success or frame_position >= end:
                 break
-        frame_position += stride
-    video.release()
+            if frame is not None:
+                yield cast(npt.NDArray[np.uint8], frame)
+            for _ in range(stride - 1):
+                success = video.grab()
+                if not success:
+                    break
+            frame_position += stride
+    finally:
+        video.release()
 
 
 def process_video(

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -975,14 +975,15 @@ class TestHeatMapAnnotator:
     def test_annotate_hottest_region_survives_uint8_wrap(
         self, test_image: np.ndarray
     ) -> None:
-        """Heat count exceeding 255 must not wrap to zero and blank the region."""
+        """Heat count at 2^8=256 must not wrap uint8 to zero and blank the region."""
         annotator = HeatMapAnnotator()
         detections = _create_detections(xyxy=[[20, 20, 60, 60]])
-        result = test_image.copy()
         for _ in range(256):
             result = annotator.annotate(scene=test_image.copy(), detections=detections)
-        painted = np.count_nonzero(np.any(result != test_image, axis=2))
-        assert painted > 0
+        region_painted = np.count_nonzero(
+            np.any(result[20:60, 20:60] != test_image[20:60, 20:60], axis=2)
+        )
+        assert region_painted > 100
 
 
 class TestEllipseAnnotator:
@@ -1350,11 +1351,14 @@ class TestCropAnnotator:
         assert deprecations == []
 
     def test_annotate_with_partially_out_of_bounds_detection(self, gradient_image):
-        """A box reaching outside the scene must be clipped, not raise cv2.error."""
+        """Partially-OOB box is clipped and rendered; scene must change."""
         detections = _create_detections(xyxy=[[-10, -10, 30, 30]], class_id=[0])
-        annotator = CropAnnotator(border_color_lookup=ColorLookup.INDEX)
+        annotator = CropAnnotator(
+            position=Position.CENTER, border_color_lookup=ColorLookup.INDEX
+        )
         result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
         assert result.shape == gradient_image.shape
+        assert not np.array_equal(gradient_image, result)
 
     def test_annotate_with_fully_out_of_bounds_detection(self, gradient_image):
         """A box fully outside the scene collapses to zero area and is skipped."""

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -972,6 +972,18 @@ class TestHeatMapAnnotator:
             warnings.simplefilter("error", RuntimeWarning)
             annotator.annotate(scene=test_image.copy(), detections=Detections.empty())
 
+    def test_annotate_hottest_region_survives_uint8_wrap(
+        self, test_image: np.ndarray
+    ) -> None:
+        """Heat count exceeding 255 must not wrap to zero and blank the region."""
+        annotator = HeatMapAnnotator()
+        detections = _create_detections(xyxy=[[20, 20, 60, 60]])
+        result = test_image.copy()
+        for _ in range(256):
+            result = annotator.annotate(scene=test_image.copy(), detections=detections)
+        painted = np.count_nonzero(np.any(result != test_image, axis=2))
+        assert painted > 0
+
 
 class TestEllipseAnnotator:
     """Tests for EllipseAnnotator class"""
@@ -1322,6 +1334,57 @@ class TestCropAnnotator:
         annotator = CropAnnotator(border_color_lookup=ColorLookup.INDEX)
         result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
         assert not np.array_equal(gradient_image, result)
+
+    def test_annotate_emits_no_deprecation_warning(self, gradient_image):
+        """Internal overlay must not surface the deprecated `overlay_image` warning."""
+        detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
+        annotator = CropAnnotator(border_color_lookup=ColorLookup.INDEX)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            annotator.annotate(scene=gradient_image.copy(), detections=detections)
+        deprecations = [
+            w
+            for w in caught
+            if issubclass(w.category, (DeprecationWarning, FutureWarning))
+        ]
+        assert deprecations == []
+
+    def test_annotate_with_partially_out_of_bounds_detection(self, gradient_image):
+        """A box reaching outside the scene must be clipped, not raise cv2.error."""
+        detections = _create_detections(xyxy=[[-10, -10, 30, 30]], class_id=[0])
+        annotator = CropAnnotator(border_color_lookup=ColorLookup.INDEX)
+        result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
+        assert result.shape == gradient_image.shape
+
+    def test_annotate_with_fully_out_of_bounds_detection(self, gradient_image):
+        """A box fully outside the scene collapses to zero area and is skipped."""
+        detections = _create_detections(xyxy=[[-50, -50, -10, -10]], class_id=[0])
+        annotator = CropAnnotator(border_color_lookup=ColorLookup.INDEX)
+        result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
+        assert np.array_equal(gradient_image, result)
+
+
+class TestIconAnnotator:
+    """Tests for IconAnnotator class"""
+
+    def test_annotate_emits_no_deprecation_warning(self, test_image, tmp_path):
+        """Internal overlay must not surface the deprecated `overlay_image` warning."""
+        icon_path = str(tmp_path / "icon.png")
+        icon = np.full((20, 20, 4), (0, 255, 0, 255), dtype=np.uint8)
+        cv2.imwrite(icon_path, icon)
+        detections = _create_detections(xyxy=[[20, 20, 60, 60]], class_id=[0])
+        annotator = IconAnnotator()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            annotator.annotate(
+                scene=test_image.copy(), detections=detections, icon_path=icon_path
+            )
+        deprecations = [
+            w
+            for w in caught
+            if issubclass(w.category, (DeprecationWarning, FutureWarning))
+        ]
+        assert deprecations == []
 
 
 class TestBackgroundOverlayAnnotator:

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -173,6 +173,17 @@ def test_overlay_image_public_wrapper_delegates_to_internal() -> None:
     np.testing.assert_array_equal(result, expected)
 
 
+def test_overlay_image_emits_future_warning() -> None:
+    """Public overlay_image must still emit FutureWarning after internal refactor."""
+    # given
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+    overlay = np.full((1, 1, 3), 255, dtype=np.uint8)
+
+    # when / then
+    with pytest.warns(FutureWarning):
+        overlay_image(image=image, overlay=overlay, anchor=(0, 0))
+
+
 def test_overlay_image_crops_rgba_overlay_at_scene_boundary() -> None:
     """RGBA overlay is cropped when anchored outside scene bounds."""
     # given

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -1,8 +1,11 @@
+import warnings
+
 import numpy as np
 import pytest
 from PIL import Image, ImageChops
 
 from supervision.utils.image import (
+    _overlay_image,
     crop_image,
     get_image_resolution_wh,
     letterbox_image,
@@ -149,6 +152,22 @@ def test_overlay_image_blends_rgba_with_float32_rounding() -> None:
 
     # when
     result = overlay_image(image=image, overlay=overlay, anchor=(0, 0))
+
+    # then
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_overlay_image_public_wrapper_delegates_to_internal() -> None:
+    """Public `overlay_image` still produces the internal `_overlay_image` result."""
+    # given
+    image = np.full((1, 1, 3), 22, dtype=np.uint8)
+    overlay = np.array([[[39, 39, 39, 60]]], dtype=np.uint8)
+    expected = _overlay_image(image=image.copy(), overlay=overlay, anchor=(0, 0))
+
+    # when
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        result = overlay_image(image=image.copy(), overlay=overlay, anchor=(0, 0))
 
     # then
     np.testing.assert_array_equal(result, expected)

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -178,10 +178,17 @@ def test_overlay_image_emits_future_warning() -> None:
     # given
     image = np.zeros((2, 2, 3), dtype=np.uint8)
     overlay = np.full((1, 1, 3), 255, dtype=np.uint8)
+    # pyDeprecate tracks per-function warned_calls (default num_warns=1) so the
+    # warning fires only once per process. Reset to make this test order-independent.
+    overlay_image._state.warned_calls = 0
 
-    # when / then
-    with pytest.warns(FutureWarning):
+    # when
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         overlay_image(image=image, overlay=overlay, anchor=(0, 0))
+
+    # then
+    assert any(issubclass(w.category, FutureWarning) for w in caught)
 
 
 def test_overlay_image_crops_rgba_overlay_at_scene_boundary() -> None:

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -200,6 +200,42 @@ def test_get_video_frames_generator(dummy_video_path) -> None:
     assert all(frame.shape == (480, 640, 3) for frame in frames)
 
 
+def test_get_video_frames_generator_releases_on_early_break(monkeypatch) -> None:
+    """
+    Verify that the capture is released when a consumer breaks out early.
+
+    Scenario: A consumer iterates one frame then abandons the generator, raising
+    GeneratorExit at the yield point.
+    Expected: The `try/finally` guard still calls `release()`, avoiding a decoder
+    leak.
+    """
+
+    class FakeCapture:
+        def __init__(self) -> None:
+            self.released = False
+
+        def read(self):
+            return True, np.zeros((2, 2, 3), dtype=np.uint8)
+
+        def grab(self):
+            return True
+
+        def release(self) -> None:
+            self.released = True
+
+    fake_capture = FakeCapture()
+    monkeypatch.setattr(
+        "supervision.utils.video._validate_and_setup_video",
+        lambda *args, **kwargs: (fake_capture, 0, 100),
+    )
+
+    generator = get_video_frames_generator("dummy")
+    next(generator)
+    generator.close()
+
+    assert fake_capture.released
+
+
 def test_get_video_frames_generator_with_stride(dummy_video_path) -> None:
     """
     Verify that get_video_frames_generator correctly handles the stride parameter.


### PR DESCRIPTION
- `IconAnnotator`/`CropAnnotator` called the deprecated public `overlay_image`, emitting a warning users could not avoid and breaking both at its 0.31.0 removal; extract a private `_overlay_image` and delegate the public wrapper to it
- `CropAnnotator` crashed (`cv2.error`) on detections partially outside the frame; clip boxes to scene bounds and skip degenerate boxes, matching `BlurAnnotator`/`PixelateAnnotator`
- `HeatMapAnnotator` cast per-pixel frame counts to uint8, so heat silently vanished after 256 accumulated frames; derive the mask from the float accumulator directly
- `get_video_frames_generator` leaked the `VideoCapture` when a consumer broke out early; release it in a `finally`
- add regression tests for all four
