### PR TITLE
fix(metrics): count false positives on empty-GT images

### DIFF
--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -1424,6 +1424,19 @@ class MeanAveragePrecision:
                         true_objs[:, 4],
                     )
                 )
+            else:
+                # Predictions on a ground-truth-empty (background) image are all
+                # false positives; record them so precision/AP is penalized.
+                stats.append(
+                    (
+                        np.zeros(
+                            (predicted_objs.shape[0], iou_thresholds.size), dtype=bool
+                        ),
+                        predicted_objs[:, 5],
+                        predicted_objs[:, 4],
+                        np.zeros((0,)),
+                    )
+                )
 
         # Compute average precisions if any matches exist
         if stats:

--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -1434,7 +1434,7 @@ class MeanAveragePrecision:
                         ),
                         predicted_objs[:, 5],
                         predicted_objs[:, 4],
-                        np.zeros((0,)),
+                        np.zeros((0,), dtype=np.float32),
                     )
                 )
 
@@ -1447,9 +1447,19 @@ class MeanAveragePrecision:
                 cast(npt.NDArray[np.int32], concatenated_stats[2]),
                 cast(npt.NDArray[np.int32], concatenated_stats[3]),
             )
-            map50 = average_precisions[:, 0].mean()
-            map75 = average_precisions[:, 5].mean()
-            map50_95 = average_precisions.mean()
+            map50 = (
+                float(average_precisions[:, 0].mean())
+                if average_precisions.size > 0
+                else 0.0
+            )
+            map75 = (
+                float(average_precisions[:, 5].mean())
+                if average_precisions.size > 0
+                else 0.0
+            )
+            map50_95 = (
+                float(average_precisions.mean()) if average_precisions.size > 0 else 0.0
+            )
         else:
             map50, map75, map50_95 = 0, 0, 0
             average_precisions = np.array([])

--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -1364,9 +1364,13 @@ class MeanAveragePrecision:
             targets: Each element of the list describes a single
                 image and has `shape = (N, 5)` where `N` is the
                 number of ground-truth objects. Each row is expected to be in
-                `(x_min, y_min, x_max, y_max, class)` format.
+                `(x_min, y_min, x_max, y_max, class)` format. An empty array
+                (``N = 0``) represents a background image; all predictions on
+                that image count as false positives and reduce AP accordingly.
+
         Returns:
