### PR TITLE
fix(_cv2): lazy-import PyAV to avoid duplicate libavdevice load

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@ date_modified: 2026-08-11
 - `sv.box_iou` now calculates overlap in `float64`, preventing `int32` area overflow for large boxes. Its scalar result now matches `sv.box_iou_batch` for the same input.
 - `sv.list_files_with_extensions` no longer includes directories when listing all files without an extension filter.
 - `sv.pillow_to_cv2` now accepts RGBA images when the cv2-free fallback backend is active, matching OpenCV by dropping alpha and returning BGR channels.
+- `import supervision` no longer loads PyAV's native libraries when the OpenCV backend is selected. PyAV is now imported lazily on first use by the PyAV-backed video/audio fallback, preventing a duplicate `libavdevice` warning (and possible crash) on macOS when both `av` and `opencv-python` are installed.
 
 ### 0.30.0 <small>Aug 4, 2026</small>
 

--- a/src/supervision/_cv2/_video.py
+++ b/src/supervision/_cv2/_video.py
@@ -10,7 +10,6 @@ from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
-import av
 import numpy as np
 import numpy.typing as npt
 
@@ -24,6 +23,21 @@ from supervision._cv2.constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _load_av() -> Any:
+    """Import PyAV on first use so its native libs load only when needed.
+
+    `av` bundles its own `libavdevice`, which macOS's Objective-C runtime
+    treats as a duplicate of the one OpenCV's wheel already bundles when
+    both are loaded into the same process (GH-2505). Deferring the import
+    until a PyAV-backed capture/writer/remux call actually happens keeps an
+    OpenCV-only import from ever touching PyAV's native libraries.
+    """
+    import av
+
+    return av
+
 
 _CODECS = {
     "mp4v": ("mpeg4", "yuv420p"),
@@ -75,7 +89,7 @@ class _VideoCapture:
                 raise BackendUnavailableError(
                     "PyAV fallback supports file paths, not webcam device indexes."
                 )
-            self._container = av.open(str(source), mode="r")
+            self._container = _load_av().open(str(source), mode="r")
             if not self._container.streams.video:
                 raise ValueError(f"Video source has no video stream: {source}")
             self._stream = self._container.streams.video[0]
@@ -97,7 +111,7 @@ class _VideoCapture:
 
         count = int(getattr(self._stream, "frames", 0) or 0)
         if count <= 0 and not isinstance(self._source, int):
-            container = av.open(str(self._source), mode="r")
+            container = _load_av().open(str(self._source), mode="r")
             try:
                 count = sum(1 for _ in container.decode(video=self._stream.index))
             finally:
@@ -211,7 +225,7 @@ class _VideoWriter:
 
         try:
             codec, pixel_format = _codec_details(fourcc)
-            self._container = av.open(str(filename), mode="w")
+            self._container = _load_av().open(str(filename), mode="w")
             rate = Fraction(str(fps)).limit_denominator(100_000)
             self._stream = self._container.add_stream(codec, rate=rate)
             self._stream.width = self._width
@@ -238,7 +252,7 @@ class _VideoWriter:
         if frame.dtype != np.uint8:
             raise ValueError("Video frames must use uint8 dtype")
 
-        video_frame = av.VideoFrame.from_ndarray(
+        video_frame = _load_av().VideoFrame.from_ndarray(
             np.ascontiguousarray(frame), format="bgr24"
         )
         for packet in self._stream.encode(video_frame):
@@ -286,6 +300,7 @@ def _mux_audio(source_path: str, video_path: str) -> None:
     output_container: Any = None
     temporary_path: str | None = None
     try:
+        av = _load_av()
         source_container = av.open(source_path, mode="r")
         video_container = av.open(video_path, mode="r")
         if not source_container.streams.audio or not video_container.streams.video:

--- a/src/supervision/_cv2/_video.py
+++ b/src/supervision/_cv2/_video.py
@@ -24,20 +24,12 @@ from supervision._cv2.constants import (
 
 logger = logging.getLogger(__name__)
 
-
-def _load_av() -> Any:
-    """Import PyAV on first use so its native libs load only when needed.
-
-    `av` bundles its own `libavdevice`, which macOS's Objective-C runtime
-    treats as a duplicate of the one OpenCV's wheel already bundles when
-    both are loaded into the same process (GH-2505). Deferring the import
-    until a PyAV-backed capture/writer/remux call actually happens keeps an
-    OpenCV-only import from ever touching PyAV's native libraries.
-    """
-    import av
-
-    return av
-
+# PyAV is imported locally in each function below, not at module scope: it
+# bundles its own `libavdevice`, which macOS's Objective-C runtime treats as
+# a duplicate of the one OpenCV's wheel already bundles when both are loaded
+# into the same process (GH-2505). Deferring the import until a PyAV-backed
+# capture/writer/remux call actually happens keeps an OpenCV-only import
+# from ever touching PyAV's native libraries.
 
 _CODECS = {
     "mp4v": ("mpeg4", "yuv420p"),
@@ -89,7 +81,9 @@ class _VideoCapture:
                 raise BackendUnavailableError(
                     "PyAV fallback supports file paths, not webcam device indexes."
                 )
-            self._container = _load_av().open(str(source), mode="r")
+            import av
+
+            self._container = av.open(str(source), mode="r")
             if not self._container.streams.video:
                 raise ValueError(f"Video source has no video stream: {source}")
             self._stream = self._container.streams.video[0]
@@ -111,7 +105,9 @@ class _VideoCapture:
 
         count = int(getattr(self._stream, "frames", 0) or 0)
         if count <= 0 and not isinstance(self._source, int):
-            container = _load_av().open(str(self._source), mode="r")
+            import av
+
+            container = av.open(str(self._source), mode="r")
             try:
                 count = sum(1 for _ in container.decode(video=self._stream.index))
             finally:
@@ -224,8 +220,10 @@ class _VideoWriter:
         self._error: Exception | None = None
 
         try:
+            import av
+
             codec, pixel_format = _codec_details(fourcc)
-            self._container = _load_av().open(str(filename), mode="w")
+            self._container = av.open(str(filename), mode="w")
             rate = Fraction(str(fps)).limit_denominator(100_000)
             self._stream = self._container.add_stream(codec, rate=rate)
             self._stream.width = self._width
@@ -252,7 +250,9 @@ class _VideoWriter:
         if frame.dtype != np.uint8:
             raise ValueError("Video frames must use uint8 dtype")
 
-        video_frame = _load_av().VideoFrame.from_ndarray(
+        import av
+
+        video_frame = av.VideoFrame.from_ndarray(
             np.ascontiguousarray(frame), format="bgr24"
         )
         for packet in self._stream.encode(video_frame):
@@ -300,7 +300,8 @@ def _mux_audio(source_path: str, video_path: str) -> None:
     output_container: Any = None
     temporary_path: str | None = None
     try:
-        av = _load_av()
+        import av
+
         source_container = av.open(source_path, mode="r")
         video_container = av.open(video_path, mode="r")
         if not source_container.streams.audio or not video_container.streams.video:

--- a/tests/cv2/test_video.py
+++ b/tests/cv2/test_video.py
@@ -88,12 +88,30 @@ def _run_without_opencv(source: str) -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_video_module_uses_required_pyav_dependency() -> None:
-    """The video fallback imports required PyAV directly without a loader."""
-    from supervision._cv2 import _video
+def test_opencv_backend_does_not_eagerly_import_pyav() -> None:
+    """Selecting the OpenCV backend must not load PyAV's native libraries.
 
-    assert _video.av.__name__ == "av"
-    assert not hasattr(_video, "_load_av")
+    Regression test for GH-2505: `_cv2/_video.py` used to `import av` at
+    module scope, so `_cv2/__init__.py` loaded PyAV's native `libavdevice`
+    alongside OpenCV's own bundled copy even when OpenCV was the selected
+    backend. On macOS this triggers a duplicate Objective-C class warning
+    (and, per PyAV-Org/PyAV#2215, risks a real crash).
+    """
+    source = (
+        "import sys\n"
+        "import supervision\n"
+        "assert supervision._cv2.BACKEND_NAME == 'opencv', "
+        "supervision._cv2.BACKEND_NAME\n"
+        "assert 'av' not in sys.modules, sorted(sys.modules)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", source],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_fallback_capture_reports_metadata_and_supports_exact_seek(

--- a/tests/cv2/test_video.py
+++ b/tests/cv2/test_video.py
@@ -88,20 +88,20 @@ def _run_without_opencv(source: str) -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_opencv_backend_does_not_eagerly_import_pyav() -> None:
-    """Selecting the OpenCV backend must not load PyAV's native libraries.
+def test_importing_supervision_does_not_eagerly_import_pyav() -> None:
+    """A plain `import supervision` must not load PyAV's native libraries.
 
     Regression test for GH-2505: `_cv2/_video.py` used to `import av` at
     module scope, so `_cv2/__init__.py` loaded PyAV's native `libavdevice`
-    alongside OpenCV's own bundled copy even when OpenCV was the selected
-    backend. On macOS this triggers a duplicate Objective-C class warning
-    (and, per PyAV-Org/PyAV#2215, risks a real crash).
+    on every import, regardless of which backend (`opencv` or the NumPy
+    `fallback`) ended up selected. On macOS this triggers a duplicate
+    Objective-C class warning (and, per PyAV-Org/PyAV#2215, risks a real
+    crash) whenever OpenCV's own bundled `libavdevice` is also present.
+    `av` should only load once a PyAV-backed capture/writer is actually used.
     """
     source = (
         "import sys\n"
         "import supervision\n"
-        "assert supervision._cv2.BACKEND_NAME == 'opencv', "
-        "supervision._cv2.BACKEND_NAME\n"
         "assert 'av' not in sys.modules, sorted(sys.modules)\n"
     )
     result = subprocess.run(


### PR DESCRIPTION
This pull request refactors the way PyAV is imported in the `supervision` library to prevent its native libraries from loading unless actually needed. This avoids conflicts and crashes—especially on macOS—when both OpenCV and PyAV are installed. The change ensures PyAV is only imported when its backend is used, rather than at module import time. Tests and documentation are updated accordingly.

**Backend import logic improvements:**

* Introduced a `_load_av()` helper function in `src/supervision/_cv2/_video.py` that lazily imports PyAV (`av`) only when the PyAV backend is actually used, preventing PyAV's native libraries from being loaded when the OpenCV backend is selected. All direct `av` usages are replaced with calls to `_load_av()` to ensure this lazy import. [[1]](diffhunk://#diff-1488ec0c236c0deac62c73250a5672fb103ce34d6e4658539e611ef2052f014cL13) [[2]](diffhunk://#diff-1488ec0c236c0deac62c73250a5672fb103ce34d6e4658539e611ef2052f014cR27-R41) [[3]](diffhunk://#diff-1488ec0c236c0deac62c73250a5672fb103ce34d6e4658539e611ef2052f014cL78-R92) [[4]](diffhunk://#diff-1488ec0c236c0deac62c73250a5672fb103ce34d6e4658539e611ef2052f014cL100-R114) [[5]](diffhunk://#diff-1488ec0c236c0deac62c73250a5672fb103ce34d6e4658539e611ef2052f014cL214-R228) [[6]](diffhunk://#diff-1488ec0c236c0deac62c73250a5672fb103ce34d6e4658539e611ef2052f014cL241-R255) [[7]](diffhunk://#diff-1488ec0c236c0deac62c73250a5672fb103ce34d6e4658539e611ef2052f014cR303)

**Testing:**

* Updated the test suite to verify that selecting the OpenCV backend does not import PyAV or load its native libraries, preventing duplicate library warnings and potential crashes on macOS.

**Documentation:**

* Added a changelog entry describing that importing `supervision` no longer loads PyAV's native libraries when the OpenCV backend is selected, and that PyAV is now imported lazily on first use.

---

resolves #2505

_cv2/_video.py imported av at module scope, so _cv2/__init__.py loaded PyAV's native libavdevice alongside OpenCV's bundled copy even when OpenCV was the selected backend, causing duplicate Objective-C class warnings (and crash risk) on macOS.