### PR TITLE
refactor(cv2): add optional backend facade

### DIFF
--- a/src/supervision/_cv2/__init__.py
+++ b/src/supervision/_cv2/__init__.py
@@ -1,0 +1,232 @@
+"""Private OpenCV compatibility surface used by Supervision."""
+
+from __future__ import annotations
+
+from typing import NoReturn
+
+
+class BackendUnavailableError(RuntimeError):
+    """Raised when an OpenCV operation is used without an available backend."""
+
+
+try:
+    import cv2
+except (ImportError, OSError):
+    _IS_CV2_AVAILABLE = False
+else:
+    _IS_CV2_AVAILABLE = True
+
+_BORDER_CONSTANT = 0
+_CAP_PROP_FPS = 5
+_CAP_PROP_FRAME_COUNT = 7
+_CAP_PROP_FRAME_HEIGHT = 4
+_CAP_PROP_FRAME_WIDTH = 3
+_CAP_PROP_POS_FRAMES = 1
+_CC_STAT_AREA = 4
+_CHAIN_APPROX_SIMPLE = 2
+_COLOR_BGR2GRAY = 6
+_COLOR_BGR2RGB = 4
+_COLOR_GRAY2BGR = 8
+_COLOR_HSV2BGR = 54
+_COLOR_RGB2BGR = 4
+_DIST_L2 = 2
+_FONT_HERSHEY_SIMPLEX = 0
+_IMREAD_COLOR = 1
+_IMREAD_UNCHANGED = -1
+_INTER_LINEAR = 1
+_INTER_NEAREST = 0
+_LINE_4 = 4
+_LINE_AA = 16
+_RETR_CCOMP = 2
+_RETR_TREE = 3
+
+if _IS_CV2_AVAILABLE:
+    from cv2 import (
+        BORDER_CONSTANT,
+        CAP_PROP_FPS,
+        CAP_PROP_FRAME_COUNT,
+        CAP_PROP_FRAME_HEIGHT,
+        CAP_PROP_FRAME_WIDTH,
+        CAP_PROP_POS_FRAMES,
+        CC_STAT_AREA,
+        CHAIN_APPROX_SIMPLE,
+        COLOR_BGR2GRAY,
+        COLOR_BGR2RGB,
+        COLOR_GRAY2BGR,
+        COLOR_HSV2BGR,
+        COLOR_RGB2BGR,
+        DIST_L2,
+        FONT_HERSHEY_SIMPLEX,
+        IMREAD_COLOR,
+        IMREAD_UNCHANGED,
+        INTER_LINEAR,
+        INTER_NEAREST,
+        LINE_4,
+        LINE_AA,
+        RETR_CCOMP,
+        RETR_TREE,
+        VideoCapture,
+        VideoWriter,
+        VideoWriter_fourcc,
+        addWeighted,
+        approxPolyDP,
+        blur,
+        circle,
+        connectedComponents,
+        connectedComponentsWithStats,
+        contourArea,
+        convertScaleAbs,
+        copyMakeBorder,
+        cvtColor,
+        distanceTransform,
+        drawContours,
+        ellipse,
+        fillPoly,
+        findContours,
+        flip,
+        getRotationMatrix2D,
+        getTextSize,
+        imread,
+        imwrite,
+        intersectConvexConvex,
+        line,
+        mean,
+        merge,
+        polylines,
+        putText,
+        rectangle,
+        resize,
+        split,
+        warpAffine,
+    )
+
+    BACKEND_NAME = "opencv"
+else:
+    BACKEND_NAME = "fallback"
+
+    BORDER_CONSTANT = _BORDER_CONSTANT
+    CAP_PROP_FPS = _CAP_PROP_FPS
+    CAP_PROP_FRAME_COUNT = _CAP_PROP_FRAME_COUNT
+    CAP_PROP_FRAME_HEIGHT = _CAP_PROP_FRAME_HEIGHT
+    CAP_PROP_FRAME_WIDTH = _CAP_PROP_FRAME_WIDTH
+    CAP_PROP_POS_FRAMES = _CAP_PROP_POS_FRAMES
+    CC_STAT_AREA = _CC_STAT_AREA
+    CHAIN_APPROX_SIMPLE = _CHAIN_APPROX_SIMPLE
+    COLOR_BGR2GRAY = _COLOR_BGR2GRAY
+    COLOR_BGR2RGB = _COLOR_BGR2RGB
+    COLOR_GRAY2BGR = _COLOR_GRAY2BGR
+    COLOR_HSV2BGR = _COLOR_HSV2BGR
+    COLOR_RGB2BGR = _COLOR_RGB2BGR
+    DIST_L2 = _DIST_L2
+    FONT_HERSHEY_SIMPLEX = _FONT_HERSHEY_SIMPLEX
+    IMREAD_COLOR = _IMREAD_COLOR
+    IMREAD_UNCHANGED = _IMREAD_UNCHANGED
+    INTER_LINEAR = _INTER_LINEAR
+    INTER_NEAREST = _INTER_NEAREST
+    LINE_4 = _LINE_4
+    LINE_AA = _LINE_AA
+    RETR_CCOMP = _RETR_CCOMP
+    RETR_TREE = _RETR_TREE
+
+    def _unavailable(*args: object, **kwargs: object) -> NoReturn:
+        """Fail clearly until the corresponding fallback is implemented."""
+        del args, kwargs
+        raise BackendUnavailableError(
+            "OpenCV is not installed and this operation has no fallback yet."
+        )
+
+    VideoCapture = _unavailable
+    VideoWriter = _unavailable
+    VideoWriter_fourcc = _unavailable
+    addWeighted = _unavailable
+    approxPolyDP = _unavailable
+    blur = _unavailable
+    circle = _unavailable
+    connectedComponents = _unavailable
+    connectedComponentsWithStats = _unavailable
+    contourArea = _unavailable
+    convertScaleAbs = _unavailable
+    copyMakeBorder = _unavailable
+    cvtColor = _unavailable
+    distanceTransform = _unavailable
+    drawContours = _unavailable
+    ellipse = _unavailable
+    fillPoly = _unavailable
+    findContours = _unavailable
+    flip = _unavailable
+    getRotationMatrix2D = _unavailable
+    getTextSize = _unavailable
+    imread = _unavailable
+    imwrite = _unavailable
+    intersectConvexConvex = _unavailable
+    line = _unavailable
+    mean = _unavailable
+    merge = _unavailable
+    polylines = _unavailable
+    putText = _unavailable
+    rectangle = _unavailable
+    resize = _unavailable
+    split = _unavailable
+    warpAffine = _unavailable
+
+
+__all__ = [
+    "BACKEND_NAME",
+    "BORDER_CONSTANT",
+    "CAP_PROP_FPS",
+    "CAP_PROP_FRAME_COUNT",
+    "CAP_PROP_FRAME_HEIGHT",
+    "CAP_PROP_FRAME_WIDTH",
+    "CAP_PROP_POS_FRAMES",
+    "CC_STAT_AREA",
+    "CHAIN_APPROX_SIMPLE",
+    "COLOR_BGR2GRAY",
+    "COLOR_BGR2RGB",
+    "COLOR_GRAY2BGR",
+    "COLOR_HSV2BGR",
+    "COLOR_RGB2BGR",
+    "DIST_L2",
+    "FONT_HERSHEY_SIMPLEX",
+    "IMREAD_COLOR",
+    "IMREAD_UNCHANGED",
+    "INTER_LINEAR",
+    "INTER_NEAREST",
+    "LINE_4",
+    "LINE_AA",
+    "RETR_CCOMP",
+    "RETR_TREE",
+    "BackendUnavailableError",
+    "VideoCapture",
+    "VideoWriter",
+    "VideoWriter_fourcc",
+    "addWeighted",
+    "approxPolyDP",
+    "blur",
+    "circle",
+    "connectedComponents",
+    "connectedComponentsWithStats",
+    "contourArea",
+    "convertScaleAbs",
+    "copyMakeBorder",
+    "cvtColor",
+    "distanceTransform",
+    "drawContours",
+    "ellipse",
+    "fillPoly",
+    "findContours",
+    "flip",
+    "getRotationMatrix2D",
+    "getTextSize",
+    "imread",
+    "imwrite",
+    "intersectConvexConvex",
+    "line",
+    "mean",
+    "merge",
+    "polylines",
+    "putText",
+    "rectangle",
+    "resize",
+    "split",
+    "warpAffine",
+]

