### PR TITLE
fix(detection): stop `xcycwh_to_xyxy` truncating integer boxes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ date_modified: 2026-08-11
 
 ### Fixed
 
+- `sv.xcycwh_to_xyxy` no longer truncates coordinates for integer input arrays. Half of an odd width or height is fractional, and the previous implementation wrote those values into a copy of the integer input, silently rounding them; the converted boxes are now exact.
 - Docs deployment for `latest` no longer fails with `error: version 'latest' already exists` when `latest` exists as an alias of a released version; the publish workflow now always deletes `latest` before redeploying it ([#2512](https://github.com/roboflow/supervision/issues/2512)).
 
 ### 0.30.1 <small>Aug 24, 2026</small>

--- a/src/supervision/detection/utils/converters.py
+++ b/src/supervision/detection/utils/converters.py
@@ -170,12 +170,23 @@ def xcycwh_to_xyxy(xcycwh: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
 
         ```
     """
-    xyxy = xcycwh.copy()
-    xyxy[:, 0] = xcycwh[:, 0] - xcycwh[:, 2] / 2
-    xyxy[:, 1] = xcycwh[:, 1] - xcycwh[:, 3] / 2
-    xyxy[:, 2] = xcycwh[:, 0] + xcycwh[:, 2] / 2
-    xyxy[:, 3] = xcycwh[:, 1] + xcycwh[:, 3] / 2
-    return cast(npt.NDArray[np.number], np.asarray(xyxy))
+    # Build the result from the half-extent arithmetic instead of writing into a
+    # copy of the input. Half of an odd width or height is fractional, so an
+    # integer input array would silently truncate those coordinates; letting the
+    # division set the output dtype keeps them exact.
+    center_x = xcycwh[:, 0]
+    center_y = xcycwh[:, 1]
+    half_width = xcycwh[:, 2] / 2
+    half_height = xcycwh[:, 3] / 2
+    xyxy = np.column_stack(
+        (
+            center_x - half_width,
+            center_y - half_height,
+            center_x + half_width,
+            center_y + half_height,
+        )
+    )
+    return cast(npt.NDArray[np.number], xyxy)
 
 
 def xyxy_to_xcycarh(xyxy: npt.NDArray[np.number]) -> npt.NDArray[np.floating]:

--- a/tests/detection/utils/test_converters.py
+++ b/tests/detection/utils/test_converters.py
@@ -139,6 +139,10 @@ def test_xyxy_to_xcycarh(xyxy: np.ndarray, expected_result: np.ndarray) -> None:
         ),  # negative coordinates
         (np.array([[50, 50, 0, 30]]), np.array([[50, 35, 50, 65]])),  # zero width
         (np.array([[50, 50, 20, 0]]), np.array([[40, 50, 60, 50]])),  # zero height
+        (
+            np.array([[50, 50, 21, 31]]),
+            np.array([[39.5, 34.5, 60.5, 65.5]]),
+        ),  # integer input, odd width/height -> fractional half must not truncate
         (np.array([]).reshape(0, 4), np.array([]).reshape(0, 4)),  # empty array
     ],
 )

--- a/tests/detection/utils/test_converters.py
+++ b/tests/detection/utils/test_converters.py
@@ -127,23 +127,38 @@ def test_xyxy_to_xcycarh(xyxy: np.ndarray, expected_result: np.ndarray) -> None:
 @pytest.mark.parametrize(
     ("xcycwh", "expected_result"),
     [
-        (np.array([[50, 50, 20, 30]]), np.array([[40, 35, 60, 65]])),  # standard case
-        (np.array([[0, 0, 0, 0]]), np.array([[0, 0, 0, 0]])),  # zero size bounding box
-        (
+        pytest.param(
+            np.array([[50, 50, 20, 30]]),
+            np.array([[40, 35, 60, 65]]),
+            id="standard-case",
+        ),
+        pytest.param(
+            np.array([[0, 0, 0, 0]]), np.array([[0, 0, 0, 0]]), id="zero-size"
+        ),
+        pytest.param(
             np.array([[50, 50, 100, 100]]),
             np.array([[0, 0, 100, 100]]),
-        ),  # large bounding box centered at (50, 50)
-        (
+            id="large-centered-box",
+        ),
+        pytest.param(
             np.array([[-10, -10, 20, 30]]),
             np.array([[-20, -25, 0, 5]]),
-        ),  # negative coordinates
-        (np.array([[50, 50, 0, 30]]), np.array([[50, 35, 50, 65]])),  # zero width
-        (np.array([[50, 50, 20, 0]]), np.array([[40, 50, 60, 50]])),  # zero height
-        (
+            id="negative-coordinates",
+        ),
+        pytest.param(
+            np.array([[50, 50, 0, 30]]), np.array([[50, 35, 50, 65]]), id="zero-width"
+        ),
+        pytest.param(
+            np.array([[50, 50, 20, 0]]), np.array([[40, 50, 60, 50]]), id="zero-height"
+        ),
+        pytest.param(
             np.array([[50, 50, 21, 31]]),
             np.array([[39.5, 34.5, 60.5, 65.5]]),
-        ),  # integer input, odd width/height -> fractional half must not truncate
-        (np.array([]).reshape(0, 4), np.array([]).reshape(0, 4)),  # empty array
+            id="integer-odd-dimensions-preserve-fractional-half-extents",
+        ),
+        pytest.param(
+            np.array([]).reshape(0, 4), np.array([]).reshape(0, 4), id="empty-input"
+        ),
     ],
 )
 def test_xcycwh_to_xyxy(xcycwh: np.ndarray, expected_result: np.ndarray) -> None:


### PR DESCRIPTION
## Description

`xcycwh_to_xyxy` built its result by writing float half-extents into a copy of the input array. When the input is an integer array, half of an odd width or height is fractional and was silently truncated, shifting the box corners by up to 0.5 px. The conversion now derives its dtype from the half-extent arithmetic (matching `xyxy_to_xcycarh` and `scale_boxes`), so integer inputs yield exact floating-point coordinates and float inputs are unchanged.

## Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

Every existing test for this converter used even widths and heights, so the truncation never surfaced. A box such as `[50, 50, 21, 31]` returned `[39, 34, 60, 65]` instead of the correct `[39.5, 34.5, 60.5, 65.5]`.

## Changes Made

- `xcycwh_to_xyxy`: build the output with `np.column_stack` from the half-extent arithmetic instead of assigning float values into an integer copy of the input.
- Added a regression test case with odd width/height to `test_xcycwh_to_xyxy`.
- Added a changelog entry under Fixed.

## Testing

- [x] I have tested this code locally
- [x] I have added a unit test that proves the fix is effective
- [x] All new and existing tests pass (`3633 passed`), and `pre-commit run --all-files` is clean on the changed files