### PR TITLE
ci: add doctest fence hook

### DIFF
--- a/.github/scripts/check_doctest_fences.py
+++ b/.github/scripts/check_doctest_fences.py
@@ -23,7 +23,7 @@ def check_file(path: Path) -> list[str]:
     line_before_previous = ""
     previous_line = ""
 
-    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         fence_match = FENCE_RE.match(line)
         if fence_match is not None:
             in_invalid_doctest_block = False

--- a/.github/scripts/check_doctest_fences.py
+++ b/.github/scripts/check_doctest_fences.py
@@ -23,7 +23,9 @@ def check_file(path: Path) -> list[str]:
     line_before_previous = ""
     previous_line = ""
 
-    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
         fence_match = FENCE_RE.match(line)
         if fence_match is not None:
             in_invalid_doctest_block = False

--- a/.github/scripts/check_doctest_fences.py
+++ b/.github/scripts/check_doctest_fences.py
@@ -12,20 +12,34 @@ DOCTEST_PROMPT_RE = re.compile(r"^\s*>>>")
 FENCE_RE = re.compile(r"^\s*```(?P<language>[A-Za-z0-9_-]*)\s*$")
 
 
-def check_file(path: Path) -> list[str]:
-    """Return doctest fence violations for a single source file."""
-    if not path.is_file() or path.suffix != ".py" or "src" not in path.parts:
-        return []
+def _check_content(content: str, path: Path) -> list[str]:
+    r"""Return doctest fence violations for file content.
 
+    Examples:
+        ```pycon
+        >>> from pathlib import Path
+        >>> _check_content('```pycon\n>>> len([1])\n1\n\n```\n', Path('src/a.py'))
+        []
+        >>> _check_content('>>> len([1])\n1\n', Path('src/a.py'))
+        ['src/a.py:1: doctest prompt must be inside a ```pycon fenced block']
+        >>> violations = _check_content(
+        ...     '```pycon\n>>> len([1])\n1\n```\n', Path('src/a.py')
+        ... )
+        >>> violations == [
+        ...     'src/a.py:4: pycon doctest block must include exactly one blank line '
+        ...     'before the closing fence'
+        ... ]
+        True
+
+        ```
+    """
     violations: list[str] = []
     active_fence_language: str | None = None
     in_invalid_doctest_block = False
     line_before_previous = ""
     previous_line = ""
 
-    for line_number, line in enumerate(
-        path.read_text(encoding="utf-8").splitlines(), start=1
-    ):
+    for line_number, line in enumerate(content.splitlines(), start=1):
         fence_match = FENCE_RE.match(line)
         if fence_match is not None:
             in_invalid_doctest_block = False
@@ -63,6 +77,14 @@ def check_file(path: Path) -> list[str]:
         previous_line = line
 
     return violations
+
+
+def check_file(path: Path) -> list[str]:
+    """Return doctest fence violations for a single source file."""
+    if not path.is_file() or path.suffix != ".py" or "src" not in path.parts:
+        return []
+
+    return _check_content(content=path.read_text(encoding="utf-8"), path=path)
 
 
 def main() -> int:

