### PR TITLE
fix(detection): merge InferenceSlicer results in source slice order

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ date_modified: 2026-08-11
 ### Fixed
 
 - Docs deployment for `latest` no longer fails with `error: version 'latest' already exists` when `latest` exists as an alias of a released version; the publish workflow now always deletes `latest` before redeploying it ([#2512](https://github.com/roboflow/supervision/issues/2512)).
+- `sv.InferenceSlicer` now merges slice results in source order when `thread_workers > 1`, restoring the ordering guarantee its docstring documents. Results were previously collected in thread-completion order, so the row order of the returned `Detections` — and, for tied confidences, which overlapping box survived `with_nms`/`with_nmm` — varied between runs on identical input. Both the per-slice and `batch_size > 1` paths are affected ([#2517](https://github.com/roboflow/supervision/pull/2517)).
 
 ### 0.30.1 <small>Aug 24, 2026</small>
 

--- a/src/supervision/detection/tools/inference_slicer.py
+++ b/src/supervision/detection/tools/inference_slicer.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import threading
 import warnings
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
@@ -373,12 +374,12 @@ class InferenceSlicer:
                     )
             else:
                 with ThreadPoolExecutor(max_workers=self.thread_workers) as executor:
-                    batch_futures = [
-                        executor.submit(self._run_callback_batch, image, ob)
-                        for ob in remaining_batches
-                    ]
-                    for batch_future in as_completed(batch_futures):
-                        detections_list.extend(batch_future.result())
+                    # `Executor.map` yields in submission order, so batches merge in
+                    # source order no matter which thread finishes first.
+                    for batch_detections in executor.map(
+                        partial(self._run_callback_batch, image), remaining_batches
+                    ):
+                        detections_list.extend(batch_detections)
             merged = Detections.merge(detections_list=detections_list)
             return self._apply_overlap_filter(merged)
 
@@ -425,12 +426,11 @@ class InferenceSlicer:
                 detections_list.append(self._run_callback(image, offset))
         else:
             with ThreadPoolExecutor(max_workers=self.thread_workers) as executor:
-                futures = [
-                    executor.submit(self._run_callback, image, offset)
-                    for offset in remaining_offsets
-                ]
-                for future in as_completed(futures):
-                    detections_list.append(future.result())
+                # `Executor.map` yields in submission order, so slices merge in
+                # source order no matter which thread finishes first.
+                detections_list.extend(
+                    executor.map(partial(self._run_callback, image), remaining_offsets)
+                )
 
         merged = Detections.merge(detections_list=detections_list)
         return self._apply_overlap_filter(merged)

--- a/tests/detection/tools/test_inference_slicer.py
+++ b/tests/detection/tools/test_inference_slicer.py
@@ -1,5 +1,8 @@
 import threading
 import warnings
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
 
 import numpy as np
 import pytest
@@ -740,6 +743,49 @@ class TestInferenceSlicerOrdering:
             class_id=np.array([index]),
         )
 
+    @staticmethod
+    def _install_reverse_completion_gate(
+        monkeypatch: pytest.MonkeyPatch, submitted_source_indices: list[int]
+    ) -> tuple[list[int], dict[int, threading.Event]]:
+        """Gate callbacks so each source predecessor follows a completed Future."""
+        completion_order: list[int] = []
+        release_events = {
+            source_index: threading.Event() for source_index in submitted_source_indices
+        }
+        predecessor_by_index = dict(
+            zip(submitted_source_indices[1:], submitted_source_indices)
+        )
+
+        class CompletionAcknowledgingExecutor(ThreadPoolExecutor):
+            """Release a preceding callback only after this Future is complete."""
+
+            def submit(
+                self,
+                fn: Callable[..., Any],
+                /,
+                *args: Any,
+                **kwargs: Any,
+            ) -> Future[Any]:
+                """Attach a post-completion release callback to each submitted task."""
+                future = super().submit(fn, *args, **kwargs)
+                offsets = np.asarray(args[-1])
+                source_index = int(offsets.flat[0] // 64)
+
+                def release_predecessor(_: Future[Any]) -> None:
+                    """Release the preceding source task after this Future completes."""
+                    predecessor = predecessor_by_index.get(source_index)
+                    if predecessor is not None:
+                        release_events[predecessor].set()
+
+                future.add_done_callback(release_predecessor)
+                return future
+
+        monkeypatch.setattr(
+            "supervision.detection.tools.inference_slicer.ThreadPoolExecutor",
+            CompletionAcknowledgingExecutor,
+        )
+        return completion_order, release_events
+
     @pytest.mark.parametrize(
         ("slice_count", "thread_workers"),
         [
@@ -748,20 +794,25 @@ class TestInferenceSlicerOrdering:
         ],
     )
     def test_threaded_slices_merge_in_source_order(
-        self, slice_count: int, thread_workers: int
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        slice_count: int,
+        thread_workers: int,
     ) -> None:
         """Slices completing out of order still merge in source order."""
-        release = threading.Event()
+        completion_order, release_events = self._install_reverse_completion_gate(
+            monkeypatch=monkeypatch,
+            submitted_source_indices=list(range(1, slice_count)),
+        )
 
         def callback(image_slice: np.ndarray) -> Detections:
-            """Hold every threaded slice until the final slice has finished."""
+            """Wait until the succeeding slice Future has completed."""
             index = int(image_slice[0, 0, 0])
-            # Slice 0 runs synchronously before the pool starts, so it must never
-            # wait. The last slice releases the gate, forcing it to complete first.
             if index == slice_count - 1:
-                release.set()
+                completion_order.append(index)
             elif index > 0:
-                release.wait(timeout=self.GATE_TIMEOUT_SECONDS)
+                assert release_events[index].wait(timeout=self.GATE_TIMEOUT_SECONDS)
+                completion_order.append(index)
             return self._detections_for(index)
 
         image = self._striped_image(slice_count)
@@ -775,23 +826,30 @@ class TestInferenceSlicerOrdering:
 
         detections = slicer(image)
 
+        assert completion_order == list(range(slice_count - 1, 0, -1))
         assert detections.class_id is not None
         assert detections.class_id.tolist() == list(range(slice_count))
 
-    def test_threaded_batches_merge_in_source_order(self) -> None:
+    def test_threaded_batches_merge_in_source_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Batches completing out of order still merge in source order."""
         slice_count, batch_size = 6, 2
-        release = threading.Event()
+        completion_order, release_events = self._install_reverse_completion_gate(
+            monkeypatch=monkeypatch,
+            submitted_source_indices=list(range(batch_size, slice_count, batch_size)),
+        )
 
-        def callback(tiles: list) -> list:
-            """Hold every threaded batch until the final batch has finished."""
+        def callback(tiles: list[np.ndarray]) -> list[Detections]:
+            """Wait until the succeeding batch Future has completed."""
             first_index = int(tiles[0][0, 0, 0])
-            # The first batch runs synchronously, so batches starting below
-            # batch_size must never wait. The last batch releases the gate.
             if first_index == slice_count - batch_size:
-                release.set()
+                completion_order.append(first_index)
             elif first_index >= batch_size:
-                release.wait(timeout=self.GATE_TIMEOUT_SECONDS)
+                assert release_events[first_index].wait(
+                    timeout=self.GATE_TIMEOUT_SECONDS
+                )
+                completion_order.append(first_index)
             return [self._detections_for(int(tile[0, 0, 0])) for tile in tiles]
 
         image = self._striped_image(slice_count)
@@ -806,5 +864,6 @@ class TestInferenceSlicerOrdering:
 
         detections = slicer(image)
 
+        assert completion_order == list(range(slice_count - batch_size, 0, -batch_size))
         assert detections.class_id is not None
         assert detections.class_id.tolist() == list(range(slice_count))

--- a/tests/detection/tools/test_inference_slicer.py
+++ b/tests/detection/tools/test_inference_slicer.py
@@ -716,3 +716,95 @@ class TestInferenceSlicerBatch:
 
         np.testing.assert_array_equal(detections.xyxy, original_xyxy)
         np.testing.assert_array_equal(moved.xyxy, np.array([[11.0, 22.0, 13.0, 24.0]]))
+
+
+class TestInferenceSlicerOrdering:
+    """Merged detections must follow source slice order, not thread completion order."""
+
+    GATE_TIMEOUT_SECONDS = 10.0
+
+    @staticmethod
+    def _striped_image(slice_count: int, slice_size: int = 64) -> np.ndarray:
+        """Build a single row of tiles, each stamped with its own slice index."""
+        image = np.zeros((slice_size, slice_size * slice_count, 3), dtype=np.uint8)
+        for index in range(slice_count):
+            image[:, index * slice_size : (index + 1) * slice_size, 0] = index
+        return image
+
+    @staticmethod
+    def _detections_for(index: int) -> Detections:
+        """Return one detection tagged with the index of the slice it came from."""
+        return Detections(
+            xyxy=np.array([[0, 0, 10, 10]], dtype=float),
+            confidence=np.array([0.9]),
+            class_id=np.array([index]),
+        )
+
+    @pytest.mark.parametrize(
+        ("slice_count", "thread_workers"),
+        [
+            pytest.param(3, 4, id="3-slices-4-workers"),
+            pytest.param(5, 8, id="5-slices-8-workers"),
+        ],
+    )
+    def test_threaded_slices_merge_in_source_order(
+        self, slice_count: int, thread_workers: int
+    ) -> None:
+        """Slices completing out of order still merge in source order."""
+        release = threading.Event()
+
+        def callback(image_slice: np.ndarray) -> Detections:
+            """Hold every threaded slice until the final slice has finished."""
+            index = int(image_slice[0, 0, 0])
+            # Slice 0 runs synchronously before the pool starts, so it must never
+            # wait. The last slice releases the gate, forcing it to complete first.
+            if index == slice_count - 1:
+                release.set()
+            elif index > 0:
+                release.wait(timeout=self.GATE_TIMEOUT_SECONDS)
+            return self._detections_for(index)
+
+        image = self._striped_image(slice_count)
+        slicer = InferenceSlicer(
+            callback=callback,
+            slice_wh=64,
+            overlap_wh=0,
+            thread_workers=thread_workers,
+            overlap_filter=OverlapFilter.NONE,
+        )
+
+        detections = slicer(image)
+
+        assert detections.class_id is not None
+        assert detections.class_id.tolist() == list(range(slice_count))
+
+    def test_threaded_batches_merge_in_source_order(self) -> None:
+        """Batches completing out of order still merge in source order."""
+        slice_count, batch_size = 6, 2
+        release = threading.Event()
+
+        def callback(tiles: list) -> list:
+            """Hold every threaded batch until the final batch has finished."""
+            first_index = int(tiles[0][0, 0, 0])
+            # The first batch runs synchronously, so batches starting below
+            # batch_size must never wait. The last batch releases the gate.
+            if first_index == slice_count - batch_size:
+                release.set()
+            elif first_index >= batch_size:
+                release.wait(timeout=self.GATE_TIMEOUT_SECONDS)
+            return [self._detections_for(int(tile[0, 0, 0])) for tile in tiles]
+
+        image = self._striped_image(slice_count)
+        slicer = InferenceSlicer(
+            callback=callback,
+            slice_wh=64,
+            overlap_wh=0,
+            batch_size=batch_size,
+            thread_workers=4,
+            overlap_filter=OverlapFilter.NONE,
+        )
+
+        detections = slicer(image)
+
+        assert detections.class_id is not None
+        assert detections.class_id.tolist() == list(range(slice_count))


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated documentation, following Google-style conventions
- [x] Added docs entry for autogeneration (not applicable: no new functions/classes)
- [x] Added/updated tests
- [x] All tests pass locally

</details>

## Description

`InferenceSlicer.__call__` documents an ordering guarantee:

> Detections are merged in a deterministic order: the first slice is always at index 0, followed by any probe slices, then the remaining slices in source order.

Both threaded paths collected results with `concurrent.futures.as_completed`, which yields in completion order rather than submission order, so the last clause did not hold. The row order of the returned `Detections` depended on which inference call happened to finish first.

Results are now collected with `Executor.map`, which yields in submission order while still running the callbacks concurrently.

## Type of Change

- 🐛 Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

This is not only a row-ordering nit, because two consumers immediately downstream are order-sensitive.

`box_non_max_suppression` sorts by confidence with `predictions[:, 4].argsort()[::-1]`. NumPy's default `argsort` kind is quicksort, which is not stable, so tied confidences are resolved by input position. Overlapping tiles are the whole point of a slicer, so the same object scoring identically in two adjacent tiles is the normal case — and which duplicate survived, along with its box, `class_name`, `tracker_id` and any custom `data`, flipped with thread scheduling.

Reproduction: 1280x640 image, 640px slices, 320px overlap. Slices 1 and 2 both report the same absolute box with the same `class_id` and confidence `0.9`, tagged via `data["src_slice"]`; slice 1 is made to finish last. Slice 0 reports an unrelated box so the empty-first-slice probe loop does not serialize the run.

```
before:
thread_workers=1: surviving src_slice=[0, 2]
thread_workers=4: surviving src_slice=[0, 1]

after:
thread_workers=1: surviving src_slice=[0, 2]
thread_workers=4: surviving src_slice=[0, 2]
```

Same image, same callback, same confidences — a different detection survived NMS depending only on `thread_workers`. That makes slicer output non-reproducible, which in turn makes it untestable in any user-side regression suite.

The guarantee itself was added deliberately in #2256; this makes the code match it rather than introducing a new promise.

## Changes Made

- Collect threaded per-slice results with `executor.map(partial(self._run_callback, image), ...)` instead of `as_completed`.
- Same for the `batch_size > 1` path over `remaining_batches`.
- Drop the now-unused `as_completed` import, add `functools.partial`.
- Add `TestInferenceSlicerOrdering` covering both paths, using a `threading.Event` gate rather than sleeps so the out-of-order completion is deterministic and cannot flake on loaded CI.
- Add a changelog entry under `Unreleased > Fixed`.

The probe loop, the OBB sequential-execution guard, the warning locks and batch splitting are untouched.

## Testing

- [x] I have tested this code locally
- [x] I have added unit tests that prove my fix is effective
- [x] All new and existing tests pass

The three new tests fail on unmodified `develop` (`0753191a`):

```
FAILED TestInferenceSlicerOrdering::test_threaded_slices_merge_in_source_order[3-slices-4-workers]
  - AssertionError: assert [0, 2, 1] == [0, 1, 2]
FAILED TestInferenceSlicerOrdering::test_threaded_slices_merge_in_source_order[5-slices-8-workers]
  - AssertionError: assert [0, 4, 1, 3, 2] == [0, 1, 2, 3, 4]
FAILED TestInferenceSlicerOrdering::test_threaded_batches_merge_in_source_order
  - AssertionError: assert [0, 1, 4, 5, 2, 3] == [0, 1, 2, 3, 4, 5]
3 failed in 0.07s
```

Commands run:

- `uv run pytest -q` on stashed `develop` — 3633 passed
- `uv run pytest -q` with the change — 3636 passed (+3 new tests, no change to the pass set)
- `uv run pytest tests/detection/tools/test_inference_slicer.py -q` — 34 passed
- `uv run pre-commit run --all-files` — 21 hooks, all passed, mypy included

Environment note: `opencv-python` is not installed locally, so the runs above exercise the NumPy fallback backend and emit its usual import `UserWarning`. No test failures were observed in either the baseline or the post-change run.

## Google Colab (optional)

Not applicable; this is a deterministic concurrency fix with no model dependency, covered by local unit tests.

## Screenshots/Videos (optional)

Not applicable; there is no visual change.

## Additional Notes

`Executor.map` does not reduce concurrency — every call is still submitted up front and runs across the pool, so wall-clock is unchanged; only the order in which completed results are yielded is constrained. Error behaviour is comparable: both forms raise the first exception encountered and the context manager joins all threads, with `map` now surfacing the earliest failure in source order rather than whichever failed first by clock.

One adjacent issue is deliberately left out of scope: `box_non_max_suppression` could also pass `kind="stable"` to `argsort` so ties never depend on input position at all. That touches every NMS caller rather than the slicer, so it seemed worth raising separately.
