### PR TITLE
refactor(ci): loop-copy GEO root files in publish-docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -103,12 +103,10 @@ jobs:
           (github.event_name == 'push' && github.ref == 'refs/heads/release/latest') ||
           (github.event_name == 'release' && github.event.action == 'published' && steps.release_metadata.outputs.is_rc != 'true')
         run: |
-          cp docs/robots.txt /tmp/robots.txt
-          cp docs/llms.txt /tmp/llms.txt
-          cp docs/llms.full.txt /tmp/llms.full.txt
-          cp docs/llms-100k.txt /tmp/llms-100k.txt
-          cp docs/_headers /tmp/headers.txt
-          cp docs/0d5d9799b1cc4a39825146388c6781eb.txt /tmp/indexnow.txt
+          root_files=(robots.txt llms.txt llms.full.txt llms-100k.txt _headers 0d5d9799b1cc4a39825146388c6781eb.txt)
+          for f in "${root_files[@]}"; do
+            cp "docs/$f" "/tmp/$f"
+          done
           if [[ "$GITHUB_REF" == "refs/heads/release/latest" ]]; then
             version_dir="latest"
           else
@@ -116,29 +114,14 @@ jobs:
           fi
           git fetch origin gh-pages
           git checkout gh-pages
-          cp /tmp/robots.txt robots.txt
-          cp /tmp/llms.txt llms.txt
-          cp /tmp/llms.full.txt llms.full.txt
-          cp /tmp/llms-100k.txt llms-100k.txt
-          cp /tmp/headers.txt _headers
-          cp /tmp/indexnow.txt 0d5d9799b1cc4a39825146388c6781eb.txt
+          for f in "${root_files[@]}"; do
+            cp "/tmp/$f" "$f"
+          done
+          files_to_add=("${root_files[@]}")
           if [[ -n "$version_dir" && -f "$version_dir/sitemap.xml" ]]; then
             cp "$version_dir/sitemap.xml" sitemap.xml
             gzip -9 -c sitemap.xml > sitemap.xml.gz
-          fi
-          files_to_add=(
-            robots.txt
-            llms.txt
-            llms.full.txt
-            llms-100k.txt
-            _headers
-            0d5d9799b1cc4a39825146388c6781eb.txt
-          )
-          if [[ -f "sitemap.xml" ]]; then
-            files_to_add+=(sitemap.xml)
-          fi
-          if [[ -f "sitemap.xml.gz" ]]; then
-            files_to_add+=(sitemap.xml.gz)
+            files_to_add+=(sitemap.xml sitemap.xml.gz)
           fi
           git add "${files_to_add[@]}"
           git diff --cached --quiet || git commit -m "chore: update GEO root files"


### PR DESCRIPTION
This pull request refactors the workflow for publishing documentation by simplifying and consolidating the handling of root documentation files in the `.github/workflows/publish-docs.yml` workflow file. The main improvement is replacing repetitive file copy commands with a loop, which makes the script easier to maintain and less error-prone.

Workflow script simplification:

* Replaced multiple individual `cp` commands for copying root documentation files with a loop that iterates over an array of filenames, reducing duplication and improving maintainability.
* Consolidated the logic for building the `files_to_add` array, ensuring that sitemap files are only added if they exist, and appending them to the array in a more streamlined way.