### PR TITLE
docs: convert fenced examples to doctests in dataset/formats/coco.py

### DIFF
--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -65,15 +65,13 @@ def classes_to_coco_categories(classes: list[str]) -> list[CocoDict]:
     Returns:
         A list of COCO category dictionaries with 1-indexed ``id`` values.
 
-    Examples:
-        ```python
-        from supervision.dataset.formats.coco import classes_to_coco_categories
+    Example:
+        ```pycon
+        >>> from supervision.dataset.formats.coco import classes_to_coco_categories
+        >>> classes_to_coco_categories(classes=["cat", "dog"])
+        [{'id': 1, 'name': 'cat', 'supercategory': 'common-objects'},
+         {'id': 2, 'name': 'dog', 'supercategory': 'common-objects'}]
 
-        classes_to_coco_categories(classes=["cat", "dog"])
-        # [
-        #     {"id": 1, "name": "cat", "supercategory": "common-objects"},
-        #     {"id": 2, "name": "dog", "supercategory": "common-objects"},
-        # ]
         ```
     """
     return [
@@ -280,23 +278,25 @@ def detections_to_coco_annotations(
         (``iscrowd=0``). Supply ``data={"iscrowd": np.array([0])}`` to
         force polygon output regardless of mask topology.
 
-    Examples:
-        ```python
-        import numpy as np
-        from supervision import Detections
-        from supervision.dataset.formats.coco import (
-            detections_to_coco_annotations,
-        )
+    Example:
+        ```pycon
+        >>> import numpy as np
+        >>> from supervision import Detections
+        >>> from supervision.dataset.formats.coco import (
+        ...     detections_to_coco_annotations,
+        ... )
+        >>> detections = Detections(
+        ...     xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
+        ...     class_id=np.array([0], dtype=int),
+        ... )
+        >>> annotations, next_id = detections_to_coco_annotations(
+        ...     detections=detections, image_id=1, annotation_id=1
+        ... )
+        >>> annotations[0]["category_id"]
+        1
+        >>> next_id
+        2
 
-        detections = Detections(
-            xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
-            class_id=np.array([0], dtype=int),
-        )
-        annotations, next_id = detections_to_coco_annotations(
-            detections=detections, image_id=1, annotation_id=1
-        )
-        annotations[0]["category_id"]
-        # 1
         ```
     """
     coco_annotations: list[CocoDict] = []


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [x] All tests pass locally

</details>

## Description

Converts the 2 runnable fenced ` ```python ` examples in `dataset/formats/coco.py` to `pycon` doctest format so they are executed and verified by `pytest --doctest-modules`, following the precedent of #2451 (same conversion for `draw/utils.py`).

The `save_coco_annotations` example is intentionally left as a fenced block — it reads dataset files from disk, which [CONTRIBUTING.md §Doctests](https://github.com/roboflow/supervision/blob/develop/.github/CONTRIBUTING.md#doctests) lists as a case where fenced blocks are appropriate.

## Type of Change

- 📝 Documentation update

## Motivation and Context

Fenced examples are rendered in the docs but never executed, so they can silently break when the API changes. Doctests are verified on every test run. Per the contributing guidelines, `>>>` doctest format is preferred when an example only uses `supervision`, NumPy, and the standard library — both converted examples qualify.

## Changes Made

- `classes_to_coco_categories`: fenced example → doctest with verified output
- `detections_to_coco_annotations`: fenced example → doctest; expected output now also demonstrates the returned `next_id`, matching the id-chaining contract described in the `Returns` section
- Normalised `Examples:` → `Example:` for Google-style consistency

## Testing

- [x] I have tested this code locally
- [x] All new and existing tests pass

`uv run pytest --doctest-modules src/supervision/dataset/formats/coco.py` — 3 passed.
Full suite: 3456 passed, 20 skipped (+2 doctests over the 3454 baseline, no regressions). `pre-commit run --files src/supervision/dataset/formats/coco.py` — all hooks pass, including `check doctest fences`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)