### PR TITLE
Fix sink state when instances are reopened

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 ---
 description: "Full version history of the supervision Python library — release notes, breaking changes, new features, and deprecations for every version."
-date_modified: 2026-07-21
+date_modified: 2026-07-27
 ---
 
 # Changelog
@@ -20,6 +20,7 @@ date_modified: 2026-07-21
 
 ### Fixed
 
+- Reopening an existing `sv.CSVSink` or `sv.JSONSink` now starts a fresh output session: CSV files receive a new header and field schema, while JSON files no longer retain rows from the previous session.
 - `sv.Detections.from_vlm` with `sv.VLM.GOOGLE_GEMINI_2_0`, `sv.VLM.GOOGLE_GEMINI_2_5`, and `sv.VLM.GOOGLE_GEMINI_3_5` now salvages the valid entries from a partially malformed JSON array (e.g. a single object with a syntax error) instead of discarding the whole response.
 - Geometry-aware IoU dispatch now powers the deprecated `merge_inner_detections_objects`, so overlapping axis-aligned envelopes no longer merge oriented boxes whose true OBB IoU is below the threshold ([#2374](https://github.com/roboflow/supervision/pull/2374)).
 - `save_coco_annotations` (and therefore `DetectionDataset.as_coco`) now reads image sizes from file headers via lazy PIL instead of cv2-decoding every image, so labels-only COCO exports no longer decode any pixel data ([#2442](https://github.com/roboflow/supervision/pull/2442)).

--- a/src/supervision/detection/tools/csv_sink.py
+++ b/src/supervision/detection/tools/csv_sink.py
@@ -108,6 +108,8 @@ class CSVSink:
 
         self.file = open(self.file_name, "w", newline="")
         self.writer = csv.writer(self.file)
+        self.header_written = False
+        self.field_names = []
 
     def close(self) -> None:
         """

--- a/src/supervision/detection/tools/json_sink.py
+++ b/src/supervision/detection/tools/json_sink.py
@@ -81,6 +81,7 @@ class JSONSink:
             os.makedirs(parent_directory)
 
         self.file = open(self.file_name, "w")
+        self.data = []
 
     @staticmethod
     def _json_default(value: Any) -> Any:

--- a/tests/detection/test_csv.py
+++ b/tests/detection/test_csv.py
@@ -562,3 +562,55 @@ def test_csv_sink_broadcasts_ndarray_when_length_mismatches_detection_count(
     assert len(rows) == 2
     np.testing.assert_array_equal(rows[0]["embedding"], expected_value)
     np.testing.assert_array_equal(rows[1]["embedding"], expected_value)
+
+
+class TestCSVSinkLifecycle:
+    """Tests for opening and reopening a CSV sink."""
+
+    def test_reopening_starts_fresh_output_session(self, tmp_path: Any) -> None:
+        """Reopening a sink writes a new header and field schema."""
+        first_path = tmp_path / "first.csv"
+        second_path = tmp_path / "second.csv"
+        first_detections = sv.Detections(
+            xyxy=np.array([[0, 0, 10, 10]]),
+            data={"first_label": ["first"]},
+        )
+        second_detections = sv.Detections(
+            xyxy=np.array([[20, 20, 30, 30]]),
+            data={"second_label": ["second"]},
+        )
+        sink = sv.CSVSink(str(first_path))
+
+        with sink:
+            sink.append(first_detections)
+        sink.file_name = str(second_path)
+        with sink:
+            sink.append(second_detections)
+
+        with open(second_path, newline="") as file:
+            reader = csv.DictReader(file)
+            field_names = reader.fieldnames
+            rows = list(reader)
+
+        assert field_names == [
+            "x_min",
+            "y_min",
+            "x_max",
+            "y_max",
+            "class_id",
+            "confidence",
+            "tracker_id",
+            "second_label",
+        ]
+        assert rows == [
+            {
+                "x_min": "20",
+                "y_min": "20",
+                "x_max": "30",
+                "y_max": "30",
+                "class_id": "",
+                "confidence": "",
+                "tracker_id": "",
+                "second_label": "second",
+            }
+        ]

--- a/tests/detection/test_json.py
+++ b/tests/detection/test_json.py
@@ -489,6 +489,45 @@ def test_json_default_raises_for_unserializable_type() -> None:
         sv.JSONSink._json_default(object())
 
 
+class TestJSONSinkLifecycle:
+    """Tests for opening and reopening a JSON sink."""
+
+    def test_reopening_starts_fresh_output_session(self, tmp_path: Any) -> None:
+        """Reopening a sink excludes rows from the prior output session."""
+        first_path = tmp_path / "first.json"
+        second_path = tmp_path / "second.json"
+        first_detections = sv.Detections(
+            xyxy=np.array([[0, 0, 10, 10]]),
+            class_id=np.array([1]),
+        )
+        second_detections = sv.Detections(
+            xyxy=np.array([[20, 20, 30, 30]]),
+            class_id=np.array([2]),
+        )
+        sink = sv.JSONSink(str(first_path))
+
+        with sink:
+            sink.append(first_detections)
+        sink.file_name = str(second_path)
+        with sink:
+            sink.append(second_detections)
+
+        with open(second_path) as file:
+            rows = json.load(file)
+
+        assert rows == [
+            {
+                "x_min": 20.0,
+                "y_min": 20.0,
+                "x_max": 30.0,
+                "y_max": 30.0,
+                "class_id": 2,
+                "confidence": "",
+                "tracker_id": "",
+            }
+        ]
+
+
 def assert_json_equal(file_name, expected_rows):
     with open(file_name) as file:
         data = json.load(file)


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated the changelog
- [x] Added/updated tests
- [x] All tests pass locally

</details>

## Description

Reset per-output state whenever an existing `sv.CSVSink` or `sv.JSONSink` instance successfully opens a new file.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Sink instances retain format-specific state after they close. Reopening a `CSVSink` leaves `header_written` and the prior field schema intact, so the next file can omit its header and serialize against stale columns. Reopening a `JSONSink` leaves the prior data buffer intact, so the next file includes rows from the previous output session.

Each successful `open()` should begin an independent output session, matching the fact that the destination file is opened in write mode.

## Changes Made

- Reset CSV header and field-schema state after opening a new file.
- Reset the JSON row buffer after opening a new file.
- Add lifecycle regressions that reuse each sink instance across two output paths.
- Document the fix in the unreleased changelog.

## Testing

- [x] `python -m pytest -q tests/detection/test_csv.py tests/detection/test_json.py` — 36 passed
- [x] `python -m pytest -q tests/detection` — 1,591 passed, 1 skipped
- [x] All pre-commit hooks passed on the five changed files, including Ruff, mypy, mdformat, and codespell

## Additional Notes

No public API changes.