--- a/.github/scripts/check_doctest_fences.py
+++ b/.github/scripts/check_doctest_fences.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate doctest prompt formatting in source docstrings."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DOCTEST_PROMPT_RE = re.compile(r"^\s*>>>")
+FENCE_RE = re.compile(r"^\s*```(?P<language>[A-Za-z0-9_-]*)\s*$")
+
+
+def check_file(path: Path) -> list[str]:
+    """Return doctest fence violations for a single source file."""
+    if not path.is_file() or path.suffix != ".py" or "src" not in path.parts:
+        return []
+
+    violations: list[str] = []
+    active_fence_language: str | None = None
+    in_invalid_doctest_block = False
+    line_before_previous = ""
+    previous_line = ""
+
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        fence_match = FENCE_RE.match(line)
+        if fence_match is not None:
+            in_invalid_doctest_block = False
+            if active_fence_language is None:
+                active_fence_language = fence_match.group("language")
+            else:
+                has_exactly_one_blank_line = (
+                    previous_line.strip() == "" and line_before_previous.strip() != ""
+                )
+                if active_fence_language == "pycon" and not has_exactly_one_blank_line:
+                    violations.append(
+                        f"{path}:{line_number}: pycon doctest block must include "
+                        "exactly one blank line before the closing fence"
+                    )
+                active_fence_language = None
+            line_before_previous = previous_line
+            previous_line = line
+            continue
+
+        if not line.strip():
+            in_invalid_doctest_block = False
+
+        if (
+            DOCTEST_PROMPT_RE.match(line)
+            and active_fence_language != "pycon"
+            and not in_invalid_doctest_block
+        ):
+            violations.append(
+                f"{path}:{line_number}: doctest prompt must be inside a "
+                "```pycon fenced block"
+            )
+            in_invalid_doctest_block = True
+
+        line_before_previous = previous_line
+        previous_line = line
+
+    return violations
+
+
+def main() -> int:
+    """Run the doctest fence check for pre-commit supplied files."""
+    parser = argparse.ArgumentParser(
+        description="Validate doctest prompts in src/ are fenced as pycon blocks."
+    )
+    parser.add_argument("files", nargs="*", type=Path)
+    args = parser.parse_args()
+
+    violations = [
+        violation for path in args.files for violation in check_file(path=path)
+    ]
+    if violations:
+        print("\n".join(violations))
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,14 @@ ci:
   autoupdate_commit_msg: "chore(pre_commit): ⬆ pre_commit autoupdate"
 
 repos:
+  - repo: local
+    hooks:
+      - id: check-doctest-fences
+        name: check doctest fences
+        entry: python .github/scripts/check_doctest_fences.py
+        language: system
+        files: ^src/.*\.py$
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-doctest-fences
         name: check doctest fences
         entry: python .github/scripts/check_doctest_fences.py
-        language: system
+        language: python
         files: ^src/.*\.py$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -416,6 +416,7 @@ def get_coco_class_index_mapping(annotations_path: str) -> dict[int, int]:
         to original COCO class id (1 to 90 with skipped ids).
 
     Examples:
