### PR TITLE
fix(geometry): prevent obb area and iou precision loss at large coordinate origins

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ date_modified: 2026-08-11
 ### Fixed
 
 - `sv.get_polygon_center` now calculates polygon centroids in translated `float64` coordinates, preventing integer overflow and precision loss for polygons with large coordinates.
-- `sv.Detections.area` and `sv.oriented_box_iou_batch` now compute oriented-box areas and intersections in origin-translated coordinates, preventing precision loss and self-IoU collapse for boxes with large coordinate origins (e.g. geospatial or stitched frames).
+- `sv.Detections.area` and `sv.oriented_box_iou_batch` now translate oriented-box coordinates to local origins before floating-point area/intersection math, preserving differences representable by the input dtype and preventing self-IoU collapse for large-coordinate inputs (e.g. geospatial or stitched frames).
 - `DetectionsSmoother` now keeps oriented-box corners aligned with smoothed `xyxy` geometry, including rotated tracks and mixed metadata windows.
 - `sv.box_iou` now calculates overlap in `float64`, preventing `int32` area overflow for large boxes. Its scalar result now matches `sv.box_iou_batch` for the same input.
 - `sv.list_files_with_extensions` no longer includes directories when listing all files without an extension filter.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ date_modified: 2026-08-11
 ### Fixed
 
 - `sv.get_polygon_center` now calculates polygon centroids in translated `float64` coordinates, preventing integer overflow and precision loss for polygons with large coordinates.
+- `sv.Detections.area` and `sv.oriented_box_iou_batch` now compute oriented-box areas and intersections in origin-translated coordinates, preventing precision loss and self-IoU collapse for boxes with large coordinate origins (e.g. geospatial or stitched frames).
 - `DetectionsSmoother` now keeps oriented-box corners aligned with smoothed `xyxy` geometry, including rotated tracks and mixed metadata windows.
 - `sv.box_iou` now calculates overlap in `float64`, preventing `int32` area overflow for large boxes. Its scalar result now matches `sv.box_iou_batch` for the same input.
 - `sv.list_files_with_extensions` no longer includes directories when listing all files without an extension filter.

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -3052,9 +3052,7 @@ class Detections:
         elif ORIENTED_BOX_COORDINATES in self.data:
             indices = oriented_box_non_max_suppression(
                 predictions=predictions,
-                oriented_boxes=np.asarray(
-                    self.data[ORIENTED_BOX_COORDINATES], dtype=np.float32
-                ),
+                oriented_boxes=np.asarray(self.data[ORIENTED_BOX_COORDINATES]),
                 iou_threshold=threshold,
                 overlap_metric=overlap_metric,
             )
@@ -3202,9 +3200,7 @@ class Detections:
         elif ORIENTED_BOX_COORDINATES in self.data:
             merge_groups = oriented_box_non_max_merge(
                 predictions=predictions,
-                oriented_boxes=np.asarray(
-                    self.data[ORIENTED_BOX_COORDINATES], dtype=np.float32
-                ),
+                oriented_boxes=np.asarray(self.data[ORIENTED_BOX_COORDINATES]),
                 iou_threshold=threshold,
                 overlap_metric=overlap_metric,
             )