-            New instance of MeanAveragePrecision.
+            MeanAveragePrecision: New instance computed from the provided
+                predictions and targets.
 
         Examples:
             ```pycon
@@ -1392,6 +1396,15 @@ class MeanAveragePrecision:
             ... )
             >>> round(float(mAP.map50), 2)
             0.81
+
+            >>> bg_pred = [np.array([[0., 0., 10., 10., 0, 0.9]], dtype=np.float32)]
+            >>> bg_tgt = [np.zeros((0, 5), dtype=np.float32)]
+            >>> mAP_bg = sv.MeanAveragePrecision.from_tensors(
+            ...     predictions=bg_pred,
+            ...     targets=bg_tgt,
+            ... )
+            >>> float(mAP_bg.map50)
+            0.0
 
             ```
         """

--- a/tests/metrics/test_detection.py
+++ b/tests/metrics/test_detection.py
@@ -1633,6 +1633,73 @@ class TestDetectionMetrics:
         assert result.map50 == pytest.approx(1.0, abs=0.01)
 
 
+class TestMeanAveragePrecisionBackgroundFalsePositives:
+    """Legacy `from_tensors` must penalize predictions on ground-truth-empty images."""
+
+    def test_background_false_positives_lower_map(self) -> None:
+        """False positives on a GT-empty image drop map50 below the FP-free baseline."""
+        # Arrange
+        matched_target = np.array([[0.0, 0.0, 10.0, 10.0, 0]], dtype=np.float32)
+        matched_prediction = np.array(
+            [[0.0, 0.0, 10.0, 10.0, 0, 0.9]], dtype=np.float32
+        )
+        background_target = np.zeros((0, 5), dtype=np.float32)
+        background_predictions = np.array(
+            [
+                [100.0, 100.0, 110.0, 110.0, 0, 0.95],
+                [200.0, 200.0, 210.0, 210.0, 0, 0.95],
+                [300.0, 300.0, 310.0, 310.0, 0, 0.95],
+            ],
+            dtype=np.float32,
+        )
+
+        # Act
+        without_fp = MeanAveragePrecision.from_tensors(
+            predictions=[matched_prediction],
+            targets=[matched_target],
+        )
+        with_fp = MeanAveragePrecision.from_tensors(
+            predictions=[matched_prediction, background_predictions],
+            targets=[matched_target, background_target],
+        )
+
+        # Assert
+        assert without_fp.map50 == pytest.approx(1.0, abs=0.01)
+        assert with_fp.map50 < without_fp.map50
+
+    def test_ground_truth_present_path_unchanged(self) -> None:
+        """GT-present scenario keeps its pinned map50 (guards normal-path numerics)."""
+        # Arrange
+        targets = [
+            np.array(
+                [
+                    [0.0, 0.0, 3.0, 3.0, 0],
+                    [2.0, 2.0, 5.0, 5.0, 0],
+                    [6.0, 1.0, 8.0, 3.0, 1],
+                ],
+                dtype=np.float32,
+            )
+        ]
+        predictions = [
+            np.array(
+                [
+                    [0.0, 0.0, 3.0, 3.0, 0, 0.9],
+                    [0.1, 0.1, 3.0, 3.0, 0, 0.9],
+                    [6.0, 1.0, 8.0, 3.0, 1, 0.8],
+                ],
+                dtype=np.float32,
+            )
+        ]
+
+        # Act
+        result = MeanAveragePrecision.from_tensors(
+            predictions=predictions, targets=targets
+        )
+
+        # Assert
+        assert round(float(result.map50), 2) == 0.81
+
+
 class TestSplitDetectionsByOutcome:
     """Tests for _split_detections_by_outcome matching and filtering logic."""
 

--- a/tests/metrics/test_detection.py
+++ b/tests/metrics/test_detection.py
@@ -1666,6 +1666,9 @@ class TestMeanAveragePrecisionBackgroundFalsePositives:
         # Assert
         assert without_fp.map50 == pytest.approx(1.0, abs=0.01)
         assert with_fp.map50 < without_fp.map50
+        assert with_fp.map50 < 0.5
+        assert with_fp.map75 < without_fp.map75
+        assert with_fp.map50_95 < without_fp.map50_95
 
     def test_ground_truth_present_path_unchanged(self) -> None:
         """GT-present scenario keeps its pinned map50 (guards normal-path numerics)."""
@@ -1698,6 +1701,24 @@ class TestMeanAveragePrecisionBackgroundFalsePositives:
 
         # Assert
         assert round(float(result.map50), 2) == 0.81
+
+    def test_all_background_images_return_zero_not_nan(self) -> None:
+        """Dataset with only background images must return map50=0, not NaN."""
+        # Arrange
+        background_pred = np.array([[0.0, 0.0, 10.0, 10.0, 0, 0.9]], dtype=np.float32)
+        background_tgt = np.zeros((0, 5), dtype=np.float32)
+
+        # Act
+        result = MeanAveragePrecision.from_tensors(
+            predictions=[background_pred],
+            targets=[background_tgt],
+        )
+
+        # Assert
+        assert not np.isnan(result.map50), (
+            "map50 must not be NaN for all-background dataset"
+        )
+        assert result.map50 == pytest.approx(0.0)
 
 
 class TestSplitDetectionsByOutcome:

--- a/tests/metrics/test_detection.py
+++ b/tests/metrics/test_detection.py
@@ -1634,7 +1634,7 @@ class TestDetectionMetrics:
 
 
 class TestMeanAveragePrecisionBackgroundFalsePositives:
-    """Legacy `from_tensors` must penalize predictions on ground-truth-empty images."""
+    """MeanAveragePrecision.from_tensors penalizes predictions on GT-empty images."""
 
     def test_background_false_positives_lower_map(self) -> None:
         """False positives on a GT-empty image drop map50 below the FP-free baseline."""


### PR DESCRIPTION
This pull request updates the mean average precision (mAP) metric calculation for object detection, ensuring that predictions on images with no ground-truth objects (background images) are properly penalized as false positives. This change corrects the prior behavior where such predictions did not reduce the mAP score, making the metric more accurate. The update is accompanied by new tests to verify the improved logic.

**Metric calculation improvements:**

* Updated `from_tensors` in `src/supervision/metrics/detection.py` to treat all predictions on ground-truth-empty images as false positives, ensuring these predictions lower the mAP score as expected.

**Testing enhancements:**

* Added `TestMeanAveragePrecisionBackgroundFalsePositives` in `tests/metrics/test_detection.py` with tests verifying that background false positives reduce mAP, and that normal cases without false positives are unaffected.