### PR TITLE
docs: track only develop on upstream remote

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Then, run `git clone` to download the project code to your computer.
 You should also set up `roboflow/supervision` as an "upstream" remote (that is, tell git that the reference Supervision repository was the source of your fork of it):
 
 ```bash
-git remote add upstream https://github.com/roboflow/supervision.git
+git remote add -t develop upstream https://github.com/roboflow/supervision.git
 git fetch upstream
 ```
 
@@ -164,7 +164,7 @@ Before starting your work on the project, set up your development environment:
 2. **Set up the upstream remote:**
 
    ```bash
-   git remote add upstream https://github.com/roboflow/supervision.git
+   git remote add -t develop upstream https://github.com/roboflow/supervision.git
    git fetch upstream
    ```
 


### PR DESCRIPTION
## Summary

- configure the `upstream` remote to track only `develop` in both contributor setup snippets
- avoid fetching unrelated upstream branches, including `gh-pages`, when contributors run `git fetch upstream`

## Motivation

I initially ran a naive full clone of the repository. It fetched a 3.75 GiB Git pack and took a long time to complete. A local object audit showed that roughly 3.55 GiB was exclusive to `gh-pages`, while all other branches and tags together repacked to about 0.21 GiB.

The contributor guide already recommends a shallow clone of `develop`, but the subsequent unrestricted `git remote add upstream` and `git fetch upstream` configure and fetch every upstream branch. That can pull in the large `gh-pages` branch after the shallow clone.

The old-version directories in the current `gh-pages` tree are needed to serve older documentation versions. However, the prior generated-site deployment commits behind the current tree are not required by GitHub Pages to serve those files, and none of that branch history is needed for normal source development. This PR only narrows the contributor fetch configuration; it does not change documentation deployment or retention.

## Verification

- `uvx pre-commit run --files .github/CONTRIBUTING.md`
- `git diff --check`
