### PR TITLE
test(detection): add the geometry contract test

### DIFF
--- a/tests/detection/test_geometry_contract.py
+++ b/tests/detection/test_geometry_contract.py
@@ -1,0 +1,159 @@
+"""Contract tests for geometry-aware detection ops (issue #2318).
+
+Several fixes have been the same bug in different functions: an op reaches for
+`xyxy` and forgets the real geometry lives in `data["xyxyxyxy"]`. Because `xyxy`
+is always present the wrong answer is the silent default, so each occurrence
+looked like a fresh bug rather than a recurring one:
+
+* `Detections.area` returned the envelope area, not the rotated body (#2306)
+* `with_nms` / `with_nmm` dropped crossed oriented boxes via envelope IoU (#2303)
+* `as_yolo` dropped oriented-box rotation on export (#2289)
+* `DetectionsSmoother` averaged `xyxy` and carried the corners over unsmoothed
+  from the oldest frame in the window (#2489)
+
+These tests state the shared contract once: **an op that claims to be
+geometry-aware must produce a different answer for an oriented box than for its
+axis-aligned envelope.** A new op is covered by adding one entry to
+`GEOMETRY_AWARE_OPS`, and an op that silently falls back to `xyxy` fails here
+rather than in a bug report months later.
+
+The fixture is a square rotated 45 degrees, whose envelope has exactly twice its
+area. That makes the expected values exact rather than approximate, so a failure
+says which geometry was used rather than only that a number moved.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection._geometry_dispatch import detection_area, detection_iou
+from supervision.detection.core import Detections
+
+#: Half-diagonal of the rotated square used throughout.
+HALF_DIAGONAL = 10.0
+
+
+def diamond(
+    cx: float = 0.0, cy: float = 0.0, half_diagonal: float = HALF_DIAGONAL
+) -> np.ndarray:
+    """Corners of a square rotated 45 degrees about ``(cx, cy)``.
+
+    Its side is ``half_diagonal * sqrt(2)``, so its area is ``2 * half_diagonal ** 2``,
+    exactly half the area of its axis-aligned envelope.
+    """
+    return np.array(
+        [
+            [
+                [cx, cy - half_diagonal],
+                [cx + half_diagonal, cy],
+                [cx, cy + half_diagonal],
+                [cx - half_diagonal, cy],
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+
+def envelope_of(corners: np.ndarray) -> np.ndarray:
+    """The axis-aligned box that bounds ``corners``."""
+    return np.array(
+        [
+            [
+                corners[0, :, 0].min(),
+                corners[0, :, 1].min(),
+                corners[0, :, 0].max(),
+                corners[0, :, 1].max(),
+            ]
+        ],
+        dtype=np.float32,
+    )
+
+
+def oriented(cx: float = 0.0, cy: float = 0.0) -> Detections:
+    """A detection carrying oriented corners and the matching envelope."""
+    corners = diamond(cx, cy)
+    return Detections(
+        xyxy=envelope_of(corners),
+        class_id=np.array([0]),
+        data={ORIENTED_BOX_COORDINATES: corners},
+    )
+
+
+def envelope_only(cx: float = 0.0, cy: float = 0.0) -> Detections:
+    """The same detection with the oriented corners stripped."""
+    return Detections(xyxy=envelope_of(diamond(cx, cy)), class_id=np.array([0]))
+
+
+#: Each entry runs an op against oriented input and against its envelope. The
+#: contract is that the two disagree; a fallback to `xyxy` makes them equal.
+GEOMETRY_AWARE_OPS: list[
+    tuple[str, Callable[[Callable[..., Detections]], np.ndarray]]
+] = [
+    ("detection_area", lambda build: detection_area(build())),
+    (
+        "detection_iou",
+        lambda build: detection_iou(build(), build(HALF_DIAGONAL, HALF_DIAGONAL)),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "run"), GEOMETRY_AWARE_OPS, ids=[n for n, _ in GEOMETRY_AWARE_OPS]
+)
+def test_op_respects_geometry(
+    name: str, run: Callable[[Callable[..., Detections]], np.ndarray]
+) -> None:
+    """A geometry-aware op must not answer the same for a box and its envelope."""
+    with_corners = np.asarray(run(oriented), dtype=float)
+    without_corners = np.asarray(run(envelope_only), dtype=float)
+
+    assert with_corners.shape == without_corners.shape, (
+        f"{name} changed result shape depending on whether corners were present"
+    )
+    assert not np.allclose(with_corners, without_corners), (
+        f"{name} gave the same answer for an oriented box and its envelope "
+        f"({with_corners.tolist()}), so it is reading xyxy rather than the "
+        "geometry the detection actually carries"
+    )
+
+
+class TestGeometryContractValues:
+    """The exact values behind the contract, so a failure names the geometry used."""
+
+    def test_area_uses_the_rotated_body(self) -> None:
+        """A 45-degree square has exactly half its envelope's area."""
+        expected_obb = 2 * HALF_DIAGONAL**2
+        expected_envelope = 4 * HALF_DIAGONAL**2
+
+        assert_allclose(detection_area(oriented()), [expected_obb], rtol=1e-5)
+        assert_allclose(detection_area(envelope_only()), [expected_envelope], rtol=1e-5)
+
+    def test_iou_uses_the_rotated_body(self) -> None:
+        """Diamonds offset along the diagonal touch on an edge; envelopes overlap.
+
+        Envelopes are ``[-d, -d, d, d]`` and ``[0, 0, 2d, 2d]``: they intersect over
+        ``d * d`` with a union of ``7 * d * d``. The bodies meet only along the shared
+        edge, so the oriented overlap is zero.
+        """
+        obb = detection_iou(oriented(), oriented(HALF_DIAGONAL, HALF_DIAGONAL))
+        envelope = detection_iou(
+            envelope_only(), envelope_only(HALF_DIAGONAL, HALF_DIAGONAL)
+        )
+
+        assert_allclose(obb, [[0.0]], atol=1e-6)
+        assert_allclose(envelope, [[1 / 7]], rtol=1e-5)
+
+    def test_envelope_is_a_faithful_bound(self) -> None:
+        """Guards the fixture itself: the envelope really does bound the corners."""
+        corners = diamond()
+        x0, y0, x1, y1 = envelope_of(corners)[0]
+
+        assert corners[0, :, 0].min() == pytest.approx(x0)
+        assert corners[0, :, 1].min() == pytest.approx(y0)
+        assert corners[0, :, 0].max() == pytest.approx(x1)
+        assert corners[0, :, 1].max() == pytest.approx(y1)

