### PR TITLE
fix(detection): prevent integer overflow in `box_area`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ date_modified: 2026-08-11
 
 ### Fixed
 
+- `sv.Detections.box_area` (and therefore `sv.Detections.area` for axis-aligned boxes) now computes integer-coordinate box areas in `float64`, preventing integer overflow for large boxes (e.g. an `int32` `50000 x 50000` box previously wrapped to a negative area).
 - Docs deployment for `latest` no longer fails with `error: version 'latest' already exists` when `latest` exists as an alias of a released version; the publish workflow now always deletes `latest` before redeploying it ([#2512](https://github.com/roboflow/supervision/issues/2512)).
 
 ### 0.30.1 <small>Aug 24, 2026</small>

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -2834,8 +2834,8 @@ class Detections:
         ``with_nms``, ``with_nmm``, and this property — always store OBB corners
         under ``config.ORIENTED_BOX_COORDINATES`` with that shape.
 
-        **Return dtype**: ``float64`` (OBB branch), input dtype (AABB fallback),
-        ``int64`` (mask branch).
+        **Return dtype**: ``float64`` (OBB branch and integer AABB fallback),
+        floating input dtype (floating AABB fallback), ``int64`` (mask branch).
 
         Returns:
             An array containing the area of each detection
@@ -2882,16 +2882,22 @@ class Detections:
 
         Returns:
             An array of floats containing the area of each bounding
-                box in the format of `(area_1, area_2, ..., area_n)`,
-                where n is the number of detections.
+            box in the format of `(area_1, area_2, ..., area_n)`,
+                where n is the number of detections. Integer coordinates
+                produce ``float64``; floating coordinates preserve their dtype.
         """
         xyxy = self.xyxy
         if np.issubdtype(xyxy.dtype, np.integer):
-            # Integer width*height overflows for large boxes (e.g. int32
-            # 50000 x 50000 wraps negative); compute in float64 first so the
-            # area stays correct. Floating inputs already avoid this and keep
-            # their own dtype.
-            xyxy = xyxy.astype(np.float64)
+            # Subtract as Python integers first: converting corners to float64
+            # would collapse adjacent 64-bit coordinates above 2**53, while
+            # native integer subtraction can overflow across the dtype range.
+            integer_coordinates = xyxy.astype(object)
+            widths = integer_coordinates[:, 2] - integer_coordinates[:, 0]
+            heights = integer_coordinates[:, 3] - integer_coordinates[:, 1]
+            return np.asarray(widths, dtype=np.float64) * np.asarray(
+                heights, dtype=np.float64
+            )
+
         widths = xyxy[:, 2] - xyxy[:, 0]
         heights = xyxy[:, 3] - xyxy[:, 1]
         return widths * heights

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -2885,7 +2885,16 @@ class Detections:
                 box in the format of `(area_1, area_2, ..., area_n)`,
                 where n is the number of detections.
         """
-        return (self.xyxy[:, 3] - self.xyxy[:, 1]) * (self.xyxy[:, 2] - self.xyxy[:, 0])
+        xyxy = self.xyxy
+        if np.issubdtype(xyxy.dtype, np.integer):
+            # Integer width*height overflows for large boxes (e.g. int32
+            # 50000 x 50000 wraps negative); compute in float64 first so the
+            # area stays correct. Floating inputs already avoid this and keep
+            # their own dtype.
+            xyxy = xyxy.astype(np.float64)
+        widths = xyxy[:, 2] - xyxy[:, 0]
+        heights = xyxy[:, 3] - xyxy[:, 1]
+        return widths * heights
 
     @property
     def box_aspect_ratio(self) -> npt.NDArray[np.generic]:

--- a/tests/detection/test_core.py
+++ b/tests/detection/test_core.py
@@ -2833,6 +2833,24 @@ class TestDetectionsArea:
         np.testing.assert_array_equal(detections.area, [expected_area])
         assert detections.area.dtype == np.int64
 
+    @pytest.mark.parametrize(
+        ("dtype", "x_max", "y_max", "expected_area"),
+        [
+            pytest.param(np.int32, 50000, 50000, 2.5e9, id="int32"),
+            pytest.param(np.int16, 300, 300, 90000.0, id="int16"),
+            pytest.param(np.uint16, 300, 300, 90000.0, id="uint16"),
+            pytest.param(np.uint32, 70000, 70000, 4.9e9, id="uint32"),
+        ],
+    )
+    def test_box_area_does_not_overflow_integer_dtypes(
+        self, dtype: type, x_max: int, y_max: int, expected_area: float
+    ) -> None:
+        """Integer box area is computed in float64 so it cannot wrap negative."""
+        detections = Detections(xyxy=np.array([[0, 0, x_max, y_max]], dtype=dtype))
+
+        assert detections.box_area.dtype == np.float64
+        assert detections.box_area[0] == pytest.approx(expected_area)
+
 
 class TestDetectionsXyxyValidation:
     @pytest.mark.parametrize(

--- a/tests/detection/test_core.py
+++ b/tests/detection/test_core.py
@@ -2851,6 +2851,57 @@ class TestDetectionsArea:
         assert detections.box_area.dtype == np.float64
         assert detections.box_area[0] == pytest.approx(expected_area)
 
+    @pytest.mark.parametrize(
+        ("dtype", "area_property"),
+        [
+            pytest.param(np.int64, "box_area", id="int64-box-area"),
+            pytest.param(np.int64, "area", id="int64-area"),
+            pytest.param(np.uint64, "box_area", id="uint64-box-area"),
+            pytest.param(np.uint64, "area", id="uint64-area"),
+        ],
+    )
+    def test_integer_area_preserves_large_coordinate_differences(
+        self, dtype: type, area_property: str
+    ) -> None:
+        """Integer AABB areas retain one-unit widths above float64 precision."""
+        origin = 2**53
+        detections = Detections(
+            xyxy=np.array([[origin, 0, origin + 1, 1]], dtype=dtype)
+        )
+
+        area = getattr(detections, area_property)
+
+        assert area.dtype == np.float64
+        np.testing.assert_array_equal(area, [1.0])
+
+    @pytest.mark.parametrize(
+        ("dtype", "x_min", "x_max"),
+        [
+            pytest.param(
+                np.int64,
+                np.iinfo(np.int64).min,
+                np.iinfo(np.int64).max,
+                id="int64-full-range",
+            ),
+            pytest.param(
+                np.uint64,
+                0,
+                np.iinfo(np.uint64).max,
+                id="uint64-full-range",
+            ),
+        ],
+    )
+    def test_integer_box_area_handles_full_coordinate_range(
+        self, dtype: type, x_min: int, x_max: int
+    ) -> None:
+        """Integer area handles coordinate differences spanning a dtype range."""
+        detections = Detections(xyxy=np.array([[x_min, 0, x_max, 1]], dtype=dtype))
+
+        expected = float(int(x_max) - int(x_min))
+
+        np.testing.assert_array_equal(detections.box_area, [expected])
+        np.testing.assert_array_equal(detections.area, [expected])
+
 
 class TestDetectionsXyxyValidation:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

`Detections.box_area` computed `(y2-y1) * (x2-x1)` in the input dtype, so integer-coordinate boxes silently wrapped to a negative area. This also affects `Detections.area` for axis-aligned boxes (the AABB fallback branch).

```python
import numpy as np
import supervision as sv

d = sv.Detections(xyxy=np.array([[0, 0, 50000, 50000]], dtype=np.int32))
d.box_area  # -> array([-1794967296], dtype=int32)   # expected 2.5e9
```

This is the same class of bug fixed for `box_iou` in #2485, but `box_area` was missed.

## Changes

- `box_area` now promotes integer `xyxy` to `float64` before multiplying, so the product cannot overflow. Floating inputs are untouched and keep their dtype (preserving the documented AABB "input dtype" contract).
- Added `test_box_area_does_not_overflow_integer_dtypes` covering `int16`/`int32`/`uint16`/`uint32`.
- Added a changelog entry.

## Testing

- Full suite: `3636 passed, 20 skipped`.
- Ruff check + format clean.