### PR TITLE
fix(key_points): guard empty selectors, ndarray indices and degenerate boxes

### DIFF
--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -965,9 +965,9 @@ class KeyPoints:
         if isinstance(i, int):
             i = [i]
 
-        if isinstance(i, list) and all(isinstance(x, bool) for x in i):
+        if isinstance(i, list) and i and all(isinstance(x, bool) for x in i):
             i = np.array(i)
-        if isinstance(j, list) and all(isinstance(x, bool) for x in j):
+        if isinstance(j, list) and j and all(isinstance(x, bool) for x in j):
             j = np.array(j)
 
         if isinstance(i, np.ndarray) and i.dtype == bool:
@@ -1290,7 +1290,7 @@ class KeyPoints:
             return Detections.empty()
 
         xy = self.xy
-        if selected_keypoint_indices:
+        if selected_keypoint_indices is not None:
             indices = np.asarray(list(selected_keypoint_indices), dtype=np.intp)
             xy = xy[:, indices, :]
 
@@ -1313,7 +1313,7 @@ class KeyPoints:
             confidence = self.detection_confidence.astype(np.float32)
         elif self.keypoint_confidence is not None:
             keypoint_confidence = self.keypoint_confidence
-            if selected_keypoint_indices:
+            if selected_keypoint_indices is not None:
                 keypoint_confidence = keypoint_confidence[:, indices]
             confidence = keypoint_confidence.mean(axis=1).astype(np.float32)
         else:
@@ -1322,6 +1322,6 @@ class KeyPoints:
         detections = Detections(xyxy=xyxy, confidence=confidence)
         detections.class_id = self.class_id
         detections.data = self.data
-        detections = detections.select(cast(Any, detections.area) > 0)
+        detections = detections.select(has_valid)
 
         return detections


### PR DESCRIPTION
Hi 👋

@abhijithneilabraham reported three small defects in `KeyPoints` input handling on `develop` (#2401), and the diagnosis there was already correct. This PR implements the fix for the three of them. They share the same root pattern — a missing empty/type guard — so it made sense to fix them together.

I could reproduce all three on `develop` (Python 3.12) with the snippet from the issue:

```python
import numpy as np
import supervision as sv

kp = sv.KeyPoints(xy=np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=np.float32))
kp[[]]   # IndexError: arrays used as indices must be of integer (or boolean) type

kp2 = sv.KeyPoints(xy=np.array([[[10, 10], [20, 20], [30, 15]]], dtype=np.float32))
kp2.as_detections(selected_keypoint_indices=np.array([0, 1]))   # ValueError: ambiguous truth value

kp3 = sv.KeyPoints(xy=np.array([[[10, 20], [30, 20]]], dtype=np.float32))
print(len(kp3), len(kp3.as_detections()))   # 1 0 -- the skeleton is gone
```

**Changes** (all in `src/supervision/key_points/core.py`):

1. `__getitem__`: `all(isinstance(x, bool) for x in i)` is vacuously `True` on an empty list, so `kp[[]]` was treated as a boolean mask and turned into a `float64` array, which then fails as an index. Added a non-empty guard so an empty list stays a plain selector and returns an empty `KeyPoints`, the same way `Detections[[]]` already does.

2. `as_detections`: `if selected_keypoint_indices:` raises `ValueError: ambiguous truth value` when you pass a numpy array, which is the most natural type for indices. Changed both checks to `is not None`.

3. `as_detections`: the final filter used `detections.area > 0`, in order to drop skeletons with no valid keypoints, but that also drops legitimate skeletons whose box is degenerate for a real reason — a single visible keypoint, or keypoints on a straight line. `has_valid` already computes the right intent a few lines above, so I filter by that instead. Skeletons with all `[0, 0]` keypoints are still dropped.

**Validation:**

- The three cases above now return an empty `KeyPoints`, a valid `Detections`, and keep the degenerate skeleton.
- The all-`[0, 0]` case is still dropped, and boolean-mask / int / list indexing keep working.
- `pytest tests/ -k key` passes (169 tests, no regressions).

Fixes #2401. Credit to @abhijithneilabraham for the diagnosis and the minimal repros ..
