### PR TITLE
feat(detection): add TrainingSlicer for tiled training data generation

### DIFF
--- a/docs/detection/tools/training_slicer.md
+++ b/docs/detection/tools/training_slicer.md
@@ -1,0 +1,46 @@
+---
+comments: true
+---
+
+# TrainingSlicer
+
+`TrainingSlicer` is the training-time counterpart to
+[`InferenceSlicer`](inference_slicer.md). Instead of running a model callback
+on each tile, it slices an image's existing ground-truth `Detections` to match
+a grid of tiles, so you can turn a dataset of large images into fixed-size
+training crops — the standard technique for training small-object detectors.
+
+```python
+import numpy as np
+import supervision as sv
+
+image = np.zeros((1024, 1024, 3), dtype=np.uint8)
+detections = sv.Detections(
+    xyxy=np.array([[100, 100, 180, 180], [900, 900, 980, 980]], dtype=float),
+    class_id=np.array([0, 1]),
+)
+
+slicer = sv.TrainingSlicer(slice_wh=320, overlap_wh=0)
+tiles = slicer(image, detections)
+
+for tile_image, tile_detections in tiles:
+    print(tile_image.shape, len(tile_detections))
+```
+
+Annotations that are cut by a tile boundary are clipped to that tile, and
+dropped from a tile entirely once too little of the original box remains
+visible there — controlled by `min_visibility`:
+
+```python
+slicer = sv.TrainingSlicer(slice_wh=320, overlap_wh=0, min_visibility=0.3)
+```
+
+By default, tiles with no annotations are still returned (useful for
+background/hard-negative training samples). Pass `drop_empty_slices=True` to
+keep only tiles that contain at least one annotation:
+
+```python
+slicer = sv.TrainingSlicer(slice_wh=320, overlap_wh=0, drop_empty_slices=True)
+```
+
+:::supervision.detection.tools.training_slicer.TrainingSlicer

--- a/docs/detection/tools/training_slicer.md
+++ b/docs/detection/tools/training_slicer.md
@@ -4,11 +4,7 @@ comments: true
 
 # TrainingSlicer
 
-`TrainingSlicer` is the training-time counterpart to
-[`InferenceSlicer`](inference_slicer.md). Instead of running a model callback
-on each tile, it slices an image's existing ground-truth `Detections` to match
-a grid of tiles, so you can turn a dataset of large images into fixed-size
-training crops — the standard technique for training small-object detectors.
+`TrainingSlicer` is the training-time counterpart to [`InferenceSlicer`](inference_slicer.md). Instead of running a model callback on each tile, it slices an image's existing ground-truth `Detections` to match a grid of tiles, so you can turn a dataset of large images into fixed-size training crops — the standard technique for training small-object detectors.
 
 ```python
 import numpy as np
@@ -27,17 +23,13 @@ for tile_image, tile_detections in tiles:
     print(tile_image.shape, len(tile_detections))
 ```
 
-Annotations that are cut by a tile boundary are clipped to that tile, and
-dropped from a tile entirely once too little of the original box remains
-visible there — controlled by `min_visibility`:
+Annotations that are cut by a tile boundary are clipped to that tile, and dropped from a tile entirely once too little of the original box remains visible there — controlled by `min_visibility`:
 
 ```python
 slicer = sv.TrainingSlicer(slice_wh=320, overlap_wh=0, min_visibility=0.3)
 ```
 
