### PR TITLE
fix(annotators): resolve annotator medium findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ warn_deprecated("'foo' deprecated in `0.29.0`, removed in `0.32.0`. Use 'bar'.")
 - Minimal implementation; type hints and Google docstrings with usage examples.
 - Tests covering new functionality and edge cases (see [CONTRIBUTING.md §Tests](.github/CONTRIBUTING.md#-tests)).
 - Update docstrings and mkdocs entries as needed.
+- Update [docs/changelog.md](docs/changelog.md) for every functional change or bug fix, including user-visible behavior changes. Skip changelog entries for lint-only, type-only, formatting-only, and pure documentation-only changes.
 
 **Extending `Detections`**: store metadata in `detections.data` as `np.ndarray` aligned with `xyxy`; define the key as a constant in `config.py` (e.g. `CLASS_NAME_DATA_FIELD`, `ORIENTED_BOX_COORDINATES`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,11 @@ These supplement [CONTRIBUTING.md](.github/CONTRIBUTING.md) — covering gaps or
 
 **Type hints**: required on all new code. mypy is enforced by pre-commit (`.pre-commit-config.yaml`).
 
+**Function docstrings**: every new or modified function, including private helpers and tests, must have a succinct docstring explaining its purpose. Put function-level why/what/how context inside the function docstring, not in a comment before the function. Public APIs still require the full Google-style structure described below.
+
 **Readable argument lists**: do not put multi-branch conditional expressions inside function or constructor arguments. If an argument needs more than a simple `a if condition else b`, assign it to a named local variable before the call.
+
+**Inline comments**: write code so the intent is clear from names, small helpers, and straightforward control flow. For non-trivial logic inside a function that still needs context, add concise inline comments explaining why the code exists, what invariant it protects, and how the tricky part works. Do not put comments before functions; use the function docstring instead. Do not comment obvious assignments, mechanical plumbing, lint-only changes, typing-only changes, or pure docs edits.
 
 **Doctest determinism** — output must be reproducible across platforms:
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 ---
 description: "Full version history of the supervision Python library — release notes, breaking changes, new features, and deprecations for every version."
-date_modified: 2026-07-05
+date_modified: 2026-07-06
 ---
 
 # Changelog
@@ -18,6 +18,7 @@ date_modified: 2026-07-05
 - `sv.mask_non_max_merge` now computes exact mask overlap at the original mask resolution and ignores the deprecated `mask_dimension` parameter. Code that relied on downscaled mask overlap should recalibrate thresholds; passing `mask_dimension` positionally now emits a deprecation warning, and the parameter is scheduled for removal in `0.33.0` ([#2400](https://github.com/roboflow/supervision/pull/2400)).
 
 ### Fixed
+- Fixed [#2407](https://github.com/roboflow/supervision/pull/2407): `sv.ColorPalette.by_idx()` now raises a clear `ValueError` when called on an empty palette instead of leaking a `ZeroDivisionError`. Non-empty palettes keep the existing index-wrapping behavior.
 - Fixed [#2393](https://github.com/roboflow/supervision/pull/2393): `sv.CropAnnotator.annotate` no longer raises `cv2.error` when detections extend outside the scene; out-of-bounds boxes are clipped to scene bounds and zero-area results are skipped silently.
 - Fixed [#2393](https://github.com/roboflow/supervision/pull/2393): `sv.HeatMapAnnotator.annotate` no longer blanks the hottest region when the per-pixel hit count exceeds 255; the heat mask is now derived from the float32 accumulator directly, avoiding uint8 wrap-around.
 - Fixed [#2393](https://github.com/roboflow/supervision/pull/2393): `sv.get_video_frames_generator` now releases the underlying `cv2.VideoCapture` via `try/finally`, so the decoder is freed when a consumer breaks out of iteration early rather than waiting for garbage collection.

--- a/src/supervision/__init__.py
+++ b/src/supervision/__init__.py
@@ -160,6 +160,7 @@ from supervision.utils.video import (
 
 __all__ = [
     "LMM",
+    "VLM",
     "BackgroundOverlayAnnotator",
     "BaseDataset",
     "BlurAnnotator",
@@ -236,6 +237,7 @@ __all__ = [
     "contains_multiple_segments",
     "crop_image",
     "cv2_to_pillow",
+    "denormalize_boxes",
     "draw_filled_polygon",
     "draw_filled_rectangle",
     "draw_image",
@@ -288,4 +290,5 @@ __all__ = [
     "xyxy_to_polygons",
     "xyxy_to_xcycarh",
     "xyxy_to_xywh",
+    "xyxyxyxy_to_xyxy",
 ]

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -54,6 +54,20 @@ from supervision.utils.logger import _get_logger
 logger = _get_logger(__name__)
 
 
+@lru_cache
+def _load_icon_from_path(
+    icon_path: str, icon_resolution_wh: tuple[int, int]
+) -> npt.NDArray[np.uint8]:
+    icon = cv2.imread(icon_path, cv2.IMREAD_UNCHANGED)
+    if icon is None:
+        raise FileNotFoundError(f"Error: Couldn't load the icon image from {icon_path}")
+    icon_array = cast(npt.NDArray[np.uint8], icon)
+    result: npt.NDArray[np.uint8] = letterbox_image(
+        image=icon_array, resolution_wh=icon_resolution_wh
+    )
+    return result
+
+
 def _normalize_color_input(color: Color | ColorPalette | str) -> Color | ColorPalette:
     """Normalize accepted color inputs to internal color objects.
 
@@ -887,7 +901,12 @@ class HaloAnnotator(BaseAnnotator):
             return scene
         alpha = self.opacity * gray / gray_max
         alpha_mask = alpha[:, :, np.newaxis]
-        blended_scene = np.uint8(scene * (1 - alpha_mask) + colored_mask * self.opacity)
+        blended_scene = np.clip(
+            scene.astype(np.float32) * (1 - alpha_mask)
+            + colored_mask.astype(np.float32) * alpha_mask,
+            0,
+            255,
+        ).astype(np.uint8)
         np.copyto(scene, blended_scene)
         return scene
 
@@ -2013,18 +2032,10 @@ class IconAnnotator(BaseAnnotator):
             scene[:] = _overlay_image(scene, icon, (x, y))
         return scene
 
-    @lru_cache
     def _load_icon(self, icon_path: str) -> npt.NDArray[np.uint8]:
-        icon = cv2.imread(icon_path, cv2.IMREAD_UNCHANGED)
-        if icon is None:
-            raise FileNotFoundError(
-                f"Error: Couldn't load the icon image from {icon_path}"
-            )
-        icon_array = cast(npt.NDArray[np.uint8], icon)
-        result: npt.NDArray[np.uint8] = letterbox_image(
-            image=icon_array, resolution_wh=self.icon_resolution_wh
+        return _load_icon_from_path(
+            icon_path=icon_path, icon_resolution_wh=self.icon_resolution_wh
         )
-        return result
 
 
 class BlurAnnotator(BaseAnnotator):

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -58,6 +58,7 @@ logger = _get_logger(__name__)
 def _load_icon_from_path(
     icon_path: str, icon_resolution_wh: tuple[int, int]
 ) -> npt.NDArray[np.uint8]:
+    """Load and resize an icon image through a cache shared by annotators."""
     icon = cv2.imread(icon_path, cv2.IMREAD_UNCHANGED)
     if icon is None:
         raise FileNotFoundError(f"Error: Couldn't load the icon image from {icon_path}")
@@ -901,6 +902,7 @@ class HaloAnnotator(BaseAnnotator):
             return scene
         alpha = self.opacity * gray / gray_max
         alpha_mask = alpha[:, :, np.newaxis]
+        # Blend in float space so halo opacity cannot wrap around uint8 boundaries.
         blended_scene = np.clip(
             scene.astype(np.float32) * (1 - alpha_mask)
             + colored_mask.astype(np.float32) * alpha_mask,
@@ -2033,6 +2035,7 @@ class IconAnnotator(BaseAnnotator):
         return scene
 
     def _load_icon(self, icon_path: str) -> npt.NDArray[np.uint8]:
+        """Load an icon through the module-level cache shared by annotators."""
         return _load_icon_from_path(
             icon_path=icon_path, icon_resolution_wh=self.icon_resolution_wh
         )

--- a/src/supervision/annotators/utils.py
+++ b/src/supervision/annotators/utils.py
@@ -129,7 +129,9 @@ def resolve_text_background_xyxy(
 
 
 def get_color_by_index(color: Color | ColorPalette, idx: int) -> Color:
+    """Resolve a color-like object to a concrete `Color` for an index."""
     color_like = cast(Any, color)
+    # Accept ColorPalette-like objects without depending on their exact concrete class.
     if callable(getattr(color_like, "by_idx", None)):
         color_like = color_like.by_idx(idx)
     if isinstance(color_like, Color):

--- a/src/supervision/annotators/utils.py
+++ b/src/supervision/annotators/utils.py
@@ -1,7 +1,7 @@
 import re
 import textwrap
 from enum import Enum
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -129,9 +129,17 @@ def resolve_text_background_xyxy(
 
 
 def get_color_by_index(color: Color | ColorPalette, idx: int) -> Color:
-    if isinstance(color, ColorPalette):
-        return color.by_idx(idx)
-    return color
+    color_like = cast(Any, color)
+    if callable(getattr(color_like, "by_idx", None)):
+        color_like = color_like.by_idx(idx)
+    if isinstance(color_like, Color):
+        return color_like
+    return Color(
+        r=int(color_like.r),
+        g=int(color_like.g),
+        b=int(color_like.b),
+        a=int(getattr(color_like, "a", 255)),
+    )
 
 
 def resolve_color(

--- a/src/supervision/draw/color.py
+++ b/src/supervision/draw/color.py
@@ -539,6 +539,8 @@ class ColorPalette:
 
             ```
         """
+        if not self.colors:
+            raise ValueError("ColorPalette must contain at least one color")
         idx = idx % len(self.colors)
         return self.colors[idx]
 

--- a/src/supervision/draw/color.py
+++ b/src/supervision/draw/color.py
@@ -499,6 +499,7 @@ class ColorPalette:
         if color_count < 1:
             raise ValueError("color_count must be greater than or equal to 1")
 
+        # Keep pyplot lazy so importing color utilities does not import matplotlib.
         import matplotlib.pyplot as plt
 
         mpl_palette = plt.get_cmap(palette_name)
@@ -508,6 +509,7 @@ class ColorPalette:
         if hasattr(mpl_palette, "colors"):
             colors = mpl_palette.colors
         else:
+            # A single color samples the palette start and avoids division by zero.
             positions = (
                 [0.0]
                 if color_count == 1
@@ -541,6 +543,7 @@ class ColorPalette:
         """
         if not self.colors:
             raise ValueError("ColorPalette must contain at least one color")
+        # Modulo preserves Python-like wrapping for negative and oversized indexes.
         idx = idx % len(self.colors)
         return self.colors[idx]
 

--- a/src/supervision/draw/color.py
+++ b/src/supervision/draw/color.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, cast
 
-import matplotlib.pyplot as plt
-
 from supervision.utils.internal import classproperty
 
 DEFAULT_COLOR_PALETTE = [
@@ -498,12 +496,24 @@ class ColorPalette:
         ![visualized_color_palette](https://media.roboflow.com/
         supervision-annotator-examples/visualized_color_palette.png)
         """
-        mpl_palette = plt.get_cmap(palette_name, color_count)
+        if color_count < 1:
+            raise ValueError("color_count must be greater than or equal to 1")
+
+        import matplotlib.pyplot as plt
+
+        mpl_palette = plt.get_cmap(palette_name)
+        if hasattr(mpl_palette, "resampled"):
+            mpl_palette = mpl_palette.resampled(color_count)
 
         if hasattr(mpl_palette, "colors"):
             colors = mpl_palette.colors
         else:
-            colors = [mpl_palette(i / (color_count - 1)) for i in range(color_count)]
+            positions = (
+                [0.0]
+                if color_count == 1
+                else [i / (color_count - 1) for i in range(color_count)]
+            )
+            colors = [mpl_palette(position) for position in positions]
 
         return cls(
             [Color(int(r * 255), int(g * 255), int(b * 255)) for r, g, b, _ in colors]
@@ -529,8 +539,6 @@ class ColorPalette:
 
             ```
         """
-        if idx < 0:
-            raise ValueError("idx argument should not be negative")
         idx = idx % len(self.colors)
         return self.colors[idx]
 
@@ -550,7 +558,7 @@ def unify_to_bgr(color: tuple[int, int, int] | Color) -> tuple[int, int, int]:
 
     Args:
         color: The color input to be converted,
-            which can be either a tuple of RGB values or an instance of a Color class.
+            which can be either a tuple of BGR values or an instance of a Color class.
 
     Returns:
         The color in BGR format as a tuple of three integers.

--- a/src/supervision/key_points/annotators.py
+++ b/src/supervision/key_points/annotators.py
@@ -20,13 +20,13 @@ logger = _get_logger(__name__)
 
 
 def _validate_edge_indices(edge: tuple[int, int], vertex_count: int) -> tuple[int, int]:
-    class_a, class_b = edge
-    if not (1 <= class_a <= vertex_count and 1 <= class_b <= vertex_count):
+    vertex_a, vertex_b = edge
+    if not (1 <= vertex_a <= vertex_count and 1 <= vertex_b <= vertex_count):
         raise ValueError(
             "Edge indices must use the 1-based convention and be within the "
             f"available keypoint range [1, {vertex_count}], got {edge}."
         )
-    return class_a - 1, class_b - 1
+    return vertex_a - 1, vertex_b - 1
 
 
 class BaseKeyPointAnnotator(ABC):

--- a/src/supervision/key_points/annotators.py
+++ b/src/supervision/key_points/annotators.py
@@ -19,6 +19,16 @@ from supervision.utils.logger import _get_logger
 logger = _get_logger(__name__)
 
 
+def _validate_edge_indices(edge: tuple[int, int], vertex_count: int) -> tuple[int, int]:
+    class_a, class_b = edge
+    if not (1 <= class_a <= vertex_count and 1 <= class_b <= vertex_count):
+        raise ValueError(
+            "Edge indices must use the 1-based convention and be within the "
+            f"available keypoint range [1, {vertex_count}], got {edge}."
+        )
+    return class_a - 1, class_b - 1
+
+
 class BaseKeyPointAnnotator(ABC):
     @abstractmethod
     def annotate(self, scene: ImageType, key_points: KeyPoints) -> ImageType:
@@ -235,9 +245,8 @@ class EdgeAnnotator(BaseKeyPointAnnotator):
                     continue
                 edges = _looked_up
 
-            for class_a, class_b in edges:
-                idx_a = class_a - 1
-                idx_b = class_b - 1
+            for edge in edges:
+                idx_a, idx_b = _validate_edge_indices(edge=edge, vertex_count=len(xy))
                 xy_a = xy[idx_a]
                 xy_b = xy[idx_b]
                 if np.allclose(xy_a, 0) or np.allclose(xy_b, 0):

--- a/src/supervision/key_points/annotators.py
+++ b/src/supervision/key_points/annotators.py
@@ -20,12 +20,14 @@ logger = _get_logger(__name__)
 
 
 def _validate_edge_indices(edge: tuple[int, int], vertex_count: int) -> tuple[int, int]:
+    """Validate 1-based skeleton edges and return zero-based vertex indexes."""
     vertex_a, vertex_b = edge
     if not (1 <= vertex_a <= vertex_count and 1 <= vertex_b <= vertex_count):
         raise ValueError(
             "Edge indices must use the 1-based convention and be within the "
             f"available keypoint range [1, {vertex_count}], got {edge}."
         )
+    # Public skeleton definitions are 1-based; keypoint arrays are zero-based.
     return vertex_a - 1, vertex_b - 1
 
 

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -561,6 +561,7 @@ class KeyPoints:
                     for face_landmark in mediapipe_results.multi_face_landmarks
                 ]
         else:
+            # Reject unsupported MediaPipe-like payloads before landmark parsing.
             raise ValueError(
                 "Unsupported MediaPipe result type. Expected an object with "
                 "pose_landmarks, face_landmarks, or multi_face_landmarks."

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -560,6 +560,11 @@ class KeyPoints:
                     face_landmark.landmark
                     for face_landmark in mediapipe_results.multi_face_landmarks
                 ]
+        else:
+            raise ValueError(
+                "Unsupported MediaPipe result type. Expected an object with "
+                "pose_landmarks, face_landmarks, or multi_face_landmarks."
+            )
 
         if len(results) == 0:
             return cls.empty()
@@ -1162,9 +1167,7 @@ class KeyPoints:
 
             ```
         """
-        empty_key_points = KeyPoints.empty()
-        empty_key_points.data = self.data
-        return self == empty_key_points
+        return len(self) == 0
 
     def with_nms(
         self,

--- a/src/supervision/utils/internal.py
+++ b/src/supervision/utils/internal.py
@@ -30,8 +30,6 @@ def format_warning(
     return f"{category.__name__}: {message}\n"
 
 
-warnings.formatwarning = format_warning
-
 if os.getenv("SUPERVISON_DEPRECATION_WARNING") == "0":
     warnings.simplefilter("ignore", SupervisionWarnings)
 else:

--- a/src/supervision/utils/notebook.py
+++ b/src/supervision/utils/notebook.py
@@ -1,5 +1,4 @@
 import cv2
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 from PIL import Image
@@ -37,6 +36,8 @@ def plot_image(
         image_np = pillow_to_cv2(image)
     else:
         image_np = image
+
+    import matplotlib.pyplot as plt
 
     plt.figure(figsize=size)
 
@@ -102,6 +103,8 @@ def plot_images_grid(
             "The number of images exceeds the grid size. Please increase the grid size"
             " or reduce the number of images."
         )
+
+    import matplotlib.pyplot as plt
 
     _fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=size)
 

--- a/src/supervision/utils/notebook.py
+++ b/src/supervision/utils/notebook.py
@@ -37,6 +37,7 @@ def plot_image(
     else:
         image_np = image
 
+    # Keep pyplot lazy so importing notebook helpers does not import matplotlib.
     import matplotlib.pyplot as plt
 
     plt.figure(figsize=size)
@@ -104,6 +105,7 @@ def plot_images_grid(
             " or reduce the number of images."
         )
 
+    # Keep pyplot lazy so importing notebook helpers does not import matplotlib.
     import matplotlib.pyplot as plt
 
     _fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=size)

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -107,6 +107,7 @@ class VideoSink:
         self.__writer: cv2.VideoWriter | None = None
 
     def __enter__(self) -> VideoSink:
+        """Open the underlying video writer for context-managed frame output."""
         fourcc_fn = cast(
             Callable[[str, str, str, str], int], getattr(cv2, "VideoWriter_fourcc")
         )
@@ -121,6 +122,7 @@ class VideoSink:
             self.video_info.fps,
             self.video_info.resolution_wh,
         )
+        # OpenCV can construct a writer object that is not usable for the target path.
         if not self.__writer.isOpened():
             self.__writer.release()
             self.__writer = None
@@ -135,6 +137,7 @@ class VideoSink:
             frame: The video frame to be written to the file. The frame
                 must be in BGR color format.
         """
+        # Preserve the context-manager invariant instead of silently dropping frames.
         if self.__writer is None:
             raise RuntimeError("write_frame requires an open VideoSink context.")
         self.__writer.write(frame)
@@ -145,6 +148,7 @@ class VideoSink:
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
     ) -> None:
+        """Release the underlying video writer when leaving the context."""
         if self.__writer is not None:
             self.__writer.release()
             self.__writer = None

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -121,6 +121,10 @@ class VideoSink:
             self.video_info.fps,
             self.video_info.resolution_wh,
         )
+        if not self.__writer.isOpened():
+            self.__writer.release()
+            self.__writer = None
+            raise RuntimeError(f"Could not open video writer for {self.target_path}")
         return self
 
     def write_frame(self, frame: npt.NDArray[np.uint8]) -> None:
@@ -131,8 +135,9 @@ class VideoSink:
             frame: The video frame to be written to the file. The frame
                 must be in BGR color format.
         """
-        if self.__writer is not None:
-            self.__writer.write(frame)
+        if self.__writer is None:
+            raise RuntimeError("write_frame requires an open VideoSink context.")
+        self.__writer.write(frame)
 
     def __exit__(
         self,
@@ -142,6 +147,7 @@ class VideoSink:
     ) -> None:
         if self.__writer is not None:
             self.__writer.release()
+            self.__writer = None
 
 
 def _mux_audio(source_path: str, video_path: str) -> None:

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -1479,6 +1479,31 @@ class TestIconAnnotator:
         ]
         assert deprecations == []
 
+    def test_icon_cache_is_shared_by_path_and_resolution(
+        self, monkeypatch, test_image, tmp_path
+    ):
+        """Equal path/resolution icon loads are cached across annotator instances."""
+        icon_path = str(tmp_path / "icon.png")
+        icon = np.full((20, 20, 4), (0, 255, 0, 255), dtype=np.uint8)
+        cv2.imwrite(icon_path, icon)
+        detections = _create_detections(xyxy=[[20, 20, 60, 60]], class_id=[0])
+        imread_calls = 0
+        original_imread = cv2.imread
+
+        def count_imread(path, flags):
+            nonlocal imread_calls
+            imread_calls += 1
+            return original_imread(path, flags)
+
+        monkeypatch.setattr(cv2, "imread", count_imread)
+
+        for _ in range(2):
+            IconAnnotator(icon_resolution_wh=(16, 16)).annotate(
+                scene=test_image.copy(), detections=detections, icon_path=icon_path
+            )
+
+        assert imread_calls == 1
+
 
 class TestBackgroundOverlayAnnotator:
     """Tests for BackgroundOverlayAnnotator class"""

--- a/tests/annotators/test_utils.py
+++ b/tests/annotators/test_utils.py
@@ -132,6 +132,22 @@ def test_resolve_color_accepts_negative_class_id() -> None:
     assert result == Color.from_hex("#0000ff")
 
 
+def test_resolve_color_accepts_palette_from_src_namespace() -> None:
+    """Palette instances imported through src.supervision still resolve by index."""
+    from src.supervision.draw.color import ColorPalette as SrcColorPalette
+
+    detections = _create_detections(xyxy=[[0, 0, 10, 10]], class_id=[0])
+
+    result = resolve_color(
+        color=SrcColorPalette.DEFAULT,
+        detections=detections,
+        detection_idx=0,
+        color_lookup=ColorLookup.CLASS,
+    )
+
+    assert result.as_bgr() == (251, 81, 163)
+
+
 @pytest.mark.parametrize(
     ("text", "max_line_length", "expected_result", "exception"),
     [

--- a/tests/annotators/test_utils.py
+++ b/tests/annotators/test_utils.py
@@ -7,11 +7,13 @@ from supervision.annotators.utils import (
     ColorLookup,
     hex_to_rgba,
     is_valid_hex,
+    resolve_color,
     resolve_color_idx,
     rgba_to_hex,
     wrap_text,
 )
 from supervision.detection.core import Detections
+from supervision.draw.color import Color, ColorPalette
 from tests.helpers import _create_detections
 
 
@@ -113,6 +115,21 @@ def test_resolve_color_idx(
             color_lookup=color_lookup,
         )
         assert result == expected_result
+
+
+def test_resolve_color_accepts_negative_class_id() -> None:
+    """Negative class ids map deterministically instead of aborting annotation."""
+    detections = _create_detections(xyxy=[[0, 0, 10, 10]], class_id=[-1])
+    palette = ColorPalette.from_hex(["#ff0000", "#00ff00", "#0000ff"])
+
+    result = resolve_color(
+        color=palette,
+        detections=detections,
+        detection_idx=0,
+        color_lookup=ColorLookup.CLASS,
+    )
+
+    assert result == Color.from_hex("#0000ff")
 
 
 @pytest.mark.parametrize(

--- a/tests/draw/test_color.py
+++ b/tests/draw/test_color.py
@@ -1,8 +1,10 @@
+import importlib
+import sys
 from contextlib import ExitStack as DoesNotRaise
 
 import pytest
 
-from supervision.draw.color import Color
+from supervision.draw.color import Color, ColorPalette, unify_to_bgr
 
 
 @pytest.mark.parametrize(
@@ -313,3 +315,32 @@ def test_color_repr(color: Color, expected_repr: str) -> None:
 def test_color_hash(color_a: Color, color_b: Color, expect_equal_hash: bool) -> None:
     assert (hash(color_a) == hash(color_b)) == expect_equal_hash
     assert (color_a == color_b) == expect_equal_hash
+
+
+def test_palette_accepts_negative_indices() -> None:
+    """Negative palette indices wrap like standard Python sequences."""
+    palette = ColorPalette.from_hex(["#ff0000", "#00ff00", "#0000ff"])
+
+    assert palette.by_idx(-1) == Color.from_hex("#0000ff")
+
+
+def test_unify_to_bgr_passes_through_bgr_tuple() -> None:
+    """Tuple inputs are already BGR and must not be channel-swapped."""
+    assert unify_to_bgr((1, 2, 3)) == (1, 2, 3)
+
+
+def test_from_matplotlib_accepts_single_color() -> None:
+    """A one-color matplotlib palette is valid and must not divide by zero."""
+    palette = ColorPalette.from_matplotlib("jet", 1)
+
+    assert len(palette) == 1
+
+
+def test_draw_color_import_does_not_import_matplotlib_pyplot() -> None:
+    """Importing draw.color keeps pyplot lazy until from_matplotlib is called."""
+    sys.modules.pop("supervision.draw.color", None)
+    sys.modules.pop("matplotlib.pyplot", None)
+
+    importlib.import_module("supervision.draw.color")
+
+    assert "matplotlib.pyplot" not in sys.modules

--- a/tests/draw/test_color.py
+++ b/tests/draw/test_color.py
@@ -324,6 +324,14 @@ def test_palette_accepts_negative_indices() -> None:
     assert palette.by_idx(-1) == Color.from_hex("#0000ff")
 
 
+def test_empty_palette_lookup_raises() -> None:
+    """Empty palette lookup raises a clear API error."""
+    palette = ColorPalette.from_hex([])
+
+    with pytest.raises(ValueError, match="at least one color"):
+        palette.by_idx(0)
+
+
 def test_unify_to_bgr_passes_through_bgr_tuple() -> None:
     """Tuple inputs are already BGR and must not be channel-swapped."""
     assert unify_to_bgr((1, 2, 3)) == (1, 2, 3)

--- a/tests/key_points/test_annotators.py
+++ b/tests/key_points/test_annotators.py
@@ -162,6 +162,24 @@ class TestEdgeAnnotator:
         result = annotator.annotate(scene=scene.copy(), key_points=key_points)
         assert not np.array_equal(result, scene)
 
+    @pytest.mark.parametrize(
+        "edges",
+        [
+            pytest.param([(0, 1)], id="zero-based"),
+            pytest.param([(1, 3)], id="too-large"),
+        ],
+    )
+    def test_invalid_edges_raise(self, scene, edges):
+        """Edges must use valid 1-based keypoint indices."""
+        key_points = sv.KeyPoints(
+            xy=np.array([[[10.0, 10.0], [90.0, 90.0]]], dtype=np.float32),
+            visible=np.array([[True, True]]),
+        )
+        annotator = sv.EdgeAnnotator(edges=edges)
+
+        with pytest.raises(ValueError, match="1-based"):
+            annotator.annotate(scene=scene.copy(), key_points=key_points)
+
     def test_annotate_no_edges_found(self, scene):
         """
         Verify returning unmodified scene when no known skeleton matches.

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -677,6 +677,17 @@ def test_key_points_is_empty():
     assert not non_empty_key_points.is_empty()
 
 
+def test_key_points_zero_length_slice_is_empty():
+    """A filtered KeyPoints object with zero rows is empty."""
+    key_points = _create_key_points(
+        xy=[[[0, 1], [2, 3]]],
+        confidence=[[0.8, 0.9]],
+        class_id=[0],
+    )
+
+    assert key_points[np.array([], dtype=int)].is_empty()
+
+
 def test_key_points_setitem():
     """Test the __setitem__ method for KeyPoints objects."""
     key_points = _create_key_points(
@@ -1024,6 +1035,12 @@ def test_from_mediapipe_input(mediapipe_results, resolution_wh, expected_key_poi
         mediapipe_results, resolution_wh=resolution_wh
     )
     assert key_points == expected_key_points
+
+
+def test_from_mediapipe_unknown_result_type_raises() -> None:
+    """Unsupported Mediapipe result objects raise a descriptive ValueError."""
+    with pytest.raises(ValueError, match="Unsupported MediaPipe result"):
+        KeyPoints.from_mediapipe(object(), resolution_wh=(100, 100))
 
 
 class TestDeprecatedConfidenceConstructor:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -16,3 +16,17 @@ def test_all_symbols_are_importable(symbol_name: str) -> None:
         f"supervision.{symbol_name} is listed in __all__ but not accessible "
         f"as a non-None package attribute"
     )
+
+
+@pytest.mark.parametrize(
+    "symbol_name",
+    [
+        pytest.param("VLM", id="VLM"),
+        pytest.param("denormalize_boxes", id="denormalize_boxes"),
+        pytest.param("xyxyxyxy_to_xyxy", id="xyxyxyxy_to_xyxy"),
+    ],
+)
+def test_shipped_imports_are_listed_in_all(symbol_name: str) -> None:
+    """Public package attributes must be discoverable through __all__."""
+    assert getattr(sv, symbol_name) is not None
+    assert symbol_name in sv.__all__

--- a/tests/utils/test_internal.py
+++ b/tests/utils/test_internal.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import ExitStack as DoesNotRaise
 from dataclasses import dataclass, field
 from typing import Any
@@ -6,7 +7,11 @@ import numpy as np
 import pytest
 
 from supervision.detection.core import Detections
-from supervision.utils.internal import get_instance_variables
+from supervision.utils.internal import (
+    SupervisionWarnings,
+    format_warning,
+    get_instance_variables,
+)
 
 
 class MockClass:
@@ -197,3 +202,11 @@ def test_get_instance_variables(
             input_instance, include_properties=include_properties
         )
         assert result == expected
+
+
+def test_supervision_warning_formatter_is_not_global() -> None:
+    """Supervision warning formatting is opt-in, not global warnings state."""
+    assert warnings.formatwarning is not format_warning
+    assert format_warning("message", SupervisionWarnings, "file.py", 1) == (
+        "SupervisionWarnings: message\n"
+    )

--- a/tests/utils/test_notebook.py
+++ b/tests/utils/test_notebook.py
@@ -1,0 +1,14 @@
+"""Tests for notebook display helpers."""
+
+import importlib
+import sys
+
+
+def test_notebook_import_does_not_import_matplotlib_pyplot() -> None:
+    """Importing notebook helpers keeps pyplot lazy until plotting is requested."""
+    sys.modules.pop("supervision.utils.notebook", None)
+    sys.modules.pop("matplotlib.pyplot", None)
+
+    importlib.import_module("supervision.utils.notebook")
+
+    assert "matplotlib.pyplot" not in sys.modules

--- a/tests/utils/test_sinks.py
+++ b/tests/utils/test_sinks.py
@@ -3,8 +3,10 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import supervision as sv
+import supervision.utils.video as video_utils
 from supervision.utils.video import VideoInfo
 
 
@@ -74,6 +76,37 @@ class TestImageSink:
 
 class TestVideoSink:
     """VideoSink writes valid video frames to a file."""
+
+    def test_write_frame_outside_context_raises(self, tmp_path: Path) -> None:
+        """write_frame requires an open VideoSink context."""
+        target = str(tmp_path / "out.avi")
+        info = VideoInfo(width=64, height=64, fps=1, total_frames=None)
+        sink = sv.VideoSink(target_path=target, video_info=info, codec="MJPG")
+
+        with pytest.raises(RuntimeError, match="open VideoSink context"):
+            sink.write_frame(frame=np.zeros((64, 64, 3), dtype=np.uint8))
+
+    def test_enter_raises_when_writer_does_not_open(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """VideoSink surfaces VideoWriter open failures immediately."""
+
+        class ClosedWriter:
+            def isOpened(self) -> bool:
+                return False
+
+            def release(self) -> None:
+                pass
+
+        monkeypatch.setattr(
+            video_utils.cv2, "VideoWriter", lambda *args: ClosedWriter()
+        )
+        target = str(tmp_path / "out.avi")
+        info = VideoInfo(width=64, height=64, fps=1, total_frames=None)
+
+        with pytest.raises(RuntimeError, match="Could not open video writer"):
+            with sv.VideoSink(target_path=target, video_info=info, codec="MJPG"):
+                pass
 
     def test_creates_output_file(self, tmp_path: Path) -> None:
         """VideoSink creates a non-empty file at target_path."""


### PR DESCRIPTION
This pull request introduces a variety of improvements and fixes across the codebase, with a focus on robustness, API consistency, and enhanced test coverage. Key highlights include improvements to color palette handling, stricter validation and error handling for keypoints and video output, better caching for icon loading, and expanded public API exports. The changes also add comprehensive tests to ensure correct behavior for edge cases and negative indices.

**API and Functionality Improvements:**

* Added new public API exports: `VLM`, `denormalize_boxes`, and `xyxyxyxy_to_xyxy` are now included in the `__all__` list, making them discoverable and importable from the package root. [[1]](diffhunk://#diff-a73c6f489f618c3cbd340026208825fd307dfa6fbb017081b10315a4c3df94f2R163) [[2]](diffhunk://#diff-a73c6f489f618c3cbd340026208825fd307dfa6fbb017081b10315a4c3df94f2R240) [[3]](diffhunk://#diff-a73c6f489f618c3cbd340026208825fd307dfa6fbb017081b10315a4c3df94f2R293) [[4]](diffhunk://#diff-d90f433ee999660cc370de441c62d4f7528f77c27ec3f09fbc7abcfc626613daR19-R32)
* Refined `ColorPalette.from_matplotlib` to handle single-color palettes and avoid division by zero, and improved negative index handling in `by_idx` to wrap using Python sequence semantics. [[1]](diffhunk://#diff-5b6dff0b0f70c148dbffd897934bbf37735d405995e0d7ac14af4189e71d929cL501-R516) [[2]](diffhunk://#diff-5b6dff0b0f70c148dbffd897934bbf37735d405995e0d7ac14af4189e71d929cL532-L533) [[3]](diffhunk://#diff-08e93b7343d55d901a29d99527c146a1d041e86c583fe01fcf9af2e3530f052aR318-R346)
* Improved color handling by clarifying that tuple inputs to `unify_to_bgr` are already in BGR format, and ensuring the function passes them through unchanged. [[1]](diffhunk://#diff-5b6dff0b0f70c148dbffd897934bbf37735d405995e0d7ac14af4189e71d929cL553-R561) [[2]](diffhunk://#diff-08e93b7343d55d901a29d99527c146a1d041e86c583fe01fcf9af2e3530f052aR318-R346)

**Validation and Error Handling:**

* Enforced 1-based keypoint edge indices and raised descriptive errors for invalid or out-of-range edge definitions in keypoint annotators. [[1]](diffhunk://#diff-5ee94c658adaa30efcd6ba298bb552d2a7e4f7ce645b86c9f253faae605cef74R22-R31) [[2]](diffhunk://#diff-5ee94c658adaa30efcd6ba298bb552d2a7e4f7ce645b86c9f253faae605cef74L238-R249) [[3]](diffhunk://#diff-0627316f648f72ada629254dd782ca335af641220db96522ab39312269cf8fb8R165-R182)
* Improved error handling in `KeyPoints.from_mediapipe` for unsupported result types, and made `KeyPoints.is_empty` rely on length for more robust emptiness checks. [[1]](diffhunk://#diff-066a81b3cbfea922e7e9b252acf869e767fcaf4858c8161c815702f0972d64fbR563-R567) [[2]](diffhunk://#diff-066a81b3cbfea922e7e9b252acf869e767fcaf4858c8161c815702f0972d64fbL1165-R1170) [[3]](diffhunk://#diff-2965b51f6329841e1e094e35e8de30aeb255be16d3ce3cd247796710d0255a9dR680-R690) [[4]](diffhunk://#diff-2965b51f6329841e1e094e35e8de30aeb255be16d3ce3cd247796710d0255a9dR1040-R1045)
* Added safety checks to `VideoSink` to ensure the video writer is properly opened before writing frames, and to raise clear errors if not. [[1]](diffhunk://#diff-2c1d5a304749d86bda9d86102aabaa13e24c671bd4fc4eaa08cdde8969845fbbR124-R127) [[2]](diffhunk://#diff-2c1d5a304749d86bda9d86102aabaa13e24c671bd4fc4eaa08cdde8969845fbbL134-R139) [[3]](diffhunk://#diff-2c1d5a304749d86bda9d86102aabaa13e24c671bd4fc4eaa08cdde8969845fbbR150)

**Performance and Internal Improvements:**

* Centralized and cached icon loading by path and resolution to avoid redundant disk reads, improving performance for repeated icon annotations. [[1]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2R57-R70) [[2]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2L2016-L2027) [[3]](diffhunk://#diff-9a755599d6d35d965e6aeaffd331b9caa7905b235fda9fce504f488d29113996R1482-R1506)
* Refined blending logic in mask annotation to ensure correct alpha blending and prevent overflow, using `np.clip` for safety.

**Testing and Lazy Imports:**

* Added tests to verify negative indices in color palettes, single-color palette support, and that importing color utilities does not import `matplotlib.pyplot` unless needed. [[1]](diffhunk://#diff-08e93b7343d55d901a29d99527c146a1d041e86c583fe01fcf9af2e3530f052aR1-R7) [[2]](diffhunk://#diff-08e93b7343d55d901a29d99527c146a1d041e86c583fe01fcf9af2e3530f052aR318-R346)
* Moved `matplotlib.pyplot` imports inside plotting functions to avoid unnecessary imports and improve startup time. [[1]](diffhunk://#diff-454f1f44b2ab2d46531d89a63b77bfedff8f2acbc1b90013289738aaa4f467c9L2) [[2]](diffhunk://#diff-454f1f44b2ab2d46531d89a63b77bfedff8f2acbc1b90013289738aaa4f467c9R40-R41) [[3]](diffhunk://#diff-454f1f44b2ab2d46531d89a63b77bfedff8f2acbc1b90013289738aaa4f467c9R107-R108)

These changes collectively improve the usability, reliability, and performance of the codebase, while expanding and clarifying the public API.