--- a/src/supervision/_cv2/__init__.py
+++ b/src/supervision/_cv2/__init__.py
@@ -41,7 +41,7 @@ _RETR_CCOMP = 2
 _RETR_TREE = 3
 
 if _IS_CV2_AVAILABLE:
-    from cv2 import (  # type: ignore[import-untyped,attr-defined]
+    from cv2 import (
         BORDER_CONSTANT,
         CAP_PROP_FPS,
         CAP_PROP_FRAME_COUNT,
@@ -135,39 +135,39 @@ else:
             "OpenCV is not installed and this operation has no fallback yet."
         )
 
-    VideoCapture = _unavailable  # type: ignore[misc]
-    VideoWriter = _unavailable  # type: ignore[misc]
-    VideoWriter_fourcc = _unavailable  # type: ignore[misc]
-    addWeighted = _unavailable  # type: ignore[misc]
-    approxPolyDP = _unavailable  # type: ignore[misc]
-    blur = _unavailable  # type: ignore[misc]
-    circle = _unavailable  # type: ignore[misc]
-    connectedComponents = _unavailable  # type: ignore[misc]
-    connectedComponentsWithStats = _unavailable  # type: ignore[misc]
-    contourArea = _unavailable  # type: ignore[misc]
-    convertScaleAbs = _unavailable  # type: ignore[misc]
-    copyMakeBorder = _unavailable  # type: ignore[misc]
-    cvtColor = _unavailable  # type: ignore[misc]
-    distanceTransform = _unavailable  # type: ignore[misc]
-    drawContours = _unavailable  # type: ignore[misc]
-    ellipse = _unavailable  # type: ignore[misc]
-    fillPoly = _unavailable  # type: ignore[misc]
-    findContours = _unavailable  # type: ignore[misc]
-    flip = _unavailable  # type: ignore[misc]
-    getRotationMatrix2D = _unavailable  # type: ignore[misc]
-    getTextSize = _unavailable  # type: ignore[misc]
-    imread = _unavailable  # type: ignore[misc]
-    imwrite = _unavailable  # type: ignore[misc]
-    intersectConvexConvex = _unavailable  # type: ignore[misc]
-    line = _unavailable  # type: ignore[misc]
-    mean = _unavailable  # type: ignore[misc]
-    merge = _unavailable  # type: ignore[misc]
-    polylines = _unavailable  # type: ignore[misc]
-    putText = _unavailable  # type: ignore[misc]
-    rectangle = _unavailable  # type: ignore[misc]
-    resize = _unavailable  # type: ignore[misc]
-    split = _unavailable  # type: ignore[misc]
-    warpAffine = _unavailable  # type: ignore[misc]
+    VideoCapture = _unavailable
+    VideoWriter = _unavailable
+    VideoWriter_fourcc = _unavailable
+    addWeighted = _unavailable
+    approxPolyDP = _unavailable
+    blur = _unavailable
+    circle = _unavailable
+    connectedComponents = _unavailable
+    connectedComponentsWithStats = _unavailable
+    contourArea = _unavailable
+    convertScaleAbs = _unavailable
+    copyMakeBorder = _unavailable
+    cvtColor = _unavailable
+    distanceTransform = _unavailable
+    drawContours = _unavailable
+    ellipse = _unavailable
+    fillPoly = _unavailable
+    findContours = _unavailable
+    flip = _unavailable
+    getRotationMatrix2D = _unavailable
+    getTextSize = _unavailable
+    imread = _unavailable
+    imwrite = _unavailable
+    intersectConvexConvex = _unavailable
+    line = _unavailable
+    mean = _unavailable
+    merge = _unavailable
+    polylines = _unavailable
+    putText = _unavailable
+    rectangle = _unavailable
+    resize = _unavailable
+    split = _unavailable
+    warpAffine = _unavailable
 
 
 __all__ = [

--- a/src/supervision/_cv2/__init__.py
+++ b/src/supervision/_cv2/__init__.py
@@ -41,7 +41,7 @@ _RETR_CCOMP = 2
 _RETR_TREE = 3
 
 if _IS_CV2_AVAILABLE:
-    from cv2 import (
+    from cv2 import (  # type: ignore[import-untyped,attr-defined]
         BORDER_CONSTANT,
         CAP_PROP_FPS,
         CAP_PROP_FRAME_COUNT,
@@ -135,39 +135,39 @@ else:
             "OpenCV is not installed and this operation has no fallback yet."
         )
 
-    VideoCapture = _unavailable
-    VideoWriter = _unavailable
-    VideoWriter_fourcc = _unavailable
-    addWeighted = _unavailable
-    approxPolyDP = _unavailable
-    blur = _unavailable
-    circle = _unavailable
-    connectedComponents = _unavailable
-    connectedComponentsWithStats = _unavailable
-    contourArea = _unavailable
-    convertScaleAbs = _unavailable
-    copyMakeBorder = _unavailable
-    cvtColor = _unavailable
-    distanceTransform = _unavailable
-    drawContours = _unavailable
-    ellipse = _unavailable
-    fillPoly = _unavailable
-    findContours = _unavailable
-    flip = _unavailable
-    getRotationMatrix2D = _unavailable
-    getTextSize = _unavailable
-    imread = _unavailable
-    imwrite = _unavailable
-    intersectConvexConvex = _unavailable
-    line = _unavailable
-    mean = _unavailable
-    merge = _unavailable
-    polylines = _unavailable
-    putText = _unavailable
-    rectangle = _unavailable
-    resize = _unavailable
-    split = _unavailable
-    warpAffine = _unavailable
+    VideoCapture = _unavailable  # type: ignore[misc]
+    VideoWriter = _unavailable  # type: ignore[misc]
+    VideoWriter_fourcc = _unavailable  # type: ignore[misc]
+    addWeighted = _unavailable  # type: ignore[misc]
+    approxPolyDP = _unavailable  # type: ignore[misc]
+    blur = _unavailable  # type: ignore[misc]
+    circle = _unavailable  # type: ignore[misc]
+    connectedComponents = _unavailable  # type: ignore[misc]
+    connectedComponentsWithStats = _unavailable  # type: ignore[misc]
+    contourArea = _unavailable  # type: ignore[misc]
+    convertScaleAbs = _unavailable  # type: ignore[misc]
+    copyMakeBorder = _unavailable  # type: ignore[misc]
+    cvtColor = _unavailable  # type: ignore[misc]
+    distanceTransform = _unavailable  # type: ignore[misc]
+    drawContours = _unavailable  # type: ignore[misc]
+    ellipse = _unavailable  # type: ignore[misc]
+    fillPoly = _unavailable  # type: ignore[misc]
+    findContours = _unavailable  # type: ignore[misc]
+    flip = _unavailable  # type: ignore[misc]
+    getRotationMatrix2D = _unavailable  # type: ignore[misc]
+    getTextSize = _unavailable  # type: ignore[misc]
+    imread = _unavailable  # type: ignore[misc]
+    imwrite = _unavailable  # type: ignore[misc]
+    intersectConvexConvex = _unavailable  # type: ignore[misc]
+    line = _unavailable  # type: ignore[misc]
+    mean = _unavailable  # type: ignore[misc]
+    merge = _unavailable  # type: ignore[misc]
+    polylines = _unavailable  # type: ignore[misc]
+    putText = _unavailable  # type: ignore[misc]
+    rectangle = _unavailable  # type: ignore[misc]
+    resize = _unavailable  # type: ignore[misc]
+    split = _unavailable  # type: ignore[misc]
+    warpAffine = _unavailable  # type: ignore[misc]
 
 
 __all__ = [

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -3,13 +3,13 @@ from functools import lru_cache
 from math import sqrt
 from typing import Any, ClassVar, cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 from deprecate import deprecated, void  # type: ignore[import-untyped,unused-ignore]
 from PIL import Image, ImageDraw, ImageFont
 from scipy.interpolate import splev, splprep
 
+from supervision import _cv2 as cv2
 from supervision.annotators.base import BaseAnnotator
 from supervision.annotators.utils import (
     PENDING_TRACK_ID,
@@ -330,7 +330,7 @@ class OrientedBoxAnnotator(BaseAnnotator):
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from ultralytics import YOLO
 

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -1769,7 +1769,7 @@ class RichLabelAnnotator(_BaseLabelAnnotator):
         """
         _validate_labels(labels, detections)
 
-        draw = ImageDraw.Draw(scene)  # type: ignore[arg-type]
+        draw = ImageDraw.Draw(scene)
         labels = get_labels_text(detections, labels)
         label_properties: npt.NDArray[np.float32] = self._get_label_properties(
             draw, detections, labels

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -1769,7 +1769,7 @@ class RichLabelAnnotator(_BaseLabelAnnotator):
         """
         _validate_labels(labels, detections)
 
-        draw = ImageDraw.Draw(scene)
+        draw = ImageDraw.Draw(scene)  # type: ignore[arg-type]
         labels = get_labels_text(detections, labels)
         label_properties: npt.NDArray[np.float32] = self._get_label_properties(
             draw, detections, labels

--- a/src/supervision/classification/core.py
+++ b/src/supervision/classification/core.py
@@ -115,7 +115,7 @@ class Classifications:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             from ultralytics import YOLO
             import supervision as sv
 

--- a/src/supervision/dataset/core.py
+++ b/src/supervision/dataset/core.py
@@ -9,11 +9,11 @@ from itertools import chain
 from pathlib import Path
 from typing import cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 from tqdm.auto import tqdm
 
+from supervision import _cv2 as cv2
 from supervision.classification.core import Classifications
 from supervision.config import CLASS_NAME_DATA_FIELD
 from supervision.dataset.formats.coco import (

--- a/src/supervision/dataset/formats/pascal_voc.py
+++ b/src/supervision/dataset/formats/pascal_voc.py
@@ -6,13 +6,13 @@ from xml.etree.ElementTree import Element, SubElement
 if TYPE_CHECKING:
     from supervision.dataset.core import DetectionDataset
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 from defusedxml.ElementTree import parse, tostring
 from defusedxml.minidom import parseString
 from tqdm.auto import tqdm
 
+from supervision import _cv2 as cv2
 from supervision.dataset.utils import (
     approximate_mask_with_polygons,
     check_no_basename_collisions,

--- a/src/supervision/dataset/utils.py
+++ b/src/supervision/dataset/utils.py
@@ -10,12 +10,12 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar, cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 from deprecate import deprecated, void  # type: ignore[import-untyped,unused-ignore]
 from tqdm.auto import tqdm
 
+from supervision import _cv2 as cv2
 from supervision.detection.core import Detections
 from supervision.detection.utils.converters import mask_to_polygons
 from supervision.detection.utils.converters import (

--- a/src/supervision/detection/compact_mask.py
+++ b/src/supervision/detection/compact_mask.py
@@ -542,7 +542,7 @@ def _resize_crop(
     Returns:
         int32 RLE array for the resized crop.
     """
-    import cv2
+    from supervision import _cv2 as cv2
 
     # All-False: skip decode entirely.
     if _rle_area(rle) == 0:

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -100,7 +100,7 @@ class Detections:
         method, which accepts model results from both detection and segmentation models.
 
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
         import supervision as sv
         from inference import get_model
 
@@ -116,7 +116,7 @@ class Detections:
         method, which accepts model results from both detection and segmentation models.
 
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
         import supervision as sv
         from ultralytics import YOLO
 
@@ -275,7 +275,7 @@ class Detections:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import torch
             import supervision as sv
 
@@ -314,7 +314,7 @@ class Detections:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from ultralytics import YOLO
 
@@ -396,7 +396,7 @@ class Detections:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             from super_gradients.training import models
             import supervision as sv
 
@@ -451,7 +451,7 @@ class Detections:
             import tensorflow as tf
             import tensorflow_hub as hub
             import numpy as np
-            import cv2
+            from supervision import _cv2 as cv2
 
             module_handle = "https://tfhub.dev/tensorflow/centernet/hourglass_512x512_kpts/1"
             model = hub.load(module_handle)
@@ -528,7 +528,7 @@ class Detections:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from mmdet.apis import init_detector, inference_detector
 
@@ -648,7 +648,7 @@ class Detections:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from detectron2.engine import DefaultPredictor
             from detectron2.config import get_cfg
@@ -742,7 +742,7 @@ class Detections:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from inference import get_model
 
@@ -874,7 +874,7 @@ class Detections:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from inference.models.sam3 import SegmentAnything3
             from inference.core.entities.requests.sam3 import Sam3Prompt
@@ -2207,7 +2207,7 @@ class Detections:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             from ncnn.model_zoo import get_model
             import supervision as sv
 
@@ -2750,7 +2750,7 @@ class Detections:
 
         Example:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from ultralytics import YOLO
 
@@ -3329,7 +3329,7 @@ def merge_inner_detection_object_pair(
 
     Example:
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
         import supervision as sv
         from inference import get_model
 

--- a/src/supervision/detection/line_zone.py
+++ b/src/supervision/detection/line_zone.py
@@ -5,10 +5,10 @@ from collections.abc import Iterable
 from functools import lru_cache
 from typing import Literal
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 
+from supervision import _cv2 as cv2
 from supervision.config import CLASS_NAME_DATA_FIELD
 from supervision.detection.core import Detections
 from supervision.detection.utils.internal import cross_product

--- a/src/supervision/detection/tools/inference_slicer.py
+++ b/src/supervision/detection/tools/inference_slicer.py
@@ -183,7 +183,7 @@ class InferenceSlicer:
 
     Example:
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
         import supervision as sv
         from rfdetr import RFDETRMedium
 
@@ -237,7 +237,7 @@ class InferenceSlicer:
         that benefit from batched forward passes:
 
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
         import numpy as np
         import supervision as sv
 

--- a/src/supervision/detection/tools/polygon_zone.py
+++ b/src/supervision/detection/tools/polygon_zone.py
@@ -1,11 +1,11 @@
 from collections.abc import Iterable
 from typing import Any, cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 
 from supervision import Detections
+from supervision import _cv2 as cv2
 from supervision.detection.utils.converters import polygon_to_mask
 from supervision.draw.color import Color
 from supervision.draw.utils import draw_filled_polygon, draw_polygon, draw_text

--- a/src/supervision/detection/utils/converters.py
+++ b/src/supervision/detection/utils/converters.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Literal, cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
+
+from supervision import _cv2 as cv2
 
 MIN_POLYGON_POINT_COUNT = 3
 CoordinateConvention = Literal["inclusive", "exclusive"]

--- a/src/supervision/detection/utils/internal.py
+++ b/src/supervision/detection/utils/internal.py
@@ -2,10 +2,10 @@ import logging
 from itertools import chain
 from typing import Any, Literal, cast, overload
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 
+from supervision import _cv2 as cv2
 from supervision.config import CLASS_NAME_DATA_FIELD
 from supervision.detection.compact_mask import CompactMask
 from supervision.detection.utils._typing import _DetectionDataType, _MetadataType

--- a/src/supervision/detection/utils/iou_and_nms.py
+++ b/src/supervision/detection/utils/iou_and_nms.py
@@ -5,10 +5,10 @@ from collections.abc import Callable, Sequence
 from enum import Enum
 from typing import Any, cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 
+from supervision import _cv2 as cv2
 from supervision.detection.compact_mask import CompactMask
 from supervision.detection.utils.converters import mask_to_xyxy
 from supervision.utils.internal import warn_deprecated

--- a/src/supervision/detection/utils/masks.py
+++ b/src/supervision/detection/utils/masks.py
@@ -1,9 +1,9 @@
 from typing import Any, Literal, cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 
+from supervision import _cv2 as cv2
 from supervision.detection.compact_mask import CompactMask
 
 

--- a/src/supervision/detection/utils/polygons.py
+++ b/src/supervision/detection/utils/polygons.py
@@ -1,6 +1,7 @@
-import cv2
 import numpy as np
 import numpy.typing as npt
+
+from supervision import _cv2 as cv2
 
 
 def filter_polygons_by_area(

--- a/src/supervision/detection/utils/polygons.py
+++ b/src/supervision/detection/utils/polygons.py
@@ -45,7 +45,7 @@ def filter_polygons_by_area(
     """
     if min_area is None and max_area is None:
         return polygons
-    ares = [cv2.contourArea(polygon) for polygon in polygons]  # type: ignore[arg-type]
+    ares = [cv2.contourArea(polygon) for polygon in polygons]
     return [
         polygon
         for polygon, area in zip(polygons, ares)
@@ -119,7 +119,7 @@ def approximate_polygon(
     approximated_points = polygon
     while len(approximated_points) > target_points:
         epsilon += epsilon_step
-        candidate = np.squeeze(cv2.approxPolyDP(polygon, epsilon, closed=True), axis=1)  # type: ignore[arg-type]
+        candidate = np.squeeze(cv2.approxPolyDP(polygon, epsilon, closed=True), axis=1)
         # Stop before the approximation collapses below a valid polygon; keep the
         # last result with at least three points.
         if len(candidate) < 3:

--- a/src/supervision/detection/utils/polygons.py
+++ b/src/supervision/detection/utils/polygons.py
@@ -45,7 +45,7 @@ def filter_polygons_by_area(
     """
     if min_area is None and max_area is None:
         return polygons
-    ares = [cv2.contourArea(polygon) for polygon in polygons]
+    ares = [cv2.contourArea(polygon) for polygon in polygons]  # type: ignore[arg-type]
     return [
         polygon
         for polygon, area in zip(polygons, ares)
@@ -119,7 +119,7 @@ def approximate_polygon(
     approximated_points = polygon
     while len(approximated_points) > target_points:
         epsilon += epsilon_step
-        candidate = np.squeeze(cv2.approxPolyDP(polygon, epsilon, closed=True), axis=1)
+        candidate = np.squeeze(cv2.approxPolyDP(polygon, epsilon, closed=True), axis=1)  # type: ignore[arg-type]
         # Stop before the approximation collapses below a valid polygon; keep the
         # last result with at least three points.
         if len(candidate) < 3:

--- a/src/supervision/draw/utils.py
+++ b/src/supervision/draw/utils.py
@@ -1,10 +1,10 @@
 import os
 from typing import cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 
+from supervision import _cv2 as cv2
 from supervision.draw.color import Color
 from supervision.geometry.core import Point, Rect
 

--- a/src/supervision/key_points/annotators.py
+++ b/src/supervision/key_points/annotators.py
@@ -109,7 +109,7 @@ class VertexAnnotator(BaseKeyPointAnnotator):
                     and not key_points.visible[detection_index, point_index]
                 ):
                     continue
-                cv2.circle(  # type: ignore[call-overload]
+                cv2.circle(
                     img=scene,
                     center=(int(x), int(y)),
                     radius=self.radius,
@@ -260,7 +260,7 @@ class EdgeAnnotator(BaseKeyPointAnnotator):
                     ):
                         continue
 
-                cv2.line(  # type: ignore[call-overload]
+                cv2.line(
                     img=scene,
                     pt1=(int(xy_a[0]), int(xy_a[1])),
                     pt2=(int(xy_b[0]), int(xy_b[1])),
@@ -467,7 +467,7 @@ class VertexEllipseAreaAnnotator(_BaseVertexEllipseAnnotator):
         overlay = scene.copy()
         for level in self._iter_ellipse_params(key_points):
             for center, axis_lengths, angle, _sigma, color in level:
-                cv2.ellipse(  # type: ignore[call-overload]
+                cv2.ellipse(
                     img=overlay,
                     center=center,
                     axes=axis_lengths,
@@ -479,7 +479,7 @@ class VertexEllipseAreaAnnotator(_BaseVertexEllipseAnnotator):
                     lineType=cv2.LINE_AA,
                 )
 
-        cv2.addWeighted(overlay, self.opacity, scene, 1 - self.opacity, 0, dst=scene)  # type: ignore[call-overload]
+        cv2.addWeighted(overlay, self.opacity, scene, 1 - self.opacity, 0, dst=scene)
         return scene
 
 
@@ -567,7 +567,7 @@ class VertexEllipseOutlineAnnotator(_BaseVertexEllipseAnnotator):
 
         for level in self._iter_ellipse_params(key_points):
             for center, axis_lengths, angle, _sigma, color in level:
-                cv2.ellipse(  # type: ignore[call-overload]
+                cv2.ellipse(
                     img=scene,
                     center=center,
                     axes=axis_lengths,
@@ -668,8 +668,8 @@ class VertexEllipseHaloAnnotator(_BaseVertexEllipseAnnotator):
         if len(key_points) == 0:
             return scene
 
-        h, w = scene.shape[:2]  # type: ignore[attr-defined]
-        composite: npt.NDArray[np.float32] = scene.astype(np.float32)  # type: ignore[attr-defined]
+        h, w = scene.shape[:2]
+        composite: npt.NDArray[np.float32] = scene.astype(np.float32)
 
         for level in self._iter_ellipse_params(key_points):
             for center, axis_lengths, angle, _sigma, color in level:
@@ -712,7 +712,7 @@ class VertexEllipseHaloAnnotator(_BaseVertexEllipseAnnotator):
                 alpha_3 = scaled_alpha[:, :, np.newaxis]
                 roi[:] = roi * (1 - alpha_3) + bgr * alpha_3
 
-        np.copyto(scene, composite.astype(np.uint8))  # type: ignore[arg-type]
+        np.copyto(scene, composite.astype(np.uint8))
         return scene
 
 
@@ -908,12 +908,12 @@ class VertexLabelAnnotator:
             all_labels, all_colors, all_text_colors, xyxy, xyxy_padded
         ):
             draw_rounded_rectangle(
-                scene=scene,  # type: ignore[arg-type]
+                scene=scene,
                 rect=Rect.from_xyxy(box_padded),
                 color=color,
                 border_radius=self.border_radius,
             )
-            cv2.putText(  # type: ignore[call-overload]
+            cv2.putText(
                 img=scene,
                 text=text,
                 org=(box[0], box[3]),

--- a/src/supervision/key_points/annotators.py
+++ b/src/supervision/key_points/annotators.py
@@ -109,7 +109,7 @@ class VertexAnnotator(BaseKeyPointAnnotator):
                     and not key_points.visible[detection_index, point_index]
                 ):
                     continue
-                cv2.circle(
+                cv2.circle(  # type: ignore[call-overload]
                     img=scene,
                     center=(int(x), int(y)),
                     radius=self.radius,
@@ -260,7 +260,7 @@ class EdgeAnnotator(BaseKeyPointAnnotator):
                     ):
                         continue
 
-                cv2.line(
+                cv2.line(  # type: ignore[call-overload]
                     img=scene,
                     pt1=(int(xy_a[0]), int(xy_a[1])),
                     pt2=(int(xy_b[0]), int(xy_b[1])),
@@ -467,7 +467,7 @@ class VertexEllipseAreaAnnotator(_BaseVertexEllipseAnnotator):
         overlay = scene.copy()
         for level in self._iter_ellipse_params(key_points):
             for center, axis_lengths, angle, _sigma, color in level:
-                cv2.ellipse(
+                cv2.ellipse(  # type: ignore[call-overload]
                     img=overlay,
                     center=center,
                     axes=axis_lengths,
@@ -479,7 +479,7 @@ class VertexEllipseAreaAnnotator(_BaseVertexEllipseAnnotator):
                     lineType=cv2.LINE_AA,
                 )
 
-        cv2.addWeighted(overlay, self.opacity, scene, 1 - self.opacity, 0, dst=scene)
+        cv2.addWeighted(overlay, self.opacity, scene, 1 - self.opacity, 0, dst=scene)  # type: ignore[call-overload]
         return scene
 
 
@@ -567,7 +567,7 @@ class VertexEllipseOutlineAnnotator(_BaseVertexEllipseAnnotator):
 
         for level in self._iter_ellipse_params(key_points):
             for center, axis_lengths, angle, _sigma, color in level:
-                cv2.ellipse(
+                cv2.ellipse(  # type: ignore[call-overload]
                     img=scene,
                     center=center,
                     axes=axis_lengths,
@@ -668,8 +668,8 @@ class VertexEllipseHaloAnnotator(_BaseVertexEllipseAnnotator):
         if len(key_points) == 0:
             return scene
 
-        h, w = scene.shape[:2]
-        composite: npt.NDArray[np.float32] = scene.astype(np.float32)
+        h, w = scene.shape[:2]  # type: ignore[attr-defined]
+        composite: npt.NDArray[np.float32] = scene.astype(np.float32)  # type: ignore[attr-defined]
 
         for level in self._iter_ellipse_params(key_points):
             for center, axis_lengths, angle, _sigma, color in level:
@@ -712,7 +712,7 @@ class VertexEllipseHaloAnnotator(_BaseVertexEllipseAnnotator):
                 alpha_3 = scaled_alpha[:, :, np.newaxis]
                 roi[:] = roi * (1 - alpha_3) + bgr * alpha_3
 
-        np.copyto(scene, composite.astype(np.uint8))
+        np.copyto(scene, composite.astype(np.uint8))  # type: ignore[arg-type]
         return scene
 
 
@@ -908,12 +908,12 @@ class VertexLabelAnnotator:
             all_labels, all_colors, all_text_colors, xyxy, xyxy_padded
         ):
             draw_rounded_rectangle(
-                scene=scene,
+                scene=scene,  # type: ignore[arg-type]
                 rect=Rect.from_xyxy(box_padded),
                 color=color,
                 border_radius=self.border_radius,
             )
-            cv2.putText(
+            cv2.putText(  # type: ignore[call-overload]
                 img=scene,
                 text=text,
                 org=(box[0], box[3]),

--- a/src/supervision/key_points/annotators.py
+++ b/src/supervision/key_points/annotators.py
@@ -2,10 +2,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 
+from supervision import _cv2 as cv2
 from supervision.detection.utils.boxes import pad_boxes, spread_out_boxes
 from supervision.draw.base import ImageType
 from supervision.draw.color import Color

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -83,7 +83,7 @@ class KeyPoints:
         conversion is needed.
 
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
         import supervision as sv
         from rfdetr import RFDETRKeypointPreview
 
@@ -100,7 +100,7 @@ class KeyPoints:
         [pose](https://docs.ultralytics.com/tasks/pose/) result.
 
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
         import supervision as sv
         from ultralytics import YOLO
 
@@ -117,7 +117,7 @@ class KeyPoints:
         method, which accepts [Inference](https://inference.roboflow.com/) pose result.
 
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
         import supervision as sv
         from inference import get_model
 
@@ -136,7 +136,7 @@ class KeyPoints:
 
 
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
         import mediapipe as mp
         import supervision as sv
 
@@ -398,7 +398,7 @@ class KeyPoints:
 
         Examples:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from inference import get_model
 
@@ -410,7 +410,7 @@ class KeyPoints:
             ```
 
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from inference_sdk import InferenceHTTPClient
 
@@ -489,7 +489,7 @@ class KeyPoints:
 
         Examples:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import mediapipe as mp
             import supervision as sv
 
@@ -515,7 +515,7 @@ class KeyPoints:
             ```
 
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import mediapipe as mp
             import supervision as sv
 
@@ -610,7 +610,7 @@ class KeyPoints:
 
         Examples:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from ultralytics import YOLO
 
@@ -647,7 +647,7 @@ class KeyPoints:
 
         Examples:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import torch
             import supervision as sv
             import super_gradients
@@ -706,7 +706,7 @@ class KeyPoints:
 
         Examples:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from detectron2.engine import DefaultPredictor
             from detectron2.config import get_cfg
@@ -1112,7 +1112,7 @@ class KeyPoints:
 
         Examples:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from ultralytics import YOLO
 
@@ -1323,7 +1323,7 @@ class KeyPoints:
 
         Examples:
             ```python
-            import cv2
+            from supervision import _cv2 as cv2
             import supervision as sv
             from rfdetr import RFDETRKeypointPreview
 

--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -453,8 +453,9 @@ def _annotate_detection_panel(
     Returns:
         Annotated copy of ``scene`` as a ``np.uint8`` array.
     """
-    import cv2  # lazy: only needed when save_directory_path is set
-
+    from supervision import (
+        _cv2 as cv2,  # lazy: only needed when save_directory_path is set
+    )
     from supervision.annotators.core import BoxAnnotator, LabelAnnotator
     from supervision.annotators.utils import ColorLookup
     from supervision.draw.color import ColorPalette
@@ -543,7 +544,9 @@ def _save_detection_validation_visualization(
         class_names: Optional list mapping class integer ids to name strings.
         metric_target: Coordinate representation used for IoU matching.
     """
-    import cv2  # lazy: only needed when save_directory_path is set
+    from supervision import (
+        _cv2 as cv2,  # lazy: only needed when save_directory_path is set
+    )
 
     tp_predictions, fp_predictions, fn_targets = _split_detections_by_outcome(
         predictions=predictions,

--- a/src/supervision/utils/conversion.py
+++ b/src/supervision/utils/conversion.py
@@ -2,12 +2,12 @@ import functools
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 from deprecate import deprecated, void  # type: ignore[import-untyped,unused-ignore]
 from PIL import Image
 
+from supervision import _cv2 as cv2
 from supervision.draw.base import ImageType
 
 F = TypeVar("F", bound=Callable[..., Any])

--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -88,10 +88,10 @@ def crop_image(
 
     if isinstance(image, np.ndarray):
         height, width = image.shape[:2]
-        x_min = int(np.clip(x_min, 0, width))  # type: ignore[assignment]
-        y_min = int(np.clip(y_min, 0, height))  # type: ignore[assignment]
-        x_max = int(np.clip(x_max, 0, width))  # type: ignore[assignment]
-        y_max = int(np.clip(y_max, 0, height))  # type: ignore[assignment]
+        x_min = int(np.clip(x_min, 0, width))
+        y_min = int(np.clip(y_min, 0, height))
+        x_max = int(np.clip(x_max, 0, width))
+        y_max = int(np.clip(y_max, 0, height))
         return image[y_min:y_max, x_min:x_max]
 
     if isinstance(image, Image.Image):
@@ -152,12 +152,12 @@ def scale_image(image: ImageType, scale_factor: float) -> ImageType:
     if scale_factor <= 0:
         raise ValueError("Scale factor must be positive.")
 
-    width_old, height_old = image.shape[1], image.shape[0]  # type: ignore[attr-defined]
+    width_old, height_old = image.shape[1], image.shape[0]
     width_new = int(width_old * scale_factor)
     height_new = int(height_old * scale_factor)
     return cast(
         npt.NDArray[np.uint8],
-        cv2.resize(image, (width_new, height_new), interpolation=cv2.INTER_LINEAR),  # type: ignore[arg-type]
+        cv2.resize(image, (width_new, height_new), interpolation=cv2.INTER_LINEAR),
     )
 
 

--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -9,7 +9,6 @@ from functools import partial
 from types import TracebackType
 from typing import Literal, cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 from deprecate import (  # type: ignore[import-untyped,unused-ignore]
@@ -18,6 +17,7 @@ from deprecate import (  # type: ignore[import-untyped,unused-ignore]
 )
 from PIL import Image
 
+from supervision import _cv2 as cv2
 from supervision.draw.base import ImageType
 from supervision.draw.color import Color, unify_to_bgr
 from supervision.draw.utils import calculate_optimal_text_scale, draw_text

--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -88,10 +88,10 @@ def crop_image(
 
     if isinstance(image, np.ndarray):
         height, width = image.shape[:2]
-        x_min = int(np.clip(x_min, 0, width))
-        y_min = int(np.clip(y_min, 0, height))
-        x_max = int(np.clip(x_max, 0, width))
-        y_max = int(np.clip(y_max, 0, height))
+        x_min = int(np.clip(x_min, 0, width))  # type: ignore[assignment]
+        y_min = int(np.clip(y_min, 0, height))  # type: ignore[assignment]
+        x_max = int(np.clip(x_max, 0, width))  # type: ignore[assignment]
+        y_max = int(np.clip(y_max, 0, height))  # type: ignore[assignment]
         return image[y_min:y_max, x_min:x_max]
 
     if isinstance(image, Image.Image):
@@ -152,12 +152,12 @@ def scale_image(image: ImageType, scale_factor: float) -> ImageType:
     if scale_factor <= 0:
         raise ValueError("Scale factor must be positive.")
 
-    width_old, height_old = image.shape[1], image.shape[0]
+    width_old, height_old = image.shape[1], image.shape[0]  # type: ignore[attr-defined]
     width_new = int(width_old * scale_factor)
     height_new = int(height_old * scale_factor)
     return cast(
         npt.NDArray[np.uint8],
-        cv2.resize(image, (width_new, height_new), interpolation=cv2.INTER_LINEAR),
+        cv2.resize(image, (width_new, height_new), interpolation=cv2.INTER_LINEAR),  # type: ignore[arg-type]
     )
 
 

--- a/src/supervision/utils/notebook.py
+++ b/src/supervision/utils/notebook.py
@@ -1,8 +1,8 @@
-import cv2
 import numpy as np
 import numpy.typing as npt
 from PIL import Image
 
+from supervision import _cv2 as cv2
 from supervision.draw.base import ImageType
 from supervision.utils.conversion import pillow_to_cv2
 

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -13,11 +13,11 @@ from queue import Empty, Full, Queue
 from types import TracebackType
 from typing import cast
 
-import cv2
 import numpy as np
 import numpy.typing as npt
 from tqdm.auto import tqdm
 
+from supervision import _cv2 as cv2
 from supervision.utils.logger import _get_logger
 
 logger = _get_logger(__name__)
@@ -293,7 +293,7 @@ def get_video_frames_generator(
         sources; `cv2.VideoCapture` must be released by the caller when done:
 
         ```python
-        import cv2
+        from supervision import _cv2 as cv2
 
         cap = cv2.VideoCapture(0)  # 0 = default webcam
         try:

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -6,12 +6,12 @@ import warnings
 from collections.abc import Iterator
 from typing import Any, cast
 
-import cv2
 import numpy as np
 import pytest
 from PIL import Image
 
 import supervision.annotators.core as annotators_core
+from supervision import _cv2 as cv2
 from supervision.annotators.base import BaseAnnotator
 from supervision.annotators.core import (
     BackgroundOverlayAnnotator,

--- a/tests/cv2/__init__.py
+++ b/tests/cv2/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the private media backend boundary."""

--- a/tests/cv2/test_cv2.py
+++ b/tests/cv2/test_cv2.py
@@ -1,0 +1,185 @@
+"""Tests for the private OpenCV compatibility surface."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from supervision import _cv2
+
+REQUIRED_SYMBOLS = {
+    "BORDER_CONSTANT",
+    "CAP_PROP_FPS",
+    "CAP_PROP_FRAME_COUNT",
+    "CAP_PROP_FRAME_HEIGHT",
+    "CAP_PROP_FRAME_WIDTH",
+    "CAP_PROP_POS_FRAMES",
+    "CC_STAT_AREA",
+    "CHAIN_APPROX_SIMPLE",
+    "COLOR_BGR2GRAY",
+    "COLOR_BGR2RGB",
+    "COLOR_GRAY2BGR",
+    "COLOR_HSV2BGR",
+    "COLOR_RGB2BGR",
+    "DIST_L2",
+    "FONT_HERSHEY_SIMPLEX",
+    "IMREAD_COLOR",
+    "IMREAD_UNCHANGED",
+    "INTER_LINEAR",
+    "INTER_NEAREST",
+    "LINE_4",
+    "LINE_AA",
+    "RETR_CCOMP",
+    "RETR_TREE",
+    "VideoCapture",
+    "VideoWriter",
+    "VideoWriter_fourcc",
+    "addWeighted",
+    "approxPolyDP",
+    "blur",
+    "circle",
+    "connectedComponents",
+    "connectedComponentsWithStats",
+    "contourArea",
+    "convertScaleAbs",
+    "copyMakeBorder",
+    "cvtColor",
+    "distanceTransform",
+    "drawContours",
+    "ellipse",
+    "fillPoly",
+    "findContours",
+    "flip",
+    "getRotationMatrix2D",
+    "getTextSize",
+    "imread",
+    "imwrite",
+    "intersectConvexConvex",
+    "line",
+    "mean",
+    "merge",
+    "polylines",
+    "putText",
+    "rectangle",
+    "resize",
+    "split",
+    "warpAffine",
+}
+
+OPENCV_CONSTANTS = {
+    "BORDER_CONSTANT": cv2.BORDER_CONSTANT,
+    "CAP_PROP_FPS": cv2.CAP_PROP_FPS,
+    "CAP_PROP_FRAME_COUNT": cv2.CAP_PROP_FRAME_COUNT,
+    "CAP_PROP_FRAME_HEIGHT": cv2.CAP_PROP_FRAME_HEIGHT,
+    "CAP_PROP_FRAME_WIDTH": cv2.CAP_PROP_FRAME_WIDTH,
+    "CAP_PROP_POS_FRAMES": cv2.CAP_PROP_POS_FRAMES,
+    "CC_STAT_AREA": cv2.CC_STAT_AREA,
+    "CHAIN_APPROX_SIMPLE": cv2.CHAIN_APPROX_SIMPLE,
+    "COLOR_BGR2GRAY": cv2.COLOR_BGR2GRAY,
+    "COLOR_BGR2RGB": cv2.COLOR_BGR2RGB,
+    "COLOR_GRAY2BGR": cv2.COLOR_GRAY2BGR,
+    "COLOR_HSV2BGR": cv2.COLOR_HSV2BGR,
+    "COLOR_RGB2BGR": cv2.COLOR_RGB2BGR,
+    "DIST_L2": cv2.DIST_L2,
+    "FONT_HERSHEY_SIMPLEX": cv2.FONT_HERSHEY_SIMPLEX,
+    "IMREAD_COLOR": cv2.IMREAD_COLOR,
+    "IMREAD_UNCHANGED": cv2.IMREAD_UNCHANGED,
+    "INTER_LINEAR": cv2.INTER_LINEAR,
+    "INTER_NEAREST": cv2.INTER_NEAREST,
+    "LINE_4": cv2.LINE_4,
+    "LINE_AA": cv2.LINE_AA,
+    "RETR_CCOMP": cv2.RETR_CCOMP,
+    "RETR_TREE": cv2.RETR_TREE,
+}
+
+
+def test_facade_exports_the_required_opencv_surface() -> None:
+    """Expose every OpenCV symbol used by production call sites."""
+    assert REQUIRED_SYMBOLS <= set(_cv2.__all__)
+    assert all(hasattr(_cv2, symbol) for symbol in REQUIRED_SYMBOLS)
+    assert _cv2.BACKEND_NAME == "opencv"
+
+
+def test_facade_constants_match_opencv() -> None:
+    """Keep compatibility constants aligned with the OpenCV reference."""
+    facade_constants = {name: getattr(_cv2, name) for name in OPENCV_CONSTANTS}
+
+    assert facade_constants == OPENCV_CONSTANTS
+
+
+def test_facade_calls_the_package_imported_surface() -> None:
+    """Route production-style calls through the Supervision facade."""
+    image = np.array([[[10, 20, 30], [40, 50, 60]]], dtype=np.uint8)
+
+    np.testing.assert_array_equal(
+        _cv2.cvtColor(image, _cv2.COLOR_BGR2RGB),
+        cv2.cvtColor(image, cv2.COLOR_BGR2RGB),
+    )
+    np.testing.assert_array_equal(
+        _cv2.resize(image, (4, 2), interpolation=_cv2.INTER_NEAREST),
+        cv2.resize(image, (4, 2), interpolation=cv2.INTER_NEAREST),
+    )
+
+
+def test_facade_imports_without_opencv() -> None:
+    """Keep fallback imports and constants valid when cv2 is unavailable."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    code = f"""
+import sys
+
+
+class BlockCv2:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "cv2":
+            raise ModuleNotFoundError("blocked for test")
+        return None
+
+
+sys.meta_path.insert(0, BlockCv2())
+from supervision import _cv2
+
+assert _cv2._IS_CV2_AVAILABLE is False
+assert _cv2.BACKEND_NAME == "fallback"
+expected = {OPENCV_CONSTANTS!r}
+actual = {{name: getattr(_cv2, name) for name in expected}}
+assert actual == expected
+try:
+    _cv2.resize(None, (1, 1), interpolation=_cv2.INTER_NEAREST)
+except _cv2.BackendUnavailableError:
+    pass
+else:
+    raise AssertionError("missing OpenCV must fail explicitly")
+"""
+    subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        check=True,
+        env=env,
+    )
+
+
+def test_facade_does_not_hide_a_breaking_opencv_import() -> None:
+    """Raise when cv2 imports but no longer exposes a required symbol."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    code = """
+import sys
+import types
+
+sys.modules["cv2"] = types.ModuleType("cv2")
+from supervision import _cv2
+"""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    assert "cannot import name" in result.stderr

--- a/tests/cv2/test_cv2.py
+++ b/tests/cv2/test_cv2.py
@@ -115,10 +115,7 @@ def test_facade_exports_the_required_opencv_surface() -> None:
     assert _cv2.BACKEND_NAME == "opencv"
 
 
-@pytest.mark.parametrize(
-    "name",
-    OPENCV_CONSTANTS
-)
+@pytest.mark.parametrize("name", OPENCV_CONSTANTS)
 def test_fallback_constant_matches_opencv(name: str) -> None:
     """Keep each private fallback constant aligned with the OpenCV reference."""
     actual = getattr(_cv2, f"_{name}")

--- a/tests/cv2/test_cv2.py
+++ b/tests/cv2/test_cv2.py
@@ -22,7 +22,8 @@ except (ImportError, OSError):
         allow_module_level=True,
     )
 
-REQUIRED_SYMBOLS = {
+
+OPENCV_CONSTANTS = [
     "BORDER_CONSTANT",
     "CAP_PROP_FPS",
     "CAP_PROP_FRAME_COUNT",
@@ -46,6 +47,9 @@ REQUIRED_SYMBOLS = {
     "LINE_AA",
     "RETR_CCOMP",
     "RETR_TREE",
+]
+
+REQUIRED_SYMBOLS = {
     "VideoCapture",
     "VideoWriter",
     "VideoWriter_fourcc",
@@ -79,33 +83,7 @@ REQUIRED_SYMBOLS = {
     "resize",
     "split",
     "warpAffine",
-}
-
-OPENCV_CONSTANTS = [
-    "BORDER_CONSTANT",
-    "CAP_PROP_FPS",
-    "CAP_PROP_FRAME_COUNT",
-    "CAP_PROP_FRAME_HEIGHT",
-    "CAP_PROP_FRAME_WIDTH",
-    "CAP_PROP_POS_FRAMES",
-    "CC_STAT_AREA",
-    "CHAIN_APPROX_SIMPLE",
-    "COLOR_BGR2GRAY",
-    "COLOR_BGR2RGB",
-    "COLOR_GRAY2BGR",
-    "COLOR_HSV2BGR",
-    "COLOR_RGB2BGR",
-    "DIST_L2",
-    "FONT_HERSHEY_SIMPLEX",
-    "IMREAD_COLOR",
-    "IMREAD_UNCHANGED",
-    "INTER_LINEAR",
-    "INTER_NEAREST",
-    "LINE_4",
-    "LINE_AA",
-    "RETR_CCOMP",
-    "RETR_TREE",
-]
+} | set(OPENCV_CONSTANTS)
 
 
 def test_facade_exports_the_required_opencv_surface() -> None:
@@ -115,10 +93,7 @@ def test_facade_exports_the_required_opencv_surface() -> None:
     assert _cv2.BACKEND_NAME == "opencv"
 
 
-@pytest.mark.parametrize(
-    "name",
-    OPENCV_CONSTANTS
-)
+@pytest.mark.parametrize("name", OPENCV_CONSTANTS)
 def test_fallback_constant_matches_opencv(name: str) -> None:
     """Keep each private fallback constant aligned with the OpenCV reference."""
     actual = getattr(_cv2, f"_{name}")

--- a/tests/cv2/test_cv2.py
+++ b/tests/cv2/test_cv2.py
@@ -81,31 +81,31 @@ REQUIRED_SYMBOLS = {
     "warpAffine",
 }
 
-OPENCV_CONSTANTS = {
-    "BORDER_CONSTANT": cv2.BORDER_CONSTANT,
-    "CAP_PROP_FPS": cv2.CAP_PROP_FPS,
-    "CAP_PROP_FRAME_COUNT": cv2.CAP_PROP_FRAME_COUNT,
-    "CAP_PROP_FRAME_HEIGHT": cv2.CAP_PROP_FRAME_HEIGHT,
-    "CAP_PROP_FRAME_WIDTH": cv2.CAP_PROP_FRAME_WIDTH,
-    "CAP_PROP_POS_FRAMES": cv2.CAP_PROP_POS_FRAMES,
-    "CC_STAT_AREA": cv2.CC_STAT_AREA,
-    "CHAIN_APPROX_SIMPLE": cv2.CHAIN_APPROX_SIMPLE,
-    "COLOR_BGR2GRAY": cv2.COLOR_BGR2GRAY,
-    "COLOR_BGR2RGB": cv2.COLOR_BGR2RGB,
-    "COLOR_GRAY2BGR": cv2.COLOR_GRAY2BGR,
-    "COLOR_HSV2BGR": cv2.COLOR_HSV2BGR,
-    "COLOR_RGB2BGR": cv2.COLOR_RGB2BGR,
-    "DIST_L2": cv2.DIST_L2,
-    "FONT_HERSHEY_SIMPLEX": cv2.FONT_HERSHEY_SIMPLEX,
-    "IMREAD_COLOR": cv2.IMREAD_COLOR,
-    "IMREAD_UNCHANGED": cv2.IMREAD_UNCHANGED,
-    "INTER_LINEAR": cv2.INTER_LINEAR,
-    "INTER_NEAREST": cv2.INTER_NEAREST,
-    "LINE_4": cv2.LINE_4,
-    "LINE_AA": cv2.LINE_AA,
-    "RETR_CCOMP": cv2.RETR_CCOMP,
-    "RETR_TREE": cv2.RETR_TREE,
-}
+OPENCV_CONSTANTS = [
+    "BORDER_CONSTANT",
+    "CAP_PROP_FPS",
+    "CAP_PROP_FRAME_COUNT",
+    "CAP_PROP_FRAME_HEIGHT",
+    "CAP_PROP_FRAME_WIDTH",
+    "CAP_PROP_POS_FRAMES",
+    "CC_STAT_AREA",
+    "CHAIN_APPROX_SIMPLE",
+    "COLOR_BGR2GRAY",
+    "COLOR_BGR2RGB",
+    "COLOR_GRAY2BGR",
+    "COLOR_HSV2BGR",
+    "COLOR_RGB2BGR",
+    "DIST_L2",
+    "FONT_HERSHEY_SIMPLEX",
+    "IMREAD_COLOR",
+    "IMREAD_UNCHANGED",
+    "INTER_LINEAR",
+    "INTER_NEAREST",
+    "LINE_4",
+    "LINE_AA",
+    "RETR_CCOMP",
+    "RETR_TREE",
+]
 
 
 def test_facade_exports_the_required_opencv_surface() -> None:
@@ -115,11 +115,16 @@ def test_facade_exports_the_required_opencv_surface() -> None:
     assert _cv2.BACKEND_NAME == "opencv"
 
 
-def test_facade_constants_match_opencv() -> None:
-    """Keep compatibility constants aligned with the OpenCV reference."""
-    facade_constants = {name: getattr(_cv2, name) for name in OPENCV_CONSTANTS}
+@pytest.mark.parametrize(
+    "name",
+    OPENCV_CONSTANTS
+)
+def test_fallback_constant_matches_opencv(name: str) -> None:
+    """Keep each private fallback constant aligned with the OpenCV reference."""
+    actual = getattr(_cv2, f"_{name}")
+    expected = getattr(cv2, name)
 
-    assert facade_constants == OPENCV_CONSTANTS
+    assert actual == expected
 
 
 def test_facade_calls_the_package_imported_surface() -> None:
@@ -143,6 +148,7 @@ def test_facade_imports_without_opencv() -> None:
     env["PYTHONPATH"] = os.pathsep.join(
         filter(None, (source_path, env.get("PYTHONPATH")))
     )
+    expected_constants = {name: getattr(cv2, name) for name in OPENCV_CONSTANTS}
     code = f"""
 import sys
 
@@ -159,8 +165,10 @@ from supervision import _cv2
 
 assert _cv2._IS_CV2_AVAILABLE is False
 assert _cv2.BACKEND_NAME == "fallback"
-expected = {OPENCV_CONSTANTS!r}
+expected = {expected_constants!r}
 actual = {{name: getattr(_cv2, name) for name in expected}}
+fallback = {{name: getattr(_cv2, f"_{{name}}") for name in expected}}
+assert fallback == expected
 assert actual == expected
 try:
     _cv2.resize(None, (1, 1), interpolation=_cv2.INTER_NEAREST)

--- a/tests/cv2/test_cv2.py
+++ b/tests/cv2/test_cv2.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 import subprocess
 import sys
 from pathlib import Path
 
-import cv2
 import numpy as np
+import pytest
 
 from supervision import _cv2
+
+# Use the real OpenCV module as the oracle for compatibility comparisons.
+try:
+    cv2 = importlib.import_module("cv2")
+except (ImportError, OSError):
+    pytest.skip(
+        "OpenCV is required as the reference implementation for this test module",
+        allow_module_level=True,
+    )
 
 REQUIRED_SYMBOLS = {
     "BORDER_CONSTANT",

--- a/tests/cv2/test_cv2.py
+++ b/tests/cv2/test_cv2.py
@@ -139,7 +139,10 @@ def test_facade_calls_the_package_imported_surface() -> None:
 def test_facade_imports_without_opencv() -> None:
     """Keep fallback imports and constants valid when cv2 is unavailable."""
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    source_path = str(Path(__file__).resolve().parents[2] / "src")
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (source_path, env.get("PYTHONPATH")))
+    )
     code = f"""
 import sys
 
@@ -176,7 +179,10 @@ else:
 def test_facade_does_not_hide_a_breaking_opencv_import() -> None:
     """Raise when cv2 imports but no longer exposes a required symbol."""
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    source_path = str(Path(__file__).resolve().parents[2] / "src")
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (source_path, env.get("PYTHONPATH")))
+    )
     code = """
 import sys
 import types

--- a/tests/utils/test_image.py
+++ b/tests/utils/test_image.py
@@ -1,10 +1,10 @@
 import warnings
 
-import cv2
 import numpy as np
 import pytest
 from PIL import Image, ImageChops
 
+from supervision import _cv2 as cv2
 from supervision.utils.image import (
     ImageSink,
     _overlay_image,

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -6,10 +6,10 @@ from queue import Queue as StdQueue
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import cv2
 import numpy as np
 import pytest
 
+from supervision import _cv2 as cv2
 from supervision.utils.video import (
     FPSMonitor,
     VideoInfo,

--- a/uv.lock
+++ b/uv.lock
@@ -3426,7 +3426,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "matplotlib", specifier = ">=3.6" },
     { name = "numpy", specifier = ">=1.21.2" },
-    { name = "opencv-python", specifier = ">=4.5.5.64" },
+    { name = "opencv-python", specifier = ">=4.5.5.64,<5" },
     { name = "pandas", marker = "extra == 'metrics'", specifier = ">=2" },
     { name = "pillow", specifier = ">=9.4" },
     { name = "pydeprecate", specifier = ">=0.9,<0.11" },


### PR DESCRIPTION
This pull request introduces a new private OpenCV compatibility layer (`src/supervision/_cv2/__init__.py`) and refactors the codebase to use it. The main goal is to centralize OpenCV imports and provide a fallback mechanism when OpenCV is not installed, improving robustness and portability. All direct `cv2` imports throughout the codebase are replaced with imports from this new compatibility module.

**Key changes:**

### OpenCV Compatibility Layer

* Added a new module `src/supervision/_cv2/__init__.py` that acts as a compatibility layer for OpenCV. It exposes OpenCV constants and functions if `cv2` is available, and provides clear error messages or fallbacks if not.

### Refactoring Imports

* Replaced all direct `import cv2` statements with `from supervision import _cv2 as cv2` throughout the codebase, including in docstring examples, to ensure consistent usage of the compatibility layer. [[1]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2L6-R12) [[2]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2L333-R333) [[3]](diffhunk://#diff-44203a331e1fcaeeb799018352abffa9b9380b7a8c264a2aad48153f7e1c9db8L118-R118) [[4]](diffhunk://#diff-3019ae880709b8b2c11823d6cf4397bd8ee822f8017cabfe4b046394867f59b5L12-R16) [[5]](diffhunk://#diff-7abb5ac55fd8982e0d6bf23b38dd3d6899083be5f4935dc495035fcb1468b007L9-R15) [[6]](diffhunk://#diff-9e33c0b647283a53a7612412fca08f092d76236ee1fa8e3bb8310171611f7a48L13-R18) [[7]](diffhunk://#diff-afb900b2725736ad48678ae4741df3210e870f8737c11e963c006a602d4b962eL545-R545) [[8]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL103-R103) [[9]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL119-R119) [[10]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL278-R278) [[11]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL317-R317) [[12]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL399-R399) [[13]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL454-R454) [[14]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL531-R531) [[15]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL651-R651) [[16]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL745-R745) [[17]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL877-R877) [[18]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL2210-R2210) [[19]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL2753-R2753) [[20]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL3332-R3332) [[21]](diffhunk://#diff-d239977d5d4d45cfda466426a1bca5dcd9b2c408aed2daf9e48172cf0eb3a184L8-R11) [[22]](diffhunk://#diff-03f0a3e1aba37b0fd9a10556d5eca488f2aee7ac4a0677c8674cbe42f4684f94L186-R186) [[23]](diffhunk://#diff-03f0a3e1aba37b0fd9a10556d5eca488f2aee7ac4a0677c8674cbe42f4684f94L240-R240) [[24]](diffhunk://#diff-8da71c314db871bea59ab052e01276c22829ed7ee48a5d97102210aa31e0901fL4-R8) [[25]](diffhunk://#diff-84c54fae7c18af90866c26386a86d9c123ddd081216a2aa9339406e919809a81L5-R9) [[26]](diffhunk://#diff-7464a4e6cf087bc7e2a83526f41dfc3d151eec62fcc721914144c96b13522145L5-R8) [[27]](diffhunk://#diff-92762cf828c0cec2b9217296e507a257d08321d1791b23ead28aee88f39a256aL8-R11) [[28]](diffhunk://#diff-76873461bd415c05ef936307b0c76ea0b62559253a2f7a02e16211f795be9642L3-R6) [[29]](diffhunk://#diff-49a4320910af70bce4a5ec0929508cfa74dcf3e9bece2a0423191804fee878c5L1-R5)

### Consistency in Examples

* Updated all code examples in docstrings to use the compatibility import, ensuring documentation matches the new import style. [[1]](diffhunk://#diff-744a1ff68917068412aa2750b9ac7e03a537f1a926de1460cf3ed24c432941d2L333-R333) [[2]](diffhunk://#diff-44203a331e1fcaeeb799018352abffa9b9380b7a8c264a2aad48153f7e1c9db8L118-R118) [[3]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL103-R103) [[4]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL119-R119) [[5]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL278-R278) [[6]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL317-R317) [[7]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL399-R399) [[8]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL454-R454) [[9]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL531-R531) [[10]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL651-R651) [[11]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL745-R745) [[12]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL877-R877) [[13]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL2210-R2210) [[14]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL2753-R2753) [[15]](diffhunk://#diff-3c7ebb73290af86929406f9eecc9b2253482eb4ddf4d1bc9f1f1e86e9c99ccedL3332-R3332) [[16]](diffhunk://#diff-03f0a3e1aba37b0fd9a10556d5eca488f2aee7ac4a0677c8674cbe42f4684f94L186-R186) [[17]](diffhunk://#diff-03f0a3e1aba37b0fd9a10556d5eca488f2aee7ac4a0677c8674cbe42f4684f94L240-R240)

These changes make the codebase more robust to environments where OpenCV may not be installed and simplify future maintenance by centralizing OpenCV-related logic.