-By default, tiles with no annotations are still returned (useful for
-background/hard-negative training samples). Pass `drop_empty_slices=True` to
-keep only tiles that contain at least one annotation:
+By default, tiles with no annotations are still returned (useful for background/hard-negative training samples). Pass `drop_empty_slices=True` to keep only tiles that contain at least one annotation:
 
 ```python
 slicer = sv.TrainingSlicer(slice_wh=320, overlap_wh=0, drop_empty_slices=True)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
           - Line Zone: detection/tools/line_zone.md
           - Polygon Zone: detection/tools/polygon_zone.md
           - Inference Slicer: detection/tools/inference_slicer.md
+          - Training Slicer: detection/tools/training_slicer.md
           - Detection Smoother: detection/tools/smoother.md
           - Save Detections: detection/tools/save_detections.md
       - Trackers: trackers.md

--- a/src/supervision/__init__.py
+++ b/src/supervision/__init__.py
@@ -60,6 +60,7 @@ from supervision.detection.tools.inference_slicer import (
 from supervision.detection.tools.json_sink import JSONSink
 from supervision.detection.tools.polygon_zone import PolygonZone, PolygonZoneAnnotator
 from supervision.detection.tools.smoother import DetectionsSmoother
+from supervision.detection.tools.training_slicer import TrainingSlicer
 from supervision.detection.utils.boxes import (
     clip_boxes,
     denormalize_boxes,
@@ -222,6 +223,7 @@ __all__ = [
     "RichLabelAnnotator",
     "RoundBoxAnnotator",
     "TraceAnnotator",
+    "TrainingSlicer",
     "TriangleAnnotator",
     "VertexAnnotator",
     "VertexEllipseAnnotator",

--- a/src/supervision/detection/tools/training_slicer.py
+++ b/src/supervision/detection/tools/training_slicer.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from supervision.detection.core import Detections
+from supervision.detection.tools.inference_slicer import move_detections
+from supervision.detection.utils.boxes import clip_boxes
+from supervision.draw.base import ImageType
+from supervision.utils.image import crop_image, get_image_resolution_wh
+
+
+class TrainingSlicer:
+    """
+        Slice a full-resolution image and its ground-truth `Detections` into a grid
+        of smaller tiles for training small-object detection or segmentation models.
+
+        This is the training-time counterpart to `InferenceSlicer`: instead of
+        running a model callback on each tile and merging predictions back into
+        full-image coordinates, `TrainingSlicer` slices existing ground-truth
+        annotations to match each tile, translating box and mask coordinates into
+        the tile's local coordinate frame. This is the standard way to turn a
+        dataset of large images into fixed-size training crops (the same technique
+        used by tools like SAHI) so that small objects occupy a larger fraction of
+        the input a detector sees.
+
+        Args:
+            slice_wh: Size of each tile `(width, height)`. If int, both width and
+                height are set to this value.
+            overlap_wh: Overlap size `(width, height)` between tiles. If int, both
+                width and height are set to this value. Unlike `InferenceSlicer`,
+                training tiles are typically generated without overlap; increase
+                this if objects that straddle a tile boundary should also appear
+                whole in a neighboring tile.
+            min_visibility: Minimum fraction, in `[0, 1]`, of an annotation's
+                original box area that must remain after clipping to a tile for
+                that annotation to be kept in the tile. Annotations that are cut
+                below this threshold by a tile boundary are dropped from that tile
+                (they still appear whole in any other tile that fully contains
+                them, when `overlap_wh` provides one). Defaults to `0.1`.
+            drop_empty_slices: If `True`, tiles left with zero annotations after
+                slicing are omitted from the returned list. If `False` (default),
+                every tile is returned, including background-only tiles — useful
+                for hard-negative mining. Defaults to `False`.
+
+        Raises:
+            ValueError: If `slice_wh` or `overlap_wh` are invalid or inconsistent.
+            ValueError: If `min_visibility` is not in `[0, 1]`.
+
+        Note:
+            Oriented bounding boxes (`OBB`) are translated into each tile's local
+            frame but are not clipped to the tile rectangle, since clipping a
+            rotated box against an axis-aligned rectangle produces a polygon with
+            more than four vertices. A box that straddles a tile boundary may
+            therefore have vertices outside that tile. Axis-aligned boxes and
+            masks are always clipped/cropped to the tile.
+
+        Example:
+    ```python
+            import supervision as sv
+            from supervision import _cv2 as cv2
+
+            image = cv2.imread("large_train_image.jpg")
+            detections = sv.Detections(...)  # ground truth for the full image
+
+            slicer = sv.TrainingSlicer(slice_wh=320, overlap_wh=0)
+            for tile_image, tile_detections in slicer(image, detections):
+                ...  # write out one training sample per tile
+    ```
+    """
+
+    def __init__(
+        self,
+        slice_wh: int | tuple[int, int] = 320,
+        overlap_wh: int | tuple[int, int] = 0,
+        min_visibility: float = 0.1,
+        drop_empty_slices: bool = False,
+    ):
+        slice_wh_norm = self._normalize_wh_pair(slice_wh, "slice_wh", allow_zero=False)
+        overlap_wh_norm = self._normalize_wh_pair(
+            overlap_wh, "overlap_wh", allow_zero=True
+        )
+        self._validate_overlap(slice_wh=slice_wh_norm, overlap_wh=overlap_wh_norm)
+
+        if not 0.0 <= min_visibility <= 1.0:
+            raise ValueError(
+                "`min_visibility` must be in the range [0, 1]. "
+                f"Received: {min_visibility}"
+            )
+
+        self.slice_wh = slice_wh_norm
+        self.overlap_wh = overlap_wh_norm
+        self.min_visibility = min_visibility
+        self.drop_empty_slices = drop_empty_slices
+
+    def __call__(
+        self, image: ImageType, detections: Detections
+    ) -> list[tuple[ImageType, Detections]]:
+        """
+        Slice `image` and `detections` into a grid of tiles.
+
+        Args:
+            image: The full-resolution image to slice.
+            detections: Ground-truth detections for `image`, in full-image
+                coordinates.
+
+        Returns:
+            A list of `(tile_image, tile_detections)` pairs, one per tile, in
+            row-major order. `tile_detections` coordinates are local to
+            `tile_image` (top-left of the tile is `(0, 0)`).
+        """
+        resolution_wh = get_image_resolution_wh(image)
+        offsets = self._generate_offsets(
+            resolution_wh=resolution_wh,
+            slice_wh=self.slice_wh,
+            overlap_wh=self.overlap_wh,
+        )
+
+        results: list[tuple[ImageType, Detections]] = []
+        for offset in offsets:
+            tile_image = crop_image(image=image, xyxy=offset)
+            tile_detections = self._slice_detections(detections, offset)
+            if self.drop_empty_slices and len(tile_detections) == 0:
+                continue
+            results.append((tile_image, tile_detections))
+        return results
+
+    def _slice_detections(
+        self, detections: Detections, offset: npt.NDArray[np.number]
+    ) -> Detections:
+        """Filter `detections` to those visible in `offset` and localize them.
+
+        Args:
+            offset: Tile coordinates `(x_min, y_min, x_max, y_max)` in the
+                full image's coordinate system.
+
+        Returns:
+            Detections whose coordinates are local to the tile, i.e. relative
+            to `(offset[0], offset[1])`.
+        """
+        x_min, y_min, x_max, y_max = offset
+        tile_w = int(x_max - x_min)
+        tile_h = int(y_max - y_min)
+
+        if len(detections) == 0:
+            keep_mask = np.zeros(0, dtype=bool)
+        else:
+            xyxy = detections.xyxy
+            inter_x1 = np.maximum(xyxy[:, 0], x_min)
+            inter_y1 = np.maximum(xyxy[:, 1], y_min)
+            inter_x2 = np.minimum(xyxy[:, 2], x_max)
+            inter_y2 = np.minimum(xyxy[:, 3], y_max)
+            inter_area = np.clip(inter_x2 - inter_x1, 0, None) * np.clip(
+                inter_y2 - inter_y1, 0, None
+            )
+
+            box_w = np.clip(xyxy[:, 2] - xyxy[:, 0], 0, None)
+            box_h = np.clip(xyxy[:, 3] - xyxy[:, 1], 0, None)
+            original_area = box_w * box_h
+
+            with np.errstate(divide="ignore", invalid="ignore"):
+                visibility = np.where(
+                    original_area > 0, inter_area / original_area, 0.0
+                )
+
+            keep_mask = (inter_area > 0) & (visibility >= self.min_visibility)
+
+        localized = move_detections(
+            detections=detections.select(keep_mask),
+            offset=np.array([-x_min, -y_min]),
+            resolution_wh=(tile_w, tile_h),
+        )
+        localized.xyxy = clip_boxes(localized.xyxy, resolution_wh=(tile_w, tile_h))
+        return localized
+
+    @staticmethod
+    def _normalize_wh_pair(
+        value: int | tuple[int, int], name: str, allow_zero: bool
+    ) -> tuple[int, int]:
+        lower_bound = 0 if allow_zero else 1
+        comparator = "non negative" if allow_zero else "positive"
+
+        if isinstance(value, int):
+            if value < lower_bound:
+                raise ValueError(
+                    f"`{name}` must be a {comparator} integer. Received: {value}"
+                )
+            return value, value
+
+        if isinstance(value, tuple) and len(value) == 2:
+            width, height = value
+            if width < lower_bound or height < lower_bound:
+                raise ValueError(
+                    f"`{name}` values must be {comparator}. Received: {value}"
+                )
+            return width, height
+
+        raise ValueError(
+            f"`{name}` must be an int or a tuple of two {comparator} integers. "
+            f"Received: {value}"
+        )
+
+    @staticmethod
+    def _validate_overlap(
+        slice_wh: tuple[int, int], overlap_wh: tuple[int, int]
+    ) -> None:
+        overlap_w, overlap_h = overlap_wh
+        slice_w, slice_h = slice_wh
+        if overlap_w >= slice_w or overlap_h >= slice_h:
+            raise ValueError(
+                "`overlap_wh` must be smaller than `slice_wh` in both dimensions "
+                f"to keep a positive stride. Received overlap_wh={overlap_wh}, "
+                f"slice_wh={slice_wh}."
+            )
+
+    @staticmethod
+    def _generate_offsets(
+        resolution_wh: tuple[int, int],
+        slice_wh: tuple[int, int],
+        overlap_wh: tuple[int, int],
+    ) -> npt.NDArray[np.number]:
+        """
+        Generate the coordinates of image tiles with overlap.
+
+        This mirrors `InferenceSlicer._generate_offset`. The two classes slice
+        images for different purposes (live model inference vs. offline
+        dataset preparation) and are kept independent so each can evolve
+        without risking the other's behavior; the grid math itself is small,
+        stable, and unit-tested in both places.
+
+        Args:
+            resolution_wh: Image resolution `(width, height)`.
+            slice_wh: Size of each tile `(width, height)`.
+            overlap_wh: Overlap size between tiles `(width, height)`.
+
+        Returns:
+            Array of shape `(num_slices, 4)` with each row as
+                `(x_min, y_min, x_max, y_max)` coordinates for a tile.
+        """
+        slice_width, slice_height = slice_wh
+        image_width, image_height = resolution_wh
+        overlap_width, overlap_height = overlap_wh
+
+        stride_x = slice_width - overlap_width
+        stride_y = slice_height - overlap_height
+
+        def _compute_axis_starts(
+            image_size: int, slice_size: int, stride: int
+        ) -> list[int]:
+            if image_size <= slice_size:
+                return [0]
+
+            if stride == slice_size:
+                return list(np.arange(0, image_size, stride).tolist())
+
+            last_start = image_size - slice_size
+            starts: list[int] = list(np.arange(0, last_start, stride).tolist())
+            if not starts or starts[-1] != last_start:
+                starts.append(last_start)
+            return starts
+
+        x_starts = _compute_axis_starts(
+            image_size=image_width, slice_size=slice_width, stride=stride_x
+        )
+        y_starts = _compute_axis_starts(
+            image_size=image_height, slice_size=slice_height, stride=stride_y
+        )
+
+        x_min, y_min = np.meshgrid(x_starts, y_starts)
+        x_max = np.clip(x_min + slice_width, 0, image_width)
+        y_max = np.clip(y_min + slice_height, 0, image_height)
+
+        offsets: npt.NDArray[np.number] = np.stack(
+            [x_min, y_min, x_max, y_max], axis=-1
+        ).reshape(-1, 4)
+
+        return offsets

--- a/tests/detection/tools/test_training_slicer.py
+++ b/tests/detection/tools/test_training_slicer.py
@@ -1,0 +1,194 @@
+import numpy as np
+import pytest
+
+from supervision.detection.core import Detections
+from supervision.detection.tools.training_slicer import TrainingSlicer
+
+
+@pytest.mark.parametrize(
+    ("resolution_wh", "slice_wh", "overlap_wh", "expected_offsets"),
+    [
+        # Case 1: image divides evenly into slices, no overlap
+        (
+            (256, 256),
+            (128, 128),
+            (0, 0),
+            np.array(
+                [
+                    [0, 0, 128, 128],
+                    [128, 0, 256, 128],
+                    [0, 128, 128, 256],
+                    [128, 128, 256, 256],
+                ]
+            ),
+        ),
+        # Case 2: image smaller than a single slice
+        (
+            (100, 80),
+            (320, 320),
+            (0, 0),
+            np.array([[0, 0, 100, 80]]),
+        ),
+        # Case 3: overlapping slices
+        (
+            (160, 160),
+            (100, 100),
+            (20, 20),
+            np.array(
+                [
+                    [0, 0, 100, 100],
+                    [60, 0, 160, 100],
+                    [0, 60, 100, 160],
+                    [60, 60, 160, 160],
+                ]
+            ),
+        ),
+    ],
+)
+def test_generate_offsets(
+    resolution_wh: tuple[int, int],
+    slice_wh: tuple[int, int],
+    overlap_wh: tuple[int, int],
+    expected_offsets: np.ndarray,
+) -> None:
+    offsets = TrainingSlicer._generate_offsets(
+        resolution_wh=resolution_wh, slice_wh=slice_wh, overlap_wh=overlap_wh
+    )
+
+    assert np.array_equal(offsets, expected_offsets)
+
+
+@pytest.mark.parametrize(
+    ("slice_wh", "overlap_wh", "min_visibility", "match"),
+    [
+        (0, 0, 0.1, "slice_wh"),
+        ((0, 10), 0, 0.1, "slice_wh"),
+        (100, -1, 0.1, "overlap_wh"),
+        (100, (100, 0), 0.1, "overlap_wh"),
+        (100, 0, -0.1, "min_visibility"),
+        (100, 0, 1.1, "min_visibility"),
+    ],
+)
+def test_init_raises_on_invalid_arguments(
+    slice_wh: int | tuple[int, int],
+    overlap_wh: int | tuple[int, int],
+    min_visibility: float,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        TrainingSlicer(
+            slice_wh=slice_wh, overlap_wh=overlap_wh, min_visibility=min_visibility
+        )
+
+
+def test_call_splits_image_into_expected_number_of_tiles() -> None:
+    image = np.zeros((200, 200, 3), dtype=np.uint8)
+    detections = Detections.empty()
+    slicer = TrainingSlicer(slice_wh=100, overlap_wh=0, drop_empty_slices=False)
+
+    result = slicer(image, detections)
+
+    assert len(result) == 4
+    for tile_image, tile_detections in result:
+        assert tile_image.shape == (100, 100, 3)
+        assert len(tile_detections) == 0
+
+
+def test_call_drop_empty_slices_removes_tiles_without_detections() -> None:
+    image = np.zeros((200, 200, 3), dtype=np.uint8)
+    detections = Detections(xyxy=np.array([[10, 10, 50, 50]], dtype=float))
+    slicer = TrainingSlicer(slice_wh=100, overlap_wh=0, drop_empty_slices=True)
+
+    result = slicer(image, detections)
+
+    assert len(result) == 1
+    tile_image, tile_detections = result[0]
+    assert tile_image.shape == (100, 100, 3)
+    np.testing.assert_array_equal(tile_detections.xyxy, [[10, 10, 50, 50]])
+
+
+def test_call_localizes_box_fully_inside_one_tile() -> None:
+    image = np.zeros((200, 200, 3), dtype=np.uint8)
+    detections = Detections(
+        xyxy=np.array([[110, 120, 140, 160]], dtype=float),
+        class_id=np.array([7]),
+    )
+    slicer = TrainingSlicer(slice_wh=100, overlap_wh=0, drop_empty_slices=True)
+
+    result = slicer(image, detections)
+
+    assert len(result) == 1
+    _, tile_detections = result[0]
+    np.testing.assert_array_equal(tile_detections.xyxy, [[10, 20, 40, 60]])
+    np.testing.assert_array_equal(tile_detections.class_id, [7])
+
+
+def test_call_drops_box_below_min_visibility_at_tile_boundary() -> None:
+    image = np.zeros((200, 200, 3), dtype=np.uint8)
+    # 60x60 box straddling the (100, 100) tile boundary: only a 10x10 corner
+    # (100 / 3600 ~= 2.8%) falls inside the top-left tile.
+    detections = Detections(xyxy=np.array([[90, 90, 150, 150]], dtype=float))
+    slicer = TrainingSlicer(
+        slice_wh=100, overlap_wh=0, min_visibility=0.5, drop_empty_slices=True
+    )
+
+    result = slicer(image, detections)
+
+    # Only the bottom-right tile keeps the box: it sees a 50x50 (~69%) crop.
+    assert len(result) == 1
+    _, tile_detections = result[0]
+    np.testing.assert_array_equal(tile_detections.xyxy, [[0, 0, 50, 50]])
+
+
+def test_call_keeps_and_clips_box_at_min_visibility_zero() -> None:
+    image = np.zeros((200, 200, 3), dtype=np.uint8)
+    detections = Detections(xyxy=np.array([[90, 90, 150, 150]], dtype=float))
+    slicer = TrainingSlicer(
+        slice_wh=100, overlap_wh=0, min_visibility=0.0, drop_empty_slices=True
+    )
+
+    result = slicer(image, detections)
+
+    # Every tile that touches the box keeps a clipped copy of it.
+    assert len(result) == 4
+    for _, tile_detections in result:
+        assert len(tile_detections) == 1
+        xyxy = tile_detections.xyxy[0]
+        assert (xyxy >= 0).all()
+        assert xyxy[0] <= xyxy[2] <= 100
+        assert xyxy[1] <= xyxy[3] <= 100
+
+
+def test_call_slices_masks_to_local_tile_coordinates() -> None:
+    image = np.zeros((200, 200, 3), dtype=np.uint8)
+    mask = np.zeros((1, 200, 200), dtype=bool)
+    mask[0, 90:150, 90:150] = True
+    detections = Detections(xyxy=np.array([[90, 90, 150, 150]], dtype=float), mask=mask)
+    slicer = TrainingSlicer(
+        slice_wh=100, overlap_wh=0, min_visibility=0.5, drop_empty_slices=True
+    )
+
+    result = slicer(image, detections)
+
+    assert len(result) == 1
+    _, tile_detections = result[0]
+    assert tile_detections.mask.shape == (1, 100, 100)
+    # Only the (100, 100)-(150, 150) portion of the mask falls in this tile,
+    # localized to (0, 0)-(50, 50).
+    assert tile_detections.mask[0].sum() == 50 * 50
+    assert tile_detections.mask[0, :50, :50].all()
+    assert not tile_detections.mask[0, 50:, :].any()
+    assert not tile_detections.mask[0, :, 50:].any()
+
+
+def test_call_returns_tiles_in_row_major_order() -> None:
+    image = np.zeros((200, 200, 3), dtype=np.uint8)
+    detections = Detections.empty()
+    slicer = TrainingSlicer(slice_wh=100, overlap_wh=0, drop_empty_slices=False)
+
+    offsets = TrainingSlicer._generate_offsets(
+        resolution_wh=(200, 200), slice_wh=(100, 100), overlap_wh=(0, 0)
+    )
+    result = slicer(image, detections)
+
+    assert len(result) == len(offsets)


### PR DESCRIPTION
Adds TrainingSlicer, the training-time counterpart to InferenceSlicer (#1996). Slices ground-truth Detections into tiles for training small-object models.

<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [x] Added docs entry for autogeneration (if new functions/classes)
- [x] Added/updated tests
- [x] All tests pass locally

</details>

## Description

Adds `TrainingSlicer`, the training-time counterpart to `InferenceSlicer`. Instead of running a model callback on each tile and merging predictions back, it slices an image's existing ground-truth `Detections` to match a grid of tiles, translating box, oriented-box, and mask coordinates into each tile's local frame. This is the standard way to turn a dataset of large images into fixed-size training crops so small objects occupy a larger fraction of what the detector sees during training (the same technique used by tools like SAHI).

## Type of Change

- ✨ New feature (non-breaking change which adds functionality)

## Motivation and Context

Closes #1996. For small-object detection/segmentation, training on full-resolution images means small objects are a tiny fraction of the input, which hurts training signal. Slicing the training set into tiles (as `InferenceSlicer` already lets you do at inference time) is a standard mitigation, but `supervision` had no equivalent for ground-truth annotations. This fills that gap.

## Changes Made

- Added `TrainingSlicer` (`src/supervision/detection/tools/training_slicer.py`): slices an image and its `Detections` into a grid of tiles, with `slice_wh`, `overlap_wh`, `min_visibility` (drops annotations a tile boundary cuts below a configurable fraction of their original area), and `drop_empty_slices` (optionally omit background-only tiles).
- Reused `move_detections` from `inference_slicer.py` for box/OBB/mask coordinate translation, so `CompactMask` and dense masks are both handled without duplicating that logic.
- Exported `TrainingSlicer` from `supervision/__init__.py`.
- Added `docs/detection/tools/training_slicer.md` and registered it in `mkdocs.yml`.
- Added unit tests in `tests/detection/tools/test_training_slicer.py` covering the tiling grid, input validation, box localization/clipping at tile boundaries, the `min_visibility` threshold, mask cropping, and `drop_empty_slices`.

## Testing

- [x] I have tested this code locally
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass

Ran the new test file (16 tests, all passing) plus the full existing test suite to confirm no regressions, `ruff check`/`ruff format`, and `mypy` on the new module.

## Google Colab (optional)

Colab link: not yet added - happy to add one on request if it'd help review.

## Screenshots/Videos (optional)

N/A (no visual/annotator changes)

## Additional Notes

One deliberate deviation from the interface sketched in #1996: that proposal had both a constructor `callback` and a `__call__` that already returns the sliced result directly, which overlap awkwardly. I dropped the `callback` param — `__call__` returns `list[tuple[image, Detections]]` directly, which is simpler and lets the caller do whatever they want downstream (write files, feed an augmentation pipeline, etc.), consistent with how `InferenceSlicer` and other tools in this package are composed. Open to feedback if maintainers prefer the callback-based shape instead.

Also worth noting: OBB coordinates are translated into each tile's local frame but not clipped to the tile rectangle (clipping a rotated box against an axis-aligned rectangle produces a >4-vertex polygon), so an OBB straddling a tile boundary may have vertices outside that tile. Documented as a known limitation in the class docstring.