### PR TITLE
fix(utils): ignore directories when listing files

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ date_modified: 2026-08-11
 ### Fixed
 
 - `sv.box_iou` now calculates overlap in `float64`, preventing `int32` area overflow for large boxes. Its scalar result now matches `sv.box_iou_batch` for the same input.
+- `sv.list_files_with_extensions` no longer includes directories when listing all files without an extension filter.
 
 ### 0.30.0 <small>Aug 4, 2026</small>
 

--- a/src/supervision/utils/file.py
+++ b/src/supervision/utils/file.py
@@ -176,7 +176,7 @@ def list_files_with_extensions(
                     files_with_extensions.append(path)
                     seen_paths.add(path)
     else:
-        files_with_extensions.extend(directory.glob("*"))
+        files_with_extensions.extend(p for p in directory.glob("*") if p.is_file())
 
     return files_with_extensions
 

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -198,3 +198,18 @@ def test_list_files_with_extensions_normalization(
     result = list_files_with_extensions(directory=tmp_path, extensions=[extension])
 
     assert {p.name for p in result} == expected_names
+
+
+def test_list_files_with_extensions_without_filter_ignores_directories(
+    tmp_path: Path,
+) -> None:
+    """Directory entries are ignored when no extension filter is provided."""
+    # given
+    (tmp_path / "image.jpg").touch()
+    (tmp_path / "labels").mkdir()
+
+    # when
+    result = list_files_with_extensions(directory=tmp_path)
+
+    # then
+    assert {p.name for p in result} == {"image.jpg"}


### PR DESCRIPTION
## Summary

- Filter out directory entries when `sv.list_files_with_extensions()` is called without an extension filter.
- Add a regression test covering mixed file/directory contents.
- Update the unreleased changelog.

## Why

The function documentation says it lists files, and the extension-filtered path already uses `Path.is_file()`. The unfiltered path used `directory.glob("*")` directly, so directories were returned alongside files.

## Validation

- `uv run --python D:\Dev\Environments\agent-reach\Scripts\python.exe pytest tests\utils\test_file.py::test_list_files_with_extensions_without_filter_ignores_directories -q`
- `uv run --python D:\Dev\Environments\agent-reach\Scripts\python.exe pytest tests\utils\test_file.py -q`
- `uv run --python D:\Dev\Environments\agent-reach\Scripts\python.exe ruff check src\supervision\utils\file.py tests\utils\test_file.py`
