### PR TITLE
fix(cv2): support RGBA input in fallback conversion

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ date_modified: 2026-08-11
 
 - `sv.box_iou` now calculates overlap in `float64`, preventing `int32` area overflow for large boxes. Its scalar result now matches `sv.box_iou_batch` for the same input.
 - `sv.list_files_with_extensions` no longer includes directories when listing all files without an extension filter.
+- `sv.pillow_to_cv2` now accepts RGBA images when the cv2-free fallback backend is active, matching OpenCV by dropping alpha and returning BGR channels.
 
 ### 0.30.0 <small>Aug 4, 2026</small>
 

--- a/src/supervision/_cv2/_color.py
+++ b/src/supervision/_cv2/_color.py
@@ -21,9 +21,11 @@ from supervision._cv2.constants import (
 def _cvt_color(image: npt.NDArray[Any], code: int) -> npt.NDArray[Any]:
     """Convert the BGR, RGB, grayscale, and 8-bit HSV formats used by Supervision."""
     if code in (_COLOR_BGR2RGB, _COLOR_RGB2BGR):
-        if image.ndim != 3 or image.shape[2] != 3:
-            raise ValueError("BGR/RGB conversion requires a three-channel image")
-        return np.ascontiguousarray(image[..., ::-1])
+        if image.ndim != 3 or image.shape[2] not in (3, 4):
+            raise ValueError(
+                "BGR/RGB conversion requires a three- or four-channel image"
+            )
+        return np.ascontiguousarray(image[..., 2::-1])
 
     if code == _COLOR_GRAY2BGR:
         if image.ndim != 2:

--- a/src/supervision/utils/conversion.py
+++ b/src/supervision/utils/conversion.py
@@ -161,10 +161,11 @@ def pillow_to_cv2(image: Image.Image) -> npt.NDArray[np.uint8]:
     """
     Converts Pillow image into OpenCV image, handling RGB -> BGR
     conversion. Palette images are first expanded to RGB so palette indices are
-    resolved to their actual colors.
+    resolved to their actual colors. RGBA images are converted to BGR, matching
+    OpenCV by dropping the alpha channel.
 
     Args:
-        image: Pillow image in RGB, grayscale, or palette mode.
+        image: Pillow image in RGB, RGBA, grayscale, or palette mode.
 
     Returns:
         Input image converted to OpenCV format.

--- a/tests/cv2/test_color.py
+++ b/tests/cv2/test_color.py
@@ -13,6 +13,7 @@ from supervision._cv2.constants import (
     _COLOR_BGR2RGB,
     _COLOR_GRAY2BGR,
     _COLOR_HSV2BGR,
+    _COLOR_RGB2BGR,
 )
 
 try:
@@ -36,6 +37,13 @@ except (ImportError, OSError):
             cv2.COLOR_BGR2RGB,
             0,
             id="bgr-to-rgb",
+        ),
+        pytest.param(
+            np.array([[[10, 20, 30, 40]]], dtype=np.uint8),
+            _COLOR_RGB2BGR,
+            cv2.COLOR_RGB2BGR,
+            0,
+            id="rgba-to-bgr",
         ),
         pytest.param(
             np.array(

--- a/tests/utils/test_conversion.py
+++ b/tests/utils/test_conversion.py
@@ -176,6 +176,15 @@ def test_pillow_to_cv2_handles_palette_images() -> None:
     np.testing.assert_array_equal(result, np.array([[[0, 0, 255]]], dtype=np.uint8))
 
 
+def test_pillow_to_cv2_handles_rgba_images() -> None:
+    """RGBA images drop alpha and reorder color channels like OpenCV."""
+    image = Image.new("RGBA", (1, 1), color=(10, 20, 30, 40))
+
+    result = pillow_to_cv2(image=image)
+
+    np.testing.assert_array_equal(result, np.array([[[30, 20, 10]]], dtype=np.uint8))
+
+
 def test_images_to_cv2_when_empty_input_provided() -> None:
     # when
     result = images_to_cv2(images=[])


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated documentation, following Google-style conventions
- [x] Added docs entry for autogeneration (not applicable: no new functions/classes)
- [x] Added/updated tests
- [x] All tests pass locally

</details>

## Description

Allow the cv2-free fallback color converter to accept four-channel RGB(A) input. This lets the public `sv.pillow_to_cv2()` path handle RGBA Pillow images consistently whether OpenCV is installed or the NumPy fallback backend is active.

## Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Supervision supports running without OpenCV, but the fallback implementation of `COLOR_RGB2BGR` rejected RGBA input even though OpenCV accepts it. Consequently, `sv.pillow_to_cv2(Image.new("RGBA", ...))` raised `ValueError` only in cv2-free installations. The fallback now matches OpenCV by reversing the RGB channels and dropping alpha.

## Changes Made

- Accept three- or four-channel input in the fallback RGB/BGR conversion.
- Document RGBA handling in `pillow_to_cv2()` and the changelog.
- Add OpenCV-reference and public-API regression coverage.

## Testing

- [x] I have tested this code locally
- [x] I have added unit tests that prove the fix is effective
- [x] All new and existing tests pass

Validation performed:

- `uv run pytest tests/cv2/test_color.py tests/utils/test_conversion.py -q` — 22 passed
- `uv run pytest --cov=supervision` — 3,740 passed, 1 skipped
- `uv run pre-commit run --all-files` — all hooks passed
- Public API with OpenCV import blocked — fallback backend returned `[[[30, 20, 10]]]` for RGBA `(10, 20, 30, 40)`

## Google Colab (optional)

Not applicable; this is a deterministic backend compatibility fix covered by local unit tests.

## Screenshots/Videos (optional)

Not applicable; there is no visual UI change.

## Additional Notes

Prepared with assistance from OpenAI Codex. The regression behavior and validation commands above were executed locally.
