### PR TITLE
perf: optimize `DetectionsSmoother` track cleanup

### DIFF
--- a/src/supervision/detection/tools/smoother.py
+++ b/src/supervision/detection/tools/smoother.py
@@ -144,15 +144,17 @@ class DetectionsSmoother:
 
             self.tracks[tracker_id].append(detections.select(detection_idx))
 
+        active_ids = set(detections.tracker_id.tolist())
+
         for track_id in self.tracks.keys():
-            if track_id not in detections.tracker_id:
+            if track_id not in active_ids:
                 self.tracks[track_id].append(None)
 
         for track_id in list(self.tracks.keys()):
-            if all([d is None for d in self.tracks[track_id]]):
+            if all(d is None for d in self.tracks[track_id]):
                 del self.tracks[track_id]
 
-        current_track_ids = {int(track_id) for track_id in detections.tracker_id}
+        current_track_ids = active_ids
         return self.get_smoothed_detections(track_ids=current_track_ids)
 
     def get_track(self, track_id: int) -> Detections | None:


### PR DESCRIPTION
## Summary
- Pre-build a `set` from `detections.tracker_id` for O(1) membership tests instead of O(n) linear scans per track
- Use generator expression in `all()` to allow short-circuit without allocating an intermediate list
- Reuse the pre-built set instead of rebuilding it for `current_track_ids`

## Test plan
- [x] All 3227 existing tests pass
- [x] Pre-commit checks pass (ruff, mypy, codespell, etc.)
- [x] No behavioral change — pure performance optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)