### PR TITLE
feat: add MediaPipe hand landmark support with correct topology

### DIFF
--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -542,7 +542,7 @@ class KeyPoints:
             ```
 
         """
-        if hasattr(mediapipe_results, "pose_landmarks"):
+        if getattr(mediapipe_results, "pose_landmarks", None) is not None:
             results = mediapipe_results.pose_landmarks
             if not isinstance(mediapipe_results.pose_landmarks, list):
                 if mediapipe_results.pose_landmarks is None:
@@ -554,9 +554,9 @@ class KeyPoints:
                             for landmark in mediapipe_results.pose_landmarks.landmark
                         ]
                     ]
-        elif hasattr(mediapipe_results, "face_landmarks"):
+        elif getattr(mediapipe_results, "face_landmarks", None) is not None:
             results = mediapipe_results.face_landmarks
-        elif hasattr(mediapipe_results, "multi_face_landmarks"):
+        elif getattr(mediapipe_results, "multi_face_landmarks", None) is not None:
             if mediapipe_results.multi_face_landmarks is None:
                 results = []
             else:
@@ -564,11 +564,21 @@ class KeyPoints:
                     face_landmark.landmark
                     for face_landmark in mediapipe_results.multi_face_landmarks
                 ]
+        elif getattr(mediapipe_results, "hand_landmarks", None) is not None:
+            results = mediapipe_results.hand_landmarks
+        elif getattr(mediapipe_results, "multi_hand_landmarks", None) is not None:
+            if mediapipe_results.multi_hand_landmarks is None:
+                results = []
+            else:
+                results = [
+                    hand_landmark.landmark
+                    for hand_landmark in mediapipe_results.multi_hand_landmarks
+                ]
         else:
-            # Reject unsupported MediaPipe-like payloads before landmark parsing.
             raise ValueError(
                 "Unsupported MediaPipe result type. Expected an object with "
-                "pose_landmarks, face_landmarks, or multi_face_landmarks."
+                "pose_landmarks, face_landmarks, multi_face_landmarks, "
+                "hand_landmarks, or multi_hand_landmarks."
             )
 
         if len(results) == 0:
@@ -585,7 +595,10 @@ class KeyPoints:
                     landmark.y * resolution_wh[1],
                 ]
                 prediction_xy.append(keypoint_xy)
-                prediction_confidence.append(landmark.visibility)
+                visibility = getattr(landmark, "visibility", None)
+                prediction_confidence.append(
+                    1.0 if visibility is None else visibility
+                )
 
             xy.append(prediction_xy)
             confidence.append(prediction_confidence)

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -596,9 +596,7 @@ class KeyPoints:
                 ]
                 prediction_xy.append(keypoint_xy)
                 visibility = getattr(landmark, "visibility", None)
-                prediction_confidence.append(
-                    1.0 if visibility is None else visibility
-                )
+                prediction_confidence.append(1.0 if visibility is None else visibility)
 
             xy.append(prediction_xy)
             confidence.append(prediction_confidence)

--- a/src/supervision/key_points/skeletons.py
+++ b/src/supervision/key_points/skeletons.py
@@ -64,12 +64,12 @@ class Skeleton(Enum):
 
     HAND = (
         # Palm
-        (1, 2),    # wrist -> thumb_cmc
-        (1, 6),    # wrist -> index_mcp
-        (6, 10),   # index_mcp -> middle_mcp
+        (1, 2),  # wrist -> thumb_cmc
+        (1, 6),  # wrist -> index_mcp
+        (6, 10),  # index_mcp -> middle_mcp
         (10, 14),  # middle_mcp -> ring_mcp
         (14, 18),  # ring_mcp -> pinky_mcp
-        (1, 18),   # wrist -> pinky_mcp
+        (1, 18),  # wrist -> pinky_mcp
         # Thumb
         (2, 3),
         (3, 4),

--- a/src/supervision/key_points/skeletons.py
+++ b/src/supervision/key_points/skeletons.py
@@ -62,6 +62,36 @@ class Skeleton(Enum):
         (31, 33),
     )
 
+    HAND = (
+        # Palm
+        (1, 2),    # wrist -> thumb_cmc
+        (1, 6),    # wrist -> index_mcp
+        (6, 10),   # index_mcp -> middle_mcp
+        (10, 14),  # middle_mcp -> ring_mcp
+        (14, 18),  # ring_mcp -> pinky_mcp
+        (1, 18),   # wrist -> pinky_mcp
+        # Thumb
+        (2, 3),
+        (3, 4),
+        (4, 5),
+        # Index
+        (6, 7),
+        (7, 8),
+        (8, 9),
+        # Middle
+        (10, 11),
+        (11, 12),
+        (12, 13),
+        # Ring
+        (14, 15),
+        (15, 16),
+        (16, 17),
+        # Pinky
+        (18, 19),
+        (19, 20),
+        (20, 21),
+    )
+
     FACEMESH_TESSELATION_NO_IRIS = (
         (128, 35),
         (35, 140),

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -357,14 +357,15 @@ class _FakeMediapipeLandmark:
         self.visibility = visibility
 
 
-
-
 class _FakeMediapipeLandmarkVisibilityNone:
     """Mimics MediaPipe Tasks API where visibility is always present but None."""
+
     def __init__(self, x, y) -> None:
         self.x = x
         self.y = y
         self.visibility = None
+
+
 class _FakeMediapipePose:
     def __init__(self, landmarks: list[_FakeMediapipeLandmark]) -> None:
         self.landmark = landmarks

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -357,6 +357,14 @@ class _FakeMediapipeLandmark:
         self.visibility = visibility
 
 
+
+
+class _FakeMediapipeLandmarkVisibilityNone:
+    """Mimics MediaPipe Tasks API where visibility is always present but None."""
+    def __init__(self, x, y) -> None:
+        self.x = x
+        self.y = y
+        self.visibility = None
 class _FakeMediapipePose:
     def __init__(self, landmarks: list[_FakeMediapipeLandmark]) -> None:
         self.landmark = landmarks
@@ -370,10 +378,14 @@ class _FakeMediapipeResults:
         | None = None,
         face_landmarks: _FakeMediapipeLandmark | None = None,
         multi_face_landmarks: list[_FakeMediapipeLandmark] | None = None,
+        hand_landmarks: list | None = None,
+        multi_hand_landmarks: list | None = None,
     ) -> None:
         self.pose_landmarks = pose_landmarks
         self.face_landmarks = face_landmarks
         self.multi_face_landmarks = multi_face_landmarks
+        self.hand_landmarks = hand_landmarks
+        self.multi_hand_landmarks = multi_hand_landmarks
 
 
 def create_yolo_dataset(

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -1433,6 +1433,7 @@ def test_from_mediapipe_multi_hand_landmarks_empty_returns_empty():
 
     class _FakeHandOnly:
         hand_landmarks: list = []
+
     key_points = KeyPoints.from_mediapipe(_FakeHandOnly(), resolution_wh=(100, 100))
     assert key_points == KeyPoints.empty()
 

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -7,6 +7,7 @@ from supervision.key_points.core import KeyPoints
 from tests.helpers import (
     _create_key_points,
     _FakeMediapipeLandmark,
+    _FakeMediapipeLandmarkVisibilityNone,
     _FakeMediapipePose,
     _FakeMediapipeResults,
     _FakeYoloNasKeyPoint,
@@ -1367,6 +1368,73 @@ def test_from_mediapipe_unknown_result_type_raises() -> None:
     with pytest.raises(ValueError, match="Unsupported MediaPipe result"):
         KeyPoints.from_mediapipe(object(), resolution_wh=(100, 100))
 
+
+
+def test_from_mediapipe_hand_landmarks():
+    """Test hand_landmarks (Tasks API) parsing."""
+    results = _FakeMediapipeResults(
+        hand_landmarks=[
+            [
+                _FakeMediapipeLandmark(0.1, 0.2, 0.9),
+                _FakeMediapipeLandmark(0.3, 0.4, 0.85),
+            ]
+        ]
+    )
+    key_points = KeyPoints.from_mediapipe(results, resolution_wh=(100, 200))
+    expected = _create_key_points(
+        xy=[[[10.0, 40.0], [30.0, 80.0]]],
+        confidence=[[0.9, 0.85]],
+        class_id=None,
+    )
+    assert key_points == expected
+
+
+def test_from_mediapipe_multi_hand_landmarks():
+    """Test multi_hand_landmarks (Legacy API) parsing."""
+    results = _FakeMediapipeResults(
+        multi_hand_landmarks=[
+            _FakeMediapipePose(
+                landmarks=[
+                    _FakeMediapipeLandmark(0.5, 0.75, 0.9),
+                    _FakeMediapipeLandmark(0.6, 0.8, 0.85),
+                ]
+            )
+        ]
+    )
+    key_points = KeyPoints.from_mediapipe(results, resolution_wh=(200, 200))
+    expected = _create_key_points(
+        xy=[[[100.0, 150.0], [120.0, 160.0]]],
+        confidence=[[0.9, 0.85]],
+        class_id=None,
+    )
+    assert key_points == expected
+
+
+def test_from_mediapipe_visibility_none_defaults_to_one():
+    """Tasks API landmarks with visibility=None should default to 1.0."""
+    results = _FakeMediapipeResults(
+        hand_landmarks=[
+            [
+                _FakeMediapipeLandmarkVisibilityNone(0.1, 0.2),
+                _FakeMediapipeLandmarkVisibilityNone(0.3, 0.4),
+            ]
+        ]
+    )
+    key_points = KeyPoints.from_mediapipe(results, resolution_wh=(100, 200))
+    expected = _create_key_points(
+        xy=[[[10.0, 40.0], [30.0, 80.0]]],
+        confidence=[[1.0, 1.0]],
+        class_id=None,
+    )
+    assert key_points == expected
+
+
+def test_from_mediapipe_multi_hand_landmarks_empty_returns_empty():
+    """Empty hand_landmarks list should return empty KeyPoints."""
+    class _FakeHandOnly:
+        hand_landmarks = []
+    key_points = KeyPoints.from_mediapipe(_FakeHandOnly(), resolution_wh=(100, 100))
+    assert key_points == KeyPoints.empty()
 
 class TestDeprecatedConfidenceConstructor:
     """Tests for backward-compatible `confidence=` kwarg in KeyPoints()."""

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -1432,8 +1432,7 @@ def test_from_mediapipe_multi_hand_landmarks_empty_returns_empty():
     """Empty hand_landmarks list should return empty KeyPoints."""
 
     class _FakeHandOnly:
-        hand_landmarks = []
-
+        hand_landmarks: list = []
     key_points = KeyPoints.from_mediapipe(_FakeHandOnly(), resolution_wh=(100, 100))
     assert key_points == KeyPoints.empty()
 

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -1,4 +1,5 @@
 from contextlib import nullcontext as DoesNotRaise
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -1432,7 +1433,7 @@ def test_from_mediapipe_multi_hand_landmarks_empty_returns_empty():
     """Empty hand_landmarks list should return empty KeyPoints."""
 
     class _FakeHandOnly:
-        hand_landmarks: list = []
+        hand_landmarks: ClassVar[list] = []
 
     key_points = KeyPoints.from_mediapipe(_FakeHandOnly(), resolution_wh=(100, 100))
     assert key_points == KeyPoints.empty()

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -1369,7 +1369,6 @@ def test_from_mediapipe_unknown_result_type_raises() -> None:
         KeyPoints.from_mediapipe(object(), resolution_wh=(100, 100))
 
 
-
 def test_from_mediapipe_hand_landmarks():
     """Test hand_landmarks (Tasks API) parsing."""
     results = _FakeMediapipeResults(
@@ -1431,10 +1430,13 @@ def test_from_mediapipe_visibility_none_defaults_to_one():
 
 def test_from_mediapipe_multi_hand_landmarks_empty_returns_empty():
     """Empty hand_landmarks list should return empty KeyPoints."""
+
     class _FakeHandOnly:
         hand_landmarks = []
+
     key_points = KeyPoints.from_mediapipe(_FakeHandOnly(), resolution_wh=(100, 100))
     assert key_points == KeyPoints.empty()
+
 
 class TestDeprecatedConfidenceConstructor:
     """Tests for backward-compatible `confidence=` kwarg in KeyPoints()."""


### PR DESCRIPTION
## Description

Adds MediaPipe hand landmark support to the key_points module, addressing the issues identified by @amerob in #2283.

## Type of Change

- ✨ New feature (non-breaking change which adds functionality)
- 🧪 Test update

## Changes Made

- Added `Skeleton.HAND` with 21 vertices and 21 edges matching MediaPipe's `HAND_CONNECTIONS` (palm drawn as an arch across knuckles, not a spoke fan from the wrist)
- Extended `KeyPoints.from_mediapipe()` to support `hand_landmarks` (Tasks API) and `multi_hand_landmarks` (Legacy API)
- Replaced `hasattr` with `getattr(..., None) is not None` so attributes set to `None` fall through correctly to the next branch
- Fixed visibility fallback: `None` → `1.0` for Tasks API landmarks where `visibility` is always present but defaults to `None`
- Added tests covering hand landmark parsing, visibility handling, and empty results

## Testing

- [x] All 136 existing + new tests pass
- [x] `python -m pytest tests/key_points/test_skeletons.py tests/key_points/test_core.py -q`

Closes #2170