+        ```pycon
         >>> import json
         >>> import os
         >>> import tempfile
@@ -443,6 +444,8 @@ def get_coco_class_index_mapping(annotations_path: str) -> dict[int, int]:
         {0: 1, 1: 3}
         >>> os.path.exists(annotations_path)
         False
+
+        ```
     """
     coco_data = read_json_file(annotations_path)
     classes = coco_categories_to_classes(coco_categories=coco_data["categories"])

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -2260,10 +2260,13 @@ class Detections:
             An empty Detections object.
 
         Example:
+            ```pycon
             >>> from supervision import Detections
             >>> empty_detections = Detections.empty()
             >>> empty_detections.xyxy.shape
             (0, 4)
+
+            ```
         """
         return cls(
             xyxy=np.empty((0, 4), dtype=np.float32),
@@ -2353,6 +2356,7 @@ class Detections:
                 `image_shape` when mixing mask types.
 
         Example:
+            ```pycon
             >>> import numpy as np
             >>> import supervision as sv
             >>> detections_1 = sv.Detections(
@@ -2374,6 +2378,8 @@ class Detections:
             array([1, 2, 1])
             >>> merged_detections.data['feature_vector']
             array([0.1, 0.2, 0.3])
+
+            ```
 
         Compact mask merge example:
 
@@ -2605,6 +2611,7 @@ class Detections:
             The stored data value, or `None` when the key is absent.
 
         Example:
+            ```pycon
             >>> import numpy as np
             >>> from supervision import Detections
             >>> detections = Detections(
@@ -2613,6 +2620,8 @@ class Detections:
             ... )
             >>> detections.get_data("class_name").tolist()
             ['cat']
+
+            ```
         """
         return self.data.get(key)
 
@@ -2631,11 +2640,14 @@ class Detections:
             even when the selection is empty or the input has zero detections.
 
         Example:
+            ```pycon
             >>> import numpy as np
             >>> from supervision import Detections
             >>> detections = Detections(xyxy=np.array([[0, 0, 1, 1], [1, 1, 2, 2]]))
             >>> detections.select([1]).xyxy.tolist()
             [[1, 1, 2, 2]]
+
+            ```
         """
         mask: npt.NDArray[np.bool_] | CompactMask | None
         if len(self) == 0:
@@ -2808,6 +2820,7 @@ class Detections:
                 where n is the number of detections.
 
         Example:
+            ```pycon
             >>> import numpy as np
             >>> import supervision as sv
             >>> corners = np.array(
@@ -2834,6 +2847,8 @@ class Detections:
             ... )
             >>> detections.area
             array([ 9, 25])
+
+            ```
         """
         if self.mask is not None:
             if isinstance(self.mask, CompactMask):

--- a/src/supervision/detection/utils/boxes.py
+++ b/src/supervision/detection/utils/boxes.py
@@ -258,11 +258,14 @@ def obb_polygon_area(corners: npt.NDArray[np.number]) -> npt.NDArray[np.float64]
         ValueError: If `corners` does not have shape `(N, 4, 2)`.
 
     Examples:
+        ```pycon
         >>> import numpy as np
         >>> from supervision.detection.utils.boxes import obb_polygon_area
         >>> corners = np.array([[[0, 5], [5, 10], [10, 5], [5, 0]]], dtype=np.float32)
         >>> obb_polygon_area(corners)
         array([50.])
+
+        ```
     """
     corners = cast(npt.NDArray[np.number], np.asarray(corners))
     if corners.ndim != 3 or corners.shape[-2:] != (4, 2):

--- a/src/supervision/detection/utils/internal.py
+++ b/src/supervision/detection/utils/internal.py
@@ -327,11 +327,14 @@ def process_roboflow_result(
         tracker IDs are dropped to preserve alignment with ``xyxy``.
 
     Examples:
+        ```pycon
         >>> from supervision.detection.utils.internal import process_roboflow_result
         >>> result = {"predictions": [], "image": {"width": 100, "height": 100}}
         >>> _, _, _, _, _, data = process_roboflow_result(result)
         >>> data["class_name"].dtype.kind
         'U'
+
+        ```
     """
     if not roboflow_result["predictions"]:
         return (
@@ -705,6 +708,7 @@ def cross_product(
         negative = to the right; zero = on the line.
 
     Examples:
+        ```pycon
         >>> import numpy as np
         >>> from supervision.geometry.core import Point, Vector
         >>> anchors = np.array([[[10.0, 5.0]], [[20.0, 5.0]]])
@@ -712,6 +716,8 @@ def cross_product(
         >>> cross_product(anchors, vector)
         array([[5.],
                [5.]])
+
+        ```
     """
     vector_at_zero = np.array(
         [

--- a/src/supervision/detection/utils/iou_and_nms.py
+++ b/src/supervision/detection/utils/iou_and_nms.py
@@ -504,12 +504,15 @@ def oriented_box_iou_batch(
             :attr:`~supervision.config.OverlapMetric.IOS`.
 
     Examples:
+        ```pycon
         >>> import numpy as np
         >>> import supervision as sv
         >>> a = np.array([[[0, 0], [2, 0], [2, 2], [0, 2]]], dtype=np.float32)
         >>> b = np.array([[[1, 0], [3, 0], [3, 2], [1, 2]]], dtype=np.float32)
         >>> sv.oriented_box_iou_batch(a, b)  # doctest: +ELLIPSIS
         array([[0.333...]])
+
+        ```
     """
 
     for name, arr in (("boxes_true", boxes_true), ("boxes_detection", boxes_detection)):
@@ -1426,6 +1429,7 @@ def oriented_box_non_max_suppression(
             mismatched lengths or invalid shapes.
 
     Examples:
+        ```pycon
         >>> import numpy as np
         >>> import supervision as sv
         >>> oriented_boxes = np.array([
@@ -1443,6 +1447,8 @@ def oriented_box_non_max_suppression(
         ... )
         >>> keep
         array([ True, False])
+
+        ```
     """
     _validate_iou_threshold(iou_threshold)
     for name, arr in (("predictions", predictions), ("oriented_boxes", oriented_boxes)):
@@ -1549,6 +1555,7 @@ def oriented_box_non_max_merge(
             mismatched lengths or invalid shapes.
 
     Examples:
+        ```pycon
         >>> import numpy as np
         >>> import supervision as sv
         >>> oriented_boxes = np.array([
@@ -1566,6 +1573,8 @@ def oriented_box_non_max_merge(
         ... )
         >>> len(groups)
         1
+
+        ```
     """
     for name, arr in (("predictions", predictions), ("oriented_boxes", oriented_boxes)):
         if name == "predictions":

--- a/src/supervision/detection/utils/masks.py
+++ b/src/supervision/detection/utils/masks.py
@@ -21,6 +21,7 @@ def count_mask_pixels(masks: npt.NDArray[np.bool_]) -> npt.NDArray[np.int64]:
         Int64 array of shape ``(N,)`` with the True-pixel count per mask.
 
     Example:
+        ```pycon
         >>> import numpy as np
         >>> from supervision.detection.utils.masks import count_mask_pixels
         >>> m = np.zeros((2, 4, 4), dtype=bool)
@@ -28,6 +29,8 @@ def count_mask_pixels(masks: npt.NDArray[np.bool_]) -> npt.NDArray[np.int64]:
         >>> m[1, :3, :3] = True  # 9 pixels
         >>> count_mask_pixels(m)
         array([4, 9])
+
+        ```
     """
     return np.fromiter(
         (np.count_nonzero(m) for m in masks), dtype=np.int64, count=len(masks)

--- a/src/supervision/detection/utils/polygons.py
+++ b/src/supervision/detection/utils/polygons.py
@@ -89,6 +89,7 @@ def approximate_polygon(
     Examples:
         Reduce a polygon to at most half its original point count:
 
+        ```pycon
         >>> import numpy as np
         >>> polygon = np.array([[0, 0], [10, 0], [10, 10], [0, 10],
         ...                     [5, 10], [5, 5], [3, 7], [1, 9]])
@@ -103,6 +104,8 @@ def approximate_polygon(
         >>> tiny = np.array([[0, 0], [5, 0], [2, 4]])
         >>> approximate_polygon(tiny, percentage=0.5) is tiny
         True
+
+        ```
     """
 
     if percentage < 0 or percentage >= 1:

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -931,6 +931,7 @@ class KeyPoints:
             The stored data value, or `None` when the key is absent.
 
         Example:
+            ```pycon
             >>> import numpy as np
             >>> from supervision import KeyPoints
             >>> key_points = KeyPoints(
@@ -939,6 +940,8 @@ class KeyPoints:
             ... )
             >>> key_points.get_data("class_name").tolist()
             ['person']
+
+            ```
         """
         return self.data.get(key)
 
@@ -958,11 +961,14 @@ class KeyPoints:
             A new `KeyPoints` instance containing the selected rows or anchors.
 
         Example:
+            ```pycon
             >>> import numpy as np
             >>> from supervision import KeyPoints
             >>> key_points = KeyPoints(xy=np.array([[[0, 1]], [[2, 3]]]))
             >>> key_points.select([1]).xy.tolist()
             [[[2, 3]]]
+
+            ```
         """
         if isinstance(index, np.ndarray) and index.ndim == 2 and index.dtype == bool:
             return self._get_by_2d_bool_mask(cast(npt.NDArray[np.bool_], index))
@@ -1210,6 +1216,7 @@ class KeyPoints:
                 same keys.
 
         Example:
+            ```pycon
             >>> import numpy as np
             >>> import supervision as sv
             >>> key_points_1 = sv.KeyPoints(
@@ -1229,6 +1236,8 @@ class KeyPoints:
             array([0, 1])
             >>> merged.data['class_name']
             array(['person', 'dog'], dtype='<U6')
+
+            ```
         """
         key_points_list = [
             key_points for key_points in key_points_list if not key_points.is_empty()


### PR DESCRIPTION
This pull request introduces a new pre-commit hook to enforce proper formatting of doctest prompts in Python source files under `src/`. The hook checks that doctest prompts are always inside `pycon`-fenced code blocks and that these blocks are properly formatted.

The most important changes are:

**Pre-commit hook configuration:**
* Added a new local pre-commit hook `check-doctest-fences` to `.pre-commit-config.yaml` that runs the doctest fence checker script on Python files in `src/`.

**Doctest fence validation script:**
* Added `.github/scripts/check_doctest_fences.py`, a script that validates doctest formatting in Python docstrings by ensuring all doctest prompts are inside `pycon`-fenced blocks and that these blocks include exactly one blank line before the closing fence.

---

shall prevent situations like #2446