@@ -3237,33 +3233,39 @@ def _merge_obb_corners(
         corners_list: List of (4, 2) corner arrays. First is the winner.
 
     Returns:
-        Merged OBB corners as a (4, 2) float32 array.
+        Merged OBB corners as a (4, 2) floating-point array. Its dtype matches
+        floating inputs and is float64 for integer inputs.
     """
-    all_corners = np.concatenate(corners_list, axis=0).astype(np.float32)
+    input_dtype = np.result_type(*[corners.dtype for corners in corners_list])
+    output_dtype = (
+        input_dtype if np.issubdtype(input_dtype, np.floating) else np.float64
+    )
+    origin = corners_list[0][0]
+    all_corners = np.concatenate(corners_list, axis=0) - origin
     # Use winner's first edge to derive orientation angle -- avoids
     # cv2.minAreaRect surprises (e.g. 90-degree flip for wide rects).
     winner_edge = corners_list[0][1] - corners_list[0][0]
-    angle = float(np.arctan2(winner_edge[1], winner_edge[0]))
+    angle = float(np.arctan2(float(winner_edge[1]), float(winner_edge[0])))
     cos, sin = float(np.cos(angle)), float(np.sin(angle))
 
     # De-rotate all corners into the winner's local frame
-    to_local = np.array([[cos, -sin], [sin, cos]], dtype=np.float32)
-    local_corners = all_corners @ to_local
+    to_local = np.array([[cos, -sin], [sin, cos]], dtype=np.float64)
+    local_corners = all_corners.astype(np.float64, copy=False) @ to_local
     x_min = float(local_corners[:, 0].min())
     x_max = float(local_corners[:, 0].max())
     y_min = float(local_corners[:, 1].min())
     y_max = float(local_corners[:, 1].max())
 
     # Rotate the enclosing AABB back to world frame
-    to_world = np.array([[cos, sin], [-sin, cos]], dtype=np.float32)
+    to_world = np.array([[cos, sin], [-sin, cos]], dtype=np.float64)
     merged: npt.NDArray[np.floating] = (
         np.array(
             [[x_min, y_min], [x_max, y_min], [x_max, y_max], [x_min, y_max]],
-            dtype=np.float32,
+            dtype=np.float64,
         )
         @ to_world
     )
-    return merged
+    return cast(npt.NDArray[np.floating], (merged + origin).astype(output_dtype))
 
 
 def _merge_detection_group(detections: list[Detections]) -> Detections:
@@ -3291,8 +3293,12 @@ def _merge_detection_group(detections: list[Detections]) -> Detections:
 
     # Area-weighted confidence: each box contributes proportionally to its
     # footprint so large overlapping boxes dominate over small slivers.
-    all_xyxy = np.array([d.xyxy[0] for d in detections], dtype=np.float32)
-    areas = (all_xyxy[:, 2] - all_xyxy[:, 0]) * (all_xyxy[:, 3] - all_xyxy[:, 1])
+    all_xyxy = np.array([d.xyxy[0] for d in detections])
+    widths = all_xyxy[:, 2] - all_xyxy[:, 0]
+    heights = all_xyxy[:, 3] - all_xyxy[:, 1]
+    areas = widths.astype(np.float64, copy=False) * heights.astype(
+        np.float64, copy=False
+    )
 
     confidence: npt.NDArray[np.floating] | None
     if winner.confidence is not None:

--- a/src/supervision/detection/utils/boxes.py
+++ b/src/supervision/detection/utils/boxes.py
@@ -282,7 +282,9 @@ def obb_polygon_area(corners: npt.NDArray[np.number]) -> npt.NDArray[np.float64]
             corners.astype(object) - origin.astype(object), dtype=np.float64
         )
     else:
-        translated = corners.astype(np.float64, copy=False) - origin
+        translated = corners.astype(np.float64, copy=False) - origin.astype(
+            np.float64, copy=False
+        )
     x = translated[..., 0]
     y = translated[..., 1]
     cross = x * np.roll(y, -1, axis=-1) - y * np.roll(x, -1, axis=-1)

--- a/src/supervision/detection/utils/boxes.py
+++ b/src/supervision/detection/utils/boxes.py
@@ -270,13 +270,19 @@ def obb_polygon_area(corners: npt.NDArray[np.number]) -> npt.NDArray[np.float64]
     corners = cast(npt.NDArray[np.number], np.asarray(corners))
     if corners.ndim != 3 or corners.shape[-2:] != (4, 2):
         raise ValueError(f"corners must have shape (N, 4, 2); got {corners.shape}")
-    # Translate each box to its own first corner before the shoelace products so
-    # coordinates with large origins (e.g. geospatial or stitched frames) stay
-    # within float64's exact-integer range (2**53). The shoelace area is
-    # translation-invariant, so the result is unchanged for small coordinates
-    # while large-origin boxes no longer lose precision to overflow.
+    # Translate each box before the shoelace products so representable integer
+    # coordinates with large origins (e.g. geospatial or stitched frames) are
+    # reduced to local extents before conversion to float64. Float inputs that
+    # were already quantized retain their input precision.
     origin = corners[:, 0:1, :]
-    translated = corners.astype(np.float64, copy=False) - origin
+    if np.issubdtype(corners.dtype, np.integer):
+        # Object arithmetic avoids unsigned underflow and signed overflow before
+        # the exact integer differences are converted to float64.
+        translated = np.asarray(
+            corners.astype(object) - origin.astype(object), dtype=np.float64
+        )
+    else:
+        translated = corners.astype(np.float64, copy=False) - origin
     x = translated[..., 0]
     y = translated[..., 1]
     cross = x * np.roll(y, -1, axis=-1) - y * np.roll(x, -1, axis=-1)

--- a/src/supervision/detection/utils/boxes.py
+++ b/src/supervision/detection/utils/boxes.py
@@ -270,8 +270,15 @@ def obb_polygon_area(corners: npt.NDArray[np.number]) -> npt.NDArray[np.float64]
     corners = cast(npt.NDArray[np.number], np.asarray(corners))
     if corners.ndim != 3 or corners.shape[-2:] != (4, 2):
         raise ValueError(f"corners must have shape (N, 4, 2); got {corners.shape}")
-    x = corners[..., 0].astype(np.float64, copy=False)
-    y = corners[..., 1].astype(np.float64, copy=False)
+    # Translate each box to its own first corner before the shoelace products so
+    # coordinates with large origins (e.g. geospatial or stitched frames) stay
+    # within float64's exact-integer range (2**53). The shoelace area is
+    # translation-invariant, so the result is unchanged for small coordinates
+    # while large-origin boxes no longer lose precision to overflow.
+    origin = corners[:, 0:1, :]
+    translated = corners.astype(np.float64, copy=False) - origin
+    x = translated[..., 0]
+    y = translated[..., 1]
     cross = x * np.roll(y, -1, axis=-1) - y * np.roll(x, -1, axis=-1)
     return cast(npt.NDArray[np.float64], 0.5 * np.abs(np.sum(cross, axis=-1)))
 

--- a/src/supervision/detection/utils/iou_and_nms.py
+++ b/src/supervision/detection/utils/iou_and_nms.py
@@ -399,13 +399,13 @@ def box_iou_batch_with_jaccard(
     return iou
 
 
-def _polygon_areas(polygons: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
+def _polygon_areas(polygons: npt.NDArray[np.number]) -> npt.NDArray[np.float64]:
     """Compute the area of each oriented-box polygon using the shoelace formula.
 
     Each polygon is translated to its own first corner before the shoelace
-    products, keeping coordinates with large origins (e.g. geospatial frames)
-    within float64's exact-integer range. The shoelace area is
-    translation-invariant, so the result is unchanged for small coordinates.
+    products, keeping representable integer coordinates with large origins (e.g.
+    geospatial frames) local before conversion to float64. Float inputs that
+    were already quantized retain their input precision.
 
     Args:
         polygons: ``(N, 4, 2)`` array of polygon corners.
@@ -414,14 +414,20 @@ def _polygon_areas(polygons: npt.NDArray[np.floating]) -> npt.NDArray[np.floatin
         ``(N,)`` array of polygon areas.
     """
     origin = polygons[:, 0:1, :]
-    translated = polygons - origin
+    if np.issubdtype(polygons.dtype, np.integer):
+        translated = np.asarray(
+            polygons.astype(object) - origin.astype(object), dtype=np.float64
+        )
+    else:
+        polygons_float = polygons.astype(np.float64, copy=False)
+        translated = polygons_float - origin
     x = translated[:, :, 0]
     y = translated[:, :, 1]
     cross = x * np.roll(y, -1, axis=1) - np.roll(x, -1, axis=1) * y
-    return cast(npt.NDArray[np.floating], 0.5 * np.abs(cross.sum(axis=1)))
+    return cast(npt.NDArray[np.float64], 0.5 * np.abs(cross.sum(axis=1)))
 
 
-def _aabb_envelopes(polygons: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
+def _aabb_envelopes(polygons: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
     """Compute the axis-aligned bounding envelope of each oriented box.
 
     Args:
@@ -438,8 +444,8 @@ def _aabb_envelopes(polygons: npt.NDArray[np.floating]) -> npt.NDArray[np.floati
 
 
 def _overlapping_envelope_pairs(
-    envelopes_true: npt.NDArray[np.floating],
-    envelopes_detection: npt.NDArray[np.floating],
+    envelopes_true: npt.NDArray[np.number],
+    envelopes_detection: npt.NDArray[np.number],
 ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
     """Return index pairs ``(i, j)`` whose axis-aligned envelopes overlap.
 
@@ -567,13 +573,8 @@ def oriented_box_iou_batch(
     # Capture identity before reshape: NMS / NMM pass the same array twice, so
     # the matrix is symmetric and we can compute only its upper triangle.
     is_self_comparison = boxes_true is boxes_detection
-    boxes_true = cast(
-        npt.NDArray[np.floating], boxes_true.reshape(-1, 4, 2).astype(np.float64)
-    )
-    boxes_detection = cast(
-        npt.NDArray[np.floating],
-        boxes_detection.reshape(-1, 4, 2).astype(np.float64),
-    )
+    boxes_true = boxes_true.reshape(-1, 4, 2)
+    boxes_detection = boxes_detection.reshape(-1, 4, 2)
 
     n, m = len(boxes_true), len(boxes_detection)
     if n == 0 or m == 0:
@@ -592,14 +593,55 @@ def oriented_box_iou_batch(
         rows, cols = rows[upper], cols[upper]
 
     ious: npt.NDArray[np.float64] = np.zeros((n, m), dtype=np.float64)
+    local_origins_true = envelopes_true[:, :2]
+    local_origins_detection = envelopes_detection[:, :2]
+    if np.issubdtype(boxes_true.dtype, np.integer):
+        local_polygons_true = np.asarray(
+            boxes_true.astype(object) - local_origins_true[:, None, :].astype(object),
+            dtype=np.float32,
+        )
+    else:
+        local_polygons_true = (boxes_true - local_origins_true[:, None, :]).astype(
+            np.float32
+        )
+    if np.issubdtype(boxes_detection.dtype, np.integer):
+        local_polygons_detection = np.asarray(
+            boxes_detection.astype(object)
+            - local_origins_detection[:, None, :].astype(object),
+            dtype=np.float32,
+        )
+    else:
+        local_polygons_detection = (
+            boxes_detection - local_origins_detection[:, None, :]
+        ).astype(np.float32)
+    # Float32 inputs already have quantized origins, so their envelope minima
+    # can be reused without loss. Float64 inputs may retain unit differences at
+    # large origins; keep their pair offsets in float64 until each pair's local
+    # cast instead of rounding absolute minima to float32 up front.
+    origins_true_float32 = (
+        local_origins_true if boxes_true.dtype == np.float32 else None
+    )
+    origins_detection_float32 = (
+        local_origins_detection if boxes_detection.dtype == np.float32 else None
+    )
+    polygon_i_buffer = np.empty((4, 2), dtype=np.float32)
+    polygon_j_buffer = np.empty((4, 2), dtype=np.float32)
     for i, j in zip(rows, cols):
-        # Translate the pair to its own origin before the float32 cast: with
-        # large coordinate origins the float32 conversion alone would quantize
-        # the corners away, and the intersection area is translation-invariant.
-        origin = np.minimum(boxes_true[i].min(axis=0), boxes_detection[j].min(axis=0))
-        polygon_i = (boxes_true[i] - origin).astype(np.float32)
-        polygon_j = (boxes_detection[j] - origin).astype(np.float32)
-        intersection, _ = cv2.intersectConvexConvex(polygon_i, polygon_j)
+        # Rebase precomputed local polygons to the shared overlap origin. This
+        # preserves translation-invariant float32 geometry without repeating
+        # corner reductions and casts for every candidate pair.
+        if origins_true_float32 is not None and origins_detection_float32 is not None:
+            origin_i = origins_true_float32[i]
+            origin_j = origins_detection_float32[j]
+        else:
+            origin_i = local_origins_true[i]
+            origin_j = local_origins_detection[j]
+        pair_origin = np.minimum(origin_i, origin_j)
+        offset_i = (origin_i - pair_origin).astype(np.float32, copy=False)
+        offset_j = (origin_j - pair_origin).astype(np.float32, copy=False)
+        np.add(local_polygons_true[i], offset_i, out=polygon_i_buffer)
+        np.add(local_polygons_detection[j], offset_j, out=polygon_j_buffer)
+        intersection, _ = cv2.intersectConvexConvex(polygon_i_buffer, polygon_j_buffer)
         if intersection <= 0:
             continue
         denominator = (

--- a/src/supervision/detection/utils/iou_and_nms.py
+++ b/src/supervision/detection/utils/iou_and_nms.py
@@ -402,14 +402,21 @@ def box_iou_batch_with_jaccard(
 def _polygon_areas(polygons: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
     """Compute the area of each oriented-box polygon using the shoelace formula.
 
+    Each polygon is translated to its own first corner before the shoelace
+    products, keeping coordinates with large origins (e.g. geospatial frames)
+    within float64's exact-integer range. The shoelace area is
+    translation-invariant, so the result is unchanged for small coordinates.
+
     Args:
         polygons: ``(N, 4, 2)`` array of polygon corners.
 
     Returns:
         ``(N,)`` array of polygon areas.
     """
-    x = polygons[:, :, 0]
-    y = polygons[:, :, 1]
+    origin = polygons[:, 0:1, :]
+    translated = polygons - origin
+    x = translated[:, :, 0]
+    y = translated[:, :, 1]
     cross = x * np.roll(y, -1, axis=1) - np.roll(x, -1, axis=1) * y
     return cast(npt.NDArray[np.floating], 0.5 * np.abs(cross.sum(axis=1)))
 
@@ -584,14 +591,15 @@ def oriented_box_iou_batch(
         upper = rows <= cols
         rows, cols = rows[upper], cols[upper]
 
-    polygons_true = [box.astype(np.float32) for box in boxes_true]
-    polygons_detection = [box.astype(np.float32) for box in boxes_detection]
-
     ious: npt.NDArray[np.float64] = np.zeros((n, m), dtype=np.float64)
     for i, j in zip(rows, cols):
-        intersection, _ = cv2.intersectConvexConvex(
-            polygons_true[i], polygons_detection[j]
-        )
+        # Translate the pair to its own origin before the float32 cast: with
+        # large coordinate origins the float32 conversion alone would quantize
+        # the corners away, and the intersection area is translation-invariant.
+        origin = np.minimum(boxes_true[i].min(axis=0), boxes_detection[j].min(axis=0))
+        polygon_i = (boxes_true[i] - origin).astype(np.float32)
+        polygon_j = (boxes_detection[j] - origin).astype(np.float32)
+        intersection, _ = cv2.intersectConvexConvex(polygon_i, polygon_j)
         if intersection <= 0:
             continue
         denominator = (

--- a/src/supervision/detection/utils/iou_and_nms.py
+++ b/src/supervision/detection/utils/iou_and_nms.py
@@ -420,7 +420,7 @@ def _polygon_areas(polygons: npt.NDArray[np.number]) -> npt.NDArray[np.float64]:
         )
     else:
         polygons_float = polygons.astype(np.float64, copy=False)
-        translated = polygons_float - origin
+        translated = polygons_float - origin.astype(np.float64, copy=False)
     x = translated[:, :, 0]
     y = translated[:, :, 1]
     cross = x * np.roll(y, -1, axis=1) - np.roll(x, -1, axis=1) * y

--- a/tests/detection/utils/test_boxes.py
+++ b/tests/detection/utils/test_boxes.py
@@ -450,9 +450,8 @@ def test_obb_polygon_area_is_invariant_to_large_origins(origin: int) -> None:
     """Area is exact for boxes at large coordinate origins.
 
     Regression: the shoelace formula was evaluated on absolute coordinates, so
-    its cross products overflowed float64's exact-integer range (2**53) once the
-    origin grew. A 100x50 box at origin 1e10 was reported as ~16384 px^2 instead
-    of 5000.
+    large cross-products rounded once the origin grew. A 100x50 box at origin
+    1e10 was reported as ~16384 px^2 instead of 5000.
     """
     corners = np.array(
         [
@@ -464,3 +463,47 @@ def test_obb_polygon_area_is_invariant_to_large_origins(origin: int) -> None:
         dtype=np.int64,
     )
     assert obb_polygon_area(corners[None])[0] == 5000.0
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        pytest.param(-(2**53), id="negative-2pow53"),
+        pytest.param(2**53, id="positive-2pow53"),
+    ],
+)
+def test_obb_polygon_area_signed_int64_origin_preserves_unit_differences(
+    origin: int,
+) -> None:
+    """Translation-before-cast preserves a 2-by-2 signed int64 OBB area at 2**53."""
+    corners = np.array(
+        [
+            [origin, origin + 1],
+            [origin + 2, origin + 1],
+            [origin + 2, origin + 3],
+            [origin, origin + 3],
+        ],
+        dtype=np.int64,
+    )
+
+    result = obb_polygon_area(corners[None])
+
+    np.testing.assert_array_equal(result, np.array([4.0]))
+
+
+def test_obb_polygon_area_uint64_origin_avoids_underflow() -> None:
+    """Unsigned coordinates translate without wrapping before float conversion."""
+    origin = np.iinfo(np.uint64).max - 10
+    corners = np.array(
+        [
+            [origin, 0],
+            [origin + 2, 0],
+            [origin + 2, 2],
+            [origin, 2],
+        ],
+        dtype=np.uint64,
+    )
+
+    result = obb_polygon_area(corners[None])
+
+    np.testing.assert_array_equal(result, np.array([4.0]))

--- a/tests/detection/utils/test_boxes.py
+++ b/tests/detection/utils/test_boxes.py
@@ -10,6 +10,7 @@ from supervision.detection.utils.boxes import (
     clip_boxes,
     denormalize_boxes,
     move_boxes,
+    obb_polygon_area,
     pad_boxes,
     scale_boxes,
     xyxyxyxy_to_xyxy,
@@ -434,3 +435,32 @@ def test_pad_boxes(
     """pad_boxes expands each box by px horizontally and py (or px) vertically."""
     result = pad_boxes(xyxy=xyxy, px=px, py=py)
     np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        pytest.param(0, id="origin-0"),
+        pytest.param(10**8, id="origin-1e8"),
+        pytest.param(10**9, id="origin-1e9"),
+        pytest.param(10**10, id="origin-1e10"),
+    ],
+)
+def test_obb_polygon_area_is_invariant_to_large_origins(origin: int) -> None:
+    """Area is exact for boxes at large coordinate origins.
+
+    Regression: the shoelace formula was evaluated on absolute coordinates, so
+    its cross products overflowed float64's exact-integer range (2**53) once the
+    origin grew. A 100x50 box at origin 1e10 was reported as ~16384 px^2 instead
+    of 5000.
+    """
+    corners = np.array(
+        [
+            [origin, origin],
+            [origin + 100, origin],
+            [origin + 100, origin + 50],
+            [origin, origin + 50],
+        ],
+        dtype=np.int64,
+    )
+    assert obb_polygon_area(corners[None])[0] == 5000.0

--- a/tests/detection/utils/test_iou_and_nms.py
+++ b/tests/detection/utils/test_iou_and_nms.py
@@ -6,6 +6,9 @@ from contextlib import ExitStack as DoesNotRaise
 import numpy as np
 import pytest
 
+from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.core import Detections
+from supervision.detection.utils.boxes import xyxyxyxy_to_xyxy
 from supervision.detection.utils.iou_and_nms import (
     OverlapMetric,
     _group_overlapping_boxes,
@@ -1648,6 +1651,41 @@ def test_box_iou_large_int64_origin_preserves_coordinate_differences(
     assert result == pytest.approx(expected, rel=1e-6)
 
 
+@pytest.mark.parametrize(
+    ("origin", "overlap_metric", "expected"),
+    [
+        pytest.param(-(2**53), OverlapMetric.IOU, 1.0 / 3.0, id="negative-2pow53-iou"),
+        pytest.param(-(2**53), OverlapMetric.IOS, 0.5, id="negative-2pow53-ios"),
+        pytest.param(2**53, OverlapMetric.IOU, 1.0 / 3.0, id="positive-2pow53-iou"),
+        pytest.param(2**53, OverlapMetric.IOS, 0.5, id="positive-2pow53-ios"),
+    ],
+)
+def test_oriented_box_iou_batch_signed_int64_origin_preserves_unit_overlap(
+    origin: int,
+    overlap_metric: OverlapMetric,
+    expected: float,
+) -> None:
+    """Translation-before-cast preserves signed int64 OBB IoU and IoS at 2**53."""
+    box_true = np.array(
+        [[origin, 0], [origin + 2, 0], [origin + 2, 2], [origin, 2]],
+        dtype=np.int64,
+    )
+    box_detection = np.array(
+        [
+            [origin + 1, 0],
+            [origin + 3, 0],
+            [origin + 3, 2],
+            [origin + 1, 2],
+        ],
+        dtype=np.int64,
+    )
+
+    result = oriented_box_iou_batch(box_true[None], box_detection[None], overlap_metric)
+
+    assert result.shape == (1, 1)
+    assert result[0, 0] == pytest.approx(expected, rel=1e-12)
+
+
 def test_box_iou_rejects_complex_coordinates() -> None:
     """Complex coordinates are rejected instead of silently truncating values."""
     box = np.array([0, 0, 2, 2], dtype=np.complex128)
@@ -1731,9 +1769,8 @@ class TestOrientedBoxIouBatch:
         """IoU stays exact for boxes at large coordinate origins.
 
         Regression: polygon areas were computed from absolute coordinates, so
-        their shoelace products overflowed float64's exact-integer range
-        (2**53) once the origin grew. Identical boxes scored self-IoU ~0.85 at
-        origin 1e8 and exactly 0.0 at origin 1e10.
+        their large shoelace products rounded once the origin grew. Identical
+        boxes scored self-IoU ~0.85 at origin 1e8 and exactly 0.0 at origin 1e10.
         """
         baseline = oriented_box_iou_batch(
             _rotated_rect(50, 50, 40, 20, 30)[None],
@@ -2114,6 +2151,40 @@ class TestOrientedBoxNonMaxMerge:
 
         sorted_groups = sorted(sorted(g) for g in groups)
         assert sorted_groups == [[0, 1], [2]]
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        pytest.param("with_nms", id="with-nms"),
+        pytest.param("with_nmm", id="with-nmm"),
+    ],
+)
+def test_detections_obb_overlap_filter_large_origin_duplicates_deduplicate(
+    method: str,
+) -> None:
+    """Public NMS/NMM preserve 1e10 OBB precision to deduplicate duplicates."""
+    origin = 10**10
+    oriented_box = np.array(
+        [
+            [origin, origin],
+            [origin + 100, origin],
+            [origin + 100, origin + 50],
+            [origin, origin + 50],
+        ],
+        dtype=np.float64,
+    )
+    oriented_boxes = np.stack([oriented_box, oriented_box])
+    detections = Detections(
+        xyxy=xyxyxyxy_to_xyxy(oriented_boxes),
+        confidence=np.array([0.9, 0.8], dtype=np.float32),
+        class_id=np.array([0, 0]),
+        data={ORIENTED_BOX_COORDINATES: oriented_boxes},
+    )
+
+    result = getattr(detections, method)(threshold=0.5)
+
+    assert len(result) == 1
 
 
 class TestIouThresholdValidation:

--- a/tests/detection/utils/test_iou_and_nms.py
+++ b/tests/detection/utils/test_iou_and_nms.py
@@ -1718,6 +1718,43 @@ class TestOrientedBoxIouBatch:
         assert baseline[0, 0] > 0.4
         assert np.allclose(transformed, baseline, rtol=1e-5, atol=1e-7)
 
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            pytest.param(0, id="origin-0"),
+            pytest.param(10**8, id="origin-1e8"),
+            pytest.param(10**9, id="origin-1e9"),
+            pytest.param(10**10, id="origin-1e10"),
+        ],
+    )
+    def test_is_invariant_to_large_origins(self, origin: float) -> None:
+        """IoU stays exact for boxes at large coordinate origins.
+
+        Regression: polygon areas were computed from absolute coordinates, so
+        their shoelace products overflowed float64's exact-integer range
+        (2**53) once the origin grew. Identical boxes scored self-IoU ~0.85 at
+        origin 1e8 and exactly 0.0 at origin 1e10.
+        """
+        baseline = oriented_box_iou_batch(
+            _rotated_rect(50, 50, 40, 20, 30)[None],
+            _rotated_rect(52, 48, 40, 20, 35)[None],
+        )
+        boxes_true = (_rotated_rect(50, 50, 40, 20, 30).astype(np.float64) + origin)[
+            None
+        ]
+        boxes_detection = (
+            _rotated_rect(52, 48, 40, 20, 35).astype(np.float64) + origin
+        )[None]
+
+        transformed = oriented_box_iou_batch(boxes_true, boxes_detection)
+        self_iou = oriented_box_iou_batch(boxes_true, boxes_true)[0, 0]
+
+        assert baseline.shape == (1, 1)
+        assert transformed.shape == (1, 1)
+        assert np.allclose(transformed, baseline, rtol=1e-5, atol=1e-7)
+        # Identical boxes must score exactly 1.0 at every origin.
+        assert self_iou == pytest.approx(1.0, abs=1e-7)
+
     def test_supports_overlap_metric(self) -> None:
         """`overlap_metric=IOS` divides by the smaller area, so a small box fully
         contained in a larger one scores exactly 1.0, while IoU is the area ratio."""


### PR DESCRIPTION
## Description

Shoelace cross products on absolute coordinates overflow float64's exact-integer range (2**53) once the coordinate origin grows. Concretely:

- \sv.Detections.area\ (via \obb_polygon_area\) reports a 100x50 OBB at origin 1e10 as **~16384 px²** instead of **5000 px²** (relative error ~2.5e5 at origin 1e12).
- \sv.oriented_box_iou_batch\ reports identical boxes at origin 1e10 with **self-IoU 0.0** (and ~0.85 at origin 1e8) instead of 1.0, silently breaking OBB NMS / NMM.

This is the same bug class recently fixed for \sv.get_polygon_center\ (#2491) and \sv.box_iou\ (#2485): polygon geometry is translation-invariant, so compute it in origin-translated coordinates.

## Changes

- \obb_polygon_area\ (\src/supervision/detection/utils/boxes.py\): translate each box to its own first corner before the shoelace products.
- \_polygon_areas\ (\src/supervision/detection/utils/iou_and_nms.py\): same origin translation.
- \oriented_box_iou_batch\: translate each candidate pair to its own origin before the float32 cast that feeds \cv2.intersectConvexConvex\, so the cast cannot quantize large-origin corners away.
- Regression tests: \obb_polygon_area\ and \oriented_box_iou_batch\ are now parameterized over origins 0 / 1e8 / 1e9 / 1e10 and must match the small-coordinate baseline exactly.
- Changelog entry under \Unreleased > Fixed\.

## Reproduction

\\\python
import numpy as np
from supervision.detection.utils.iou_and_nms import oriented_box_iou_batch

box = np.array([[1e10, 1e10], [1e10 + 100, 1e10], [1e10 + 100, 1e10 + 50], [1e10, 1e10 + 50]], dtype=np.float64)
print(oriented_box_iou_batch(box[None], box[None]))  # before: 0.0, after: 1.0
\\\

## Test plan

- \pytest tests/detection/utils\ — 288 passed (incl. 8 new parametrized cases).
- Full suite — 3277 passed, 20 skipped; the single failure (\	est_ordinary_suite_passes_when_cv2_is_blocked\) also fails on clean \develop\ in this environment (no \opencv-python\ installed) and is unrelated.
- \uff check\ — clean.