### PR TITLE
docs: convert fenced examples to doctests in dataset/formats/createml.py

### DIFF
--- a/src/supervision/dataset/formats/createml.py
+++ b/src/supervision/dataset/formats/createml.py
@@ -77,21 +77,23 @@ def createml_annotations_to_detections(
             ``"label"``, or any coordinate sub-key), or if a coordinate value
             cannot be converted to float.
 
-    Examples:
-        ```python
-        import supervision as sv
-        from supervision.dataset.formats.createml import (
-            createml_annotations_to_detections,
-        )
+    Example:
+        ```pycon
+        >>> from supervision.dataset.formats.createml import (
+        ...     createml_annotations_to_detections,
+        ... )
+        >>> annotations = [
+        ...     {
+        ...         "label": "dog",
+        ...         "coordinates": {"x": 50, "y": 50, "width": 20, "height": 20},
+        ...     }
+        ... ]
+        >>> detections = createml_annotations_to_detections(annotations, {"dog": 0})
+        >>> detections.xyxy
+        array([[40., 40., 60., 60.]], dtype=float32)
+        >>> detections.class_id
+        array([0])
 
-        annotations = [
-            {
-                "label": "dog",
-                "coordinates": {"x": 50, "y": 50, "width": 20, "height": 20},
-            }
-        ]
-        detections = createml_annotations_to_detections(annotations, {"dog": 0})
-        # detections.xyxy → [[40, 40, 60, 60]]
         ```
     """
     if not image_annotations:
@@ -240,20 +242,21 @@ def detections_to_createml_annotations(
     Raises:
         ValueError: If ``detections.class_id`` is ``None``.
 
-    Examples:
-        ```python
-        import numpy as np
-        import supervision as sv
-        from supervision.dataset.formats.createml import (
-            detections_to_createml_annotations,
-        )
+    Example:
+        ```pycon
+        >>> import numpy as np
+        >>> import supervision as sv
+        >>> from supervision.dataset.formats.createml import (
+        ...     detections_to_createml_annotations,
+        ... )
+        >>> detections = sv.Detections(
+        ...     xyxy=np.array([[40, 40, 60, 60]], dtype=np.float32),
+        ...     class_id=np.array([0], dtype=int),
+        ... )
+        >>> detections_to_createml_annotations(detections, classes=["dog"])
+        [{'label': 'dog', 'coordinates':
+          {'x': 50.0, 'y': 50.0, 'width': 20.0, 'height': 20.0}}]
 
-        detections = sv.Detections(
-            xyxy=np.array([[40, 40, 60, 60]], dtype=np.float32),
-            class_id=np.array([0], dtype=int),
-        )
-        detections_to_createml_annotations(detections, classes=["dog"])
-        # [{"label": "dog", "coordinates": {"x": 50.0, "y": 50.0, ...}}]
         ```
     """
     class_ids = detections.class_id
@@ -301,7 +304,7 @@ def save_createml_annotations(
         ValueError: If two image paths share the same basename and would map to
             the same CreateML ``image`` entry.
 
-    Examples:
+    Example:
         ```python
         import supervision as sv
         from supervision.dataset.formats.createml import save_createml_annotations


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [x] All tests pass locally

</details>

## Description

Converts the 2 runnable fenced ` ```python ` examples in `dataset/formats/createml.py` to `pycon` doctest format so they are executed and verified by `pytest --doctest-modules`. Follow-up to #2474 (same conversion for `dataset/formats/coco.py`) and #2451 (`draw/utils.py`).

The `save_createml_annotations` example is intentionally left as a fenced block — it writes a file to disk, which [CONTRIBUTING.md §Doctests](https://github.com/roboflow/supervision/blob/develop/.github/CONTRIBUTING.md#doctests) lists as a case where fenced blocks are appropriate.

## Type of Change

- 📝 Documentation update

## Motivation and Context

Fenced examples are rendered in the docs but never executed, so they can silently drift from real behaviour. Both converted examples use only `supervision` and NumPy, so per the contributing guidelines they should be doctests.

## Changes Made

- `createml_annotations_to_detections`: fenced example → doctest; verified output now also asserts `class_id`, covering the label→id mapping half of the function's contract alongside the centre→corner box conversion. Removed an `import supervision as sv` that the example never used.
- `detections_to_createml_annotations`: fenced example → doctest with the full coordinates dict as verified output (round-trip of the example above).
- Normalised `Examples:` → `Example:` for Google-style consistency.

## Testing

- [x] I have tested this code locally
- [x] All new and existing tests pass

`uv run pytest --doctest-modules src/supervision/dataset/formats/createml.py` — 2 passed.
Full suite: 3565 passed, 20 skipped (+2 doctests, no regressions). `pre-commit run` — all hooks pass, including `check doctest fences`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)