### PR TITLE
fix(ci): update latest docs with existing alias

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -62,8 +62,7 @@ jobs:
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if mike list | grep -Eq '^latest(\s|$)'; then mike delete latest; fi
-          mike deploy --push latest
+          mike deploy --push --update-aliases latest
 
       - name: 🏷️ Determine release deployment metadata
         id: release_metadata


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the change
- [x] Documentation and API updates are not applicable
- [x] Unit tests are not applicable to this workflow-only change
- [x] Relevant repository pre-commit checks pass

</details>

## Description

Replace the manual `latest` alias detection and deletion with the Mike-supported `--update-aliases` deployment behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

`https://supervision.roboflow.com/latest/` still serves the 0.28.0 documentation even though 0.29.0, 0.29.1, and 0.30.0 have been published.

The current workflow looks for a line beginning with `latest` in `mike list`. Mike represents this state as `0.28.0 [latest]`, so the condition never matches and the alias is not deleted. The subsequent deployment then fails with `error: version latest already exists`.

This caused the `release/latest` documentation deployments for 0.29.0 and 0.29.1 to fail. The 0.30.0 run timed out during checkout before reaching the same deployment command.

The previous attempt in #2340 added the alias check, but its pattern does not match the actual Mike output.

## Changes Made

- Replace the output-format-dependent `mike list | grep` check.
- Deploy `latest` with Mike `--update-aliases`, which handles the current alias state and subsequent version updates.
- Align Supervision with the equivalent RF-DETR `release/latest` automation, which uses the same `mike deploy --push --update-aliases latest` command: https://github.com/roboflow/rf-detr/blob/develop/.github/workflows/publish-docs.yml

Trackers and Maestro likewise use `--update-aliases` when advancing their latest documentation during release deployments:

- https://github.com/roboflow/trackers/blob/develop/.github/workflows/publish-docs.yml
- https://github.com/roboflow/maestro/blob/develop/.github/workflows/publish-docs.yml

## Testing

- [x] `uvx pre-commit run --files .github/workflows/publish-docs.yml`
- [x] `git diff --check`
- [ ] Live deployment cannot be exercised from a pull request

## Additional Notes

After this is merged into `develop`, the fix must also reach `release/latest` and a push to that branch must trigger the workflow to repair the currently deployed `/latest/` documentation.