### PR TITLE
fix(detection): stop `denormalize_boxes` truncating integer boxes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ date_modified: 2026-08-11
 
 ### Fixed
 
+- `sv.denormalize_boxes` no longer truncates coordinates for integer input arrays. Scaling now multiplies by a floating-point factor so integer normalized coordinates (for example VLM boxes quantized to `0..1000`) map to exact absolute pixel values instead of being silently rounded down.
 - Docs deployment for `latest` no longer fails with `error: version 'latest' already exists` when `latest` exists as an alias of a released version; the publish workflow now always deletes `latest` before redeploying it ([#2512](https://github.com/roboflow/supervision/issues/2512)).
 
 ### 0.30.1 <small>Aug 24, 2026</small>

--- a/src/supervision/detection/utils/boxes.py
+++ b/src/supervision/detection/utils/boxes.py
@@ -157,12 +157,16 @@ def denormalize_boxes(
         ```
     """
     width, height = resolution_wh
-    result = cast(npt.NDArray[Any], xyxy.copy())
 
-    result[:, [0, 2]] = (result[:, [0, 2]] * width) / normalization_factor
-    result[:, [1, 3]] = (result[:, [1, 3]] * height) / normalization_factor
+    # Scale each column by width/height over the normalization factor. Multiplying
+    # by a float scale vector lets the result dtype follow the division, so an
+    # integer input array (e.g. VLM coordinates quantized to 0..1000) is not
+    # silently truncated the way writing the float result back into a copy of that
+    # integer array would be.
+    scale = np.array([width, height, width, height], dtype=np.float64)
+    scale /= normalization_factor
 
-    return cast(npt.NDArray[np.number], result)
+    return xyxy * scale
 
 
 def move_boxes(

--- a/src/supervision/detection/utils/boxes.py
+++ b/src/supervision/detection/utils/boxes.py
@@ -158,12 +158,12 @@ def denormalize_boxes(
     """
     width, height = resolution_wh
 
-    # Scale each column by width/height over the normalization factor. Multiplying
-    # by a float scale vector lets the result dtype follow the division, so an
-    # integer input array (e.g. VLM coordinates quantized to 0..1000) is not
-    # silently truncated the way writing the float result back into a copy of that
-    # integer array would be.
-    scale = np.array([width, height, width, height], dtype=np.float64)
+    # Preserve floating caller dtypes; integer inputs need float64 to retain
+    # fractional pixel coordinates rather than silently truncating them.
+    scale_dtype = (
+        xyxy.dtype if np.issubdtype(xyxy.dtype, np.inexact) else np.dtype(np.float64)
+    )
+    scale = np.array([width, height, width, height], dtype=scale_dtype)
     scale /= normalization_factor
 
     return xyxy * scale

--- a/tests/detection/utils/test_boxes.py
+++ b/tests/detection/utils/test_boxes.py
@@ -264,6 +264,32 @@ def test_denormalize_boxes(
         assert np.allclose(result, expected_result)
 
 
+def test_denormalize_boxes_preserves_float32_dtype() -> None:
+    """Retains float32 output for float32 normalized coordinates."""
+    xyxy = np.array([[0.1, 0.2, 0.5, 0.6]], dtype=np.float32)
+    expected_result = np.array([[128.0, 144.0, 640.0, 432.0]], dtype=np.float32)
+
+    result = denormalize_boxes(xyxy=xyxy, resolution_wh=(1280, 720))
+
+    assert result.dtype == np.float32
+    assert np.allclose(result, expected_result)
+
+
+def test_denormalize_boxes_promotes_integer_dtype() -> None:
+    """Promotes integer normalized coordinates to float64 output."""
+    xyxy = np.array([[101, 201, 301, 401]])
+    expected_result = np.array([[129.28, 144.72, 385.28, 288.72]])
+
+    result = denormalize_boxes(
+        xyxy=xyxy,
+        resolution_wh=(1280, 720),
+        normalization_factor=1000.0,
+    )
+
+    assert result.dtype == np.float64
+    assert np.allclose(result, expected_result)
+
+
 @pytest.mark.parametrize(
     ("corners", "expected"),
     [

--- a/tests/detection/utils/test_boxes.py
+++ b/tests/detection/utils/test_boxes.py
@@ -239,6 +239,13 @@ def test_scale_boxes(
             np.array([[320.0, 240.0, 320.0, 240.0]]),
             DoesNotRaise(),
         ),  # zero-area box (point)
+        (
+            np.array([[101, 201, 301, 401]]),
+            (1280, 720),
+            1000.0,
+            np.array([[129.28, 144.72, 385.28, 288.72]]),
+            DoesNotRaise(),
+        ),  # integer input must not truncate fractional pixel coordinates
     ],
 )
 def test_denormalize_boxes(

--- a/tests/detection/utils/test_boxes.py
+++ b/tests/detection/utils/test_boxes.py
@@ -264,29 +264,43 @@ def test_denormalize_boxes(
         assert np.allclose(result, expected_result)
 
 
-def test_denormalize_boxes_preserves_float32_dtype() -> None:
-    """Retains float32 output for float32 normalized coordinates."""
-    xyxy = np.array([[0.1, 0.2, 0.5, 0.6]], dtype=np.float32)
-    expected_result = np.array([[128.0, 144.0, 640.0, 432.0]], dtype=np.float32)
-
-    result = denormalize_boxes(xyxy=xyxy, resolution_wh=(1280, 720))
-
-    assert result.dtype == np.float32
-    assert np.allclose(result, expected_result)
-
-
-def test_denormalize_boxes_promotes_integer_dtype() -> None:
-    """Promotes integer normalized coordinates to float64 output."""
-    xyxy = np.array([[101, 201, 301, 401]])
-    expected_result = np.array([[129.28, 144.72, 385.28, 288.72]])
+@pytest.mark.parametrize(
+    (
+        "xyxy",
+        "normalization_factor",
+        "expected_result",
+    ),
+    [
+        pytest.param(
+            np.array([[0.1, 0.2, 0.5, 0.6]], dtype=np.float32),
+            1.0,
+            np.array([[128.0, 144.0, 640.0, 432.0]], dtype=np.float32),
+            id="preserves-float32",
+        ),
+        pytest.param(
+            np.array([[101, 201, 301, 401]]),
+            1000.0,
+            np.array([[129.28, 144.72, 385.28, 288.72]]),
+            id="promotes-integer-to-float64",
+        ),
+    ],
+)
+def test_denormalize_boxes_returns_expected_dtype(
+    xyxy: np.ndarray,
+    normalization_factor: float,
+    expected_result: np.ndarray,
+) -> None:
+    """Returns the specified coordinates and dtype for each input contract."""
+    resolution_wh = (1280, 720)
+    expected_dtype = xyxy.dtype if np.issubdtype(xyxy.dtype, np.inexact) else np.float64
 
     result = denormalize_boxes(
         xyxy=xyxy,
-        resolution_wh=(1280, 720),
-        normalization_factor=1000.0,
+        resolution_wh=resolution_wh,
+        normalization_factor=normalization_factor,
     )
 
-    assert result.dtype == np.float64
+    assert result.dtype == expected_dtype
     assert np.allclose(result, expected_result)
 
 


### PR DESCRIPTION
## Description

`denormalize_boxes` scaled coordinates by writing the float division results into a copy of the input array. When the input is an integer array, half-open scaling of quantized coordinates (for example VLM boxes emitted in a `0..1000` range) was silently truncated toward zero. Scaling now multiplies by a floating-point factor vector, so the output dtype follows the division and integer inputs map to exact absolute pixel coordinates. Float inputs are unchanged.

## Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

All existing tests for this function used floating-point inputs, so the truncation never surfaced. `denormalize_boxes(np.array([[101, 201, 301, 401]]), (1280, 720), normalization_factor=1000)` returned `[[129, 144, 385, 288]]` instead of `[[129.28, 144.72, 385.28, 288.72]]`. The library's own VLM connectors already cast to `float64` before calling this helper, so this fixes the public `sv.denormalize_boxes` entry point for callers that pass integer coordinate arrays directly.

## Changes Made

- `denormalize_boxes`: scale by a float factor vector instead of assigning float results into an integer copy of the input.
- Added a regression test with integer input and fractional expected coordinates.
- Added a changelog entry under Fixed.

## Testing

- [x] I have tested this code locally
- [x] I have added a unit test that proves the fix is effective
- [x] All new and existing tests pass (`3633 passed`), and pre-commit (ruff, mypy, mdformat, codespell) is clean on the changed files