--- a/tests/detection/test_geometry_contract.py
+++ b/tests/detection/test_geometry_contract.py
@@ -91,35 +91,39 @@ def _envelope_only(cx: float = 0.0, cy: float = 0.0) -> Detections:
 
 #: Each entry runs an op against oriented input and against its envelope. The
 #: contract is that the two disagree; a fallback to `xyxy` makes them equal.
-_GEOMETRY_AWARE_OPS: list[
-    tuple[str, Callable[[Callable[..., Detections]], np.ndarray]]
-] = [
-    ("detection_area", lambda build: detection_area(build())),
-    (
+_GEOMETRY_AWARE_OPS = [
+    pytest.param(
+        "detection_area",
+        lambda build: detection_area(build()),
+        id="detection-area",
+    ),
+    pytest.param(
         "detection_iou",
         lambda build: detection_iou(build(), build(HALF_DIAGONAL, HALF_DIAGONAL)),
+        id="detection-iou",
     ),
 ]
 
 
-@pytest.mark.parametrize(
-    ("name", "run"), _GEOMETRY_AWARE_OPS, ids=[n for n, _ in _GEOMETRY_AWARE_OPS]
-)
-def test_op_respects_geometry(
-    name: str, run: Callable[[Callable[..., Detections]], np.ndarray]
-) -> None:
-    """A geometry-aware op must not answer the same for a box and its envelope."""
-    with_corners = np.asarray(run(_oriented), dtype=float)
-    without_corners = np.asarray(run(_envelope_only), dtype=float)
+class TestGeometryAwareOperations:
+    """Contract tests shared by geometry-aware detection operations."""
 
-    assert with_corners.shape == without_corners.shape, (
-        f"{name} changed result shape depending on whether corners were present"
-    )
-    assert not np.allclose(with_corners, without_corners), (
-        f"{name} gave the same answer for an oriented box and its envelope "
-        f"({with_corners.tolist()}), so it is reading xyxy rather than the "
-        "geometry the detection actually carries"
-    )
+    @pytest.mark.parametrize(("name", "run"), _GEOMETRY_AWARE_OPS)
+    def test_op_respects_geometry(
+        self, name: str, run: Callable[[Callable[..., Detections]], np.ndarray]
+    ) -> None:
+        """A geometry-aware op must not answer the same for a box and its envelope."""
+        with_corners = np.asarray(run(_oriented), dtype=float)
+        without_corners = np.asarray(run(_envelope_only), dtype=float)
+
+        assert with_corners.shape == without_corners.shape, (
+            f"{name} changed result shape depending on whether corners were present"
+        )
+        assert not np.allclose(with_corners, without_corners), (
+            f"{name} gave the same answer for an oriented box and its envelope "
+            f"({with_corners.tolist()}), so it is reading xyxy rather than the "
+            "geometry the detection actually carries"
+        )
 
 
 class TestGeometryContractValues:

--- a/tests/detection/test_geometry_contract.py
+++ b/tests/detection/test_geometry_contract.py
@@ -14,7 +14,7 @@ looked like a fresh bug rather than a recurring one:
 These tests state the shared contract once: **an op that claims to be
 geometry-aware must produce a different answer for an oriented box than for its
 axis-aligned envelope.** A new op is covered by adding one entry to
-`GEOMETRY_AWARE_OPS`, and an op that silently falls back to `xyxy` fails here
+`_GEOMETRY_AWARE_OPS`, and an op that silently falls back to `xyxy` fails here
 rather than in a bug report months later.
 
 The fixture is a square rotated 45 degrees, whose envelope has exactly twice its
@@ -38,7 +38,7 @@ from supervision.detection.core import Detections
 HALF_DIAGONAL = 10.0
 
 
-def diamond(
+def _diamond(
     cx: float = 0.0, cy: float = 0.0, half_diagonal: float = HALF_DIAGONAL
 ) -> np.ndarray:
     """Corners of a square rotated 45 degrees about ``(cx, cy)``.
@@ -59,7 +59,7 @@ def diamond(
     )
 
 
-def envelope_of(corners: np.ndarray) -> np.ndarray:
+def _envelope_of(corners: np.ndarray) -> np.ndarray:
     """The axis-aligned box that bounds ``corners``."""
     return np.array(
         [
@@ -74,24 +74,24 @@ def envelope_of(corners: np.ndarray) -> np.ndarray:
     )
 
 
-def oriented(cx: float = 0.0, cy: float = 0.0) -> Detections:
+def _oriented(cx: float = 0.0, cy: float = 0.0) -> Detections:
     """A detection carrying oriented corners and the matching envelope."""
-    corners = diamond(cx, cy)
+    corners = _diamond(cx, cy)
     return Detections(
-        xyxy=envelope_of(corners),
+        xyxy=_envelope_of(corners),
         class_id=np.array([0]),
         data={ORIENTED_BOX_COORDINATES: corners},
     )
 
 
-def envelope_only(cx: float = 0.0, cy: float = 0.0) -> Detections:
+def _envelope_only(cx: float = 0.0, cy: float = 0.0) -> Detections:
     """The same detection with the oriented corners stripped."""
-    return Detections(xyxy=envelope_of(diamond(cx, cy)), class_id=np.array([0]))
+    return Detections(xyxy=_envelope_of(_diamond(cx, cy)), class_id=np.array([0]))
 
 
 #: Each entry runs an op against oriented input and against its envelope. The
 #: contract is that the two disagree; a fallback to `xyxy` makes them equal.
-GEOMETRY_AWARE_OPS: list[
+_GEOMETRY_AWARE_OPS: list[
     tuple[str, Callable[[Callable[..., Detections]], np.ndarray]]
 ] = [
     ("detection_area", lambda build: detection_area(build())),
@@ -103,14 +103,14 @@ GEOMETRY_AWARE_OPS: list[
 
 
 @pytest.mark.parametrize(
-    ("name", "run"), GEOMETRY_AWARE_OPS, ids=[n for n, _ in GEOMETRY_AWARE_OPS]
+    ("name", "run"), _GEOMETRY_AWARE_OPS, ids=[n for n, _ in _GEOMETRY_AWARE_OPS]
 )
 def test_op_respects_geometry(
     name: str, run: Callable[[Callable[..., Detections]], np.ndarray]
 ) -> None:
     """A geometry-aware op must not answer the same for a box and its envelope."""
-    with_corners = np.asarray(run(oriented), dtype=float)
-    without_corners = np.asarray(run(envelope_only), dtype=float)
+    with_corners = np.asarray(run(_oriented), dtype=float)
+    without_corners = np.asarray(run(_envelope_only), dtype=float)
 
     assert with_corners.shape == without_corners.shape, (
         f"{name} changed result shape depending on whether corners were present"
@@ -130,8 +130,10 @@ class TestGeometryContractValues:
         expected_obb = 2 * HALF_DIAGONAL**2
         expected_envelope = 4 * HALF_DIAGONAL**2
 
-        assert_allclose(detection_area(oriented()), [expected_obb], rtol=1e-5)
-        assert_allclose(detection_area(envelope_only()), [expected_envelope], rtol=1e-5)
+        assert_allclose(detection_area(_oriented()), [expected_obb], rtol=1e-5)
+        assert_allclose(
+            detection_area(_envelope_only()), [expected_envelope], rtol=1e-5
+        )
 
     def test_iou_uses_the_rotated_body(self) -> None:
         """Diamonds offset along the diagonal touch on an edge; envelopes overlap.
@@ -140,9 +142,9 @@ class TestGeometryContractValues:
         ``d * d`` with a union of ``7 * d * d``. The bodies meet only along the shared
         edge, so the oriented overlap is zero.
         """
-        obb = detection_iou(oriented(), oriented(HALF_DIAGONAL, HALF_DIAGONAL))
+        obb = detection_iou(_oriented(), _oriented(HALF_DIAGONAL, HALF_DIAGONAL))
         envelope = detection_iou(
-            envelope_only(), envelope_only(HALF_DIAGONAL, HALF_DIAGONAL)
+            _envelope_only(), _envelope_only(HALF_DIAGONAL, HALF_DIAGONAL)
         )
 
         assert_allclose(obb, [[0.0]], atol=1e-6)
@@ -150,8 +152,8 @@ class TestGeometryContractValues:
 
     def test_envelope_is_a_faithful_bound(self) -> None:
         """Guards the fixture itself: the envelope really does bound the corners."""
-        corners = diamond()
-        x0, y0, x1, y1 = envelope_of(corners)[0]
+        corners = _diamond()
+        x0, y0, x1, y1 = _envelope_of(corners)[0]
 
         assert corners[0, :, 0].min() == pytest.approx(x0)
         assert corners[0, :, 1].min() == pytest.approx(y0)


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [ ] Added docs entry for autogeneration (if new functions/classes)
- [x] Added/updated tests
- [x] All tests pass locally

</details>

## Description

Adds the `test_op_respects_geometry` contract test that #2318 lists as its third rollout step, after the `detection_area` / `detection_iou` dispatch that landed in #2374 and #2382.

The contract is stated once: **a geometry-aware op must not give the same answer for an oriented box as for its axis-aligned envelope.** A new op joins by adding one entry to `GEOMETRY_AWARE_OPS`; an op that silently falls back to `xyxy` fails here rather than in a bug report months later.

## Type of Change

- 🧪 Test update

## Motivation and Context

#2318 describes the pattern rather than a single bug: `Detections` carries several geometries at once, `xyxy` is always present, so forgetting the real one fails silently and looks like a fresh bug each time.

- `Detections.area` returned the envelope area, not the rotated body (#2306)
- `with_nms` / `with_nmm` dropped crossed oriented boxes via envelope IoU (#2303)
- `as_yolo` dropped rotation on export (#2289)
- `DetectionsSmoother` averaged `xyxy` and carried the corners over unsmoothed from the oldest frame in the window (#2489)

Each was found by someone hitting it in practice. The contract test is the part of #2318 that makes the next one fail in CI instead.

Refs #2318.

## Changes Made

- Adds `tests/detection/test_geometry_contract.py`.
- `GEOMETRY_AWARE_OPS` is a registry of ops, each run twice: once against a detection carrying oriented corners, once against the same detection with the corners stripped. The contract is that the two disagree.
- Exact-value tests alongside the contract, so a failure says which geometry was used rather than only that a number moved.
- A guard on the fixture itself, so a broken fixture cannot quietly weaken the contract.

The fixture is a square rotated 45 degrees. Its envelope has exactly twice its area, which keeps the expectations exact:

```
area(oriented)  = 2 * d^2      area(envelope)  = 4 * d^2
```

For IoU, two diamonds offset along the diagonal meet only along a shared edge while their envelopes overlap over `d * d` with a union of `7 * d * d`:

```
iou(oriented)   = 0            iou(envelope)   = 1/7
```

## Testing

- [x] I have tested this code locally
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass

A test that never fails is worth nothing, so I checked it catches the bug class by reintroducing two of the historical occurrences.

Reverting `detection_area` to the envelope, i.e. #2306:

```text
FAILED test_op_respects_geometry[detection_area]
E   AssertionError: detection_area gave the same answer for an oriented box and its
    envelope ([400.0]), so it is reading xyxy rather than the geometry the detection
    actually carries
FAILED TestGeometryContractValues::test_area_uses_the_rotated_body
2 failed, 3 passed
```

Reverting `detection_iou` to box IoU, i.e. #2303:

```text
FAILED test_op_respects_geometry[detection_iou]
FAILED TestGeometryContractValues::test_iou_uses_the_rotated_body
2 failed, 3 passed
```

Both restored afterwards; the diff contains no source change.

```text
tests/detection/                     1624 passed, 1 skipped
tests/detection/test_geometry_contract.py   5 passed
```

`ruff check` and `ruff format --check` clean.

## Additional Notes

Two things I deliberately left out, both worth your call rather than mine:

- **Scope.** Only the two ops that currently go through `_geometry_dispatch` are registered. `as_coco` / `as_pascal_voc` and the annotators also read geometry, but adding them here would assert behaviour they do not have yet, which turns a contract test into a failing wishlist. They are one line each once the dispatch reaches them.
- **`move_detections`.** #2318 lists consolidating it as step 1, and I could not find a `move_detections` in the tree to consolidate, so I have not assumed what its shape should be.

I came to this from #2489, which was the `DetectionsSmoother` instance of the same bug: the corners were carried over unsmoothed while `xyxy` was averaged. That one was found by reading the code rather than by a test, which is the gap this closes.
