### PR TITLE
test(tests): align parametrization identifiers

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -339,7 +339,7 @@ class TestDetectionsWithNms:
     def test_raises_when_confidence_missing(self): ...
 ```
 
-**Parametrize aggressively:** Three or more structurally identical tests should become a single `@pytest.mark.parametrize` case. Use `pytest.param(..., id="slug")` per case — not `ids=[...]` on the decorator — so the ID stays co-located with its arguments and survives reordering.
+**Parametrize aggressively:** Three or more structurally identical tests should become a single `@pytest.mark.parametrize` case. Use bare strings, numbers, booleans, and `None` values. Use `pytest.param(..., id="semantic-slug")` when a case passes a function, object, or compound setup; needs a per-case mark; or would otherwise produce an unclear or empty ID. Never use a parallel `ids=[...]` list: co-locate an explicit ID with its arguments so it survives reordering. Move a trailing comment that only names a case into that ID; retain comments only when they explain a non-obvious invariant.
 
 ```python
 @pytest.mark.parametrize(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ These supplement [CONTRIBUTING.md](.github/CONTRIBUTING.md) — covering gaps or
 - Never assert `dict` or `set` iteration order.
 - No network or filesystem access outside `supervision/assets/`.
 
-**⚠ Test structure** — agents frequently fail here; read [CONTRIBUTING.md §Tests](.github/CONTRIBUTING.md#-tests) carefully: AAA structure, class grouping, parametrize with `pytest.param(..., id="slug")`, one-line docstring per test.
+**⚠ Test structure** — agents frequently fail here; read [CONTRIBUTING.md §Tests](.github/CONTRIBUTING.md#-tests) carefully: AAA structure, class grouping, bare simple parametrized values, `pytest.param(..., id="semantic-slug")` for compound or unclear cases (never parallel `ids`), one-line docstring per test.
 
 For branching, commit, code style, and API design conventions see [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -1876,7 +1876,6 @@ class TestTraceAnnotatorSmoothStationary:
     @pytest.mark.parametrize(
         "unique_positions",
         [1, 2, 3, 4],
-        ids=["1_unique", "2_unique", "3_unique", "4_unique"],
     )
     def test_smooth_does_not_crash_for_unique_point_counts(
         self, test_image, unique_positions

--- a/tests/cv2/test_text.py
+++ b/tests/cv2/test_text.py
@@ -54,7 +54,7 @@ class TestGetTextSize:
     """Text-metric contract of the Pillow fallback getTextSize."""
 
     @pytest.mark.parametrize("font_face", FONT_FACES)
-    @pytest.mark.parametrize("italic", [False, True], ids=["regular", "italic"])
+    @pytest.mark.parametrize("italic", [False, True])
     def test_returns_positive_metrics_for_every_face(
         self, font_face: int, italic: bool
     ) -> None:
@@ -100,7 +100,7 @@ class TestPutText:
     """Rendering behavior of the Pillow fallback putText."""
 
     @pytest.mark.parametrize("font_face", FONT_FACES)
-    @pytest.mark.parametrize("italic", [False, True], ids=["regular", "italic"])
+    @pytest.mark.parametrize("italic", [False, True])
     def test_renders_every_font_face_in_place(
         self, font_face: int, italic: bool
     ) -> None:

--- a/tests/detection/test_core.py
+++ b/tests/detection/test_core.py
@@ -1194,19 +1194,21 @@ def test_merge_inner_detection_object_pair(
 @pytest.mark.parametrize(
     ("detections", "expected"),
     [
-        (
+        pytest.param(
             Detections.empty(),
             True,
-        ),  # canonical empty
-        (
+            id="canonical-empty",
+        ),
+        pytest.param(
             Detections(
                 xyxy=np.array([[0, 0, 10, 10]]),
                 class_id=np.array([1]),
                 confidence=np.array([0.9]),
             ),
             False,
-        ),  # non-empty, no tracker_id
-        (
+            id="non-empty-no-tracker",
+        ),
+        pytest.param(
             Detections(
                 xyxy=np.array([[0, 0, 10, 10], [0, 0, 20, 30]]),
                 class_id=np.array([1, 2]),
@@ -1214,8 +1216,9 @@ def test_merge_inner_detection_object_pair(
                 tracker_id=np.array([1, 2]),
             )[np.array([False, False])],
             True,
-        ),  # filtered to empty with tracker_id — the regression case from #2195
-        (
+            id="filtered-empty-with-tracker-regression-2195",
+        ),
+        pytest.param(
             Detections(
                 xyxy=np.array([[0, 0, 10, 10], [0, 0, 20, 30]]),
                 class_id=np.array([1, 2]),
@@ -1223,22 +1226,17 @@ def test_merge_inner_detection_object_pair(
                 tracker_id=np.array([1, 2]),
             )[np.array([True, False])],
             False,
-        ),  # one detection remaining after filter
-        (
+            id="one-detection-after-filter",
+        ),
+        pytest.param(
             Detections(
                 xyxy=np.array([[0, 0, 10, 10], [0, 0, 20, 30]]),
                 mask=np.zeros((2, 4, 4), dtype=bool),
                 class_id=np.array([1, 2]),
             )[np.array([False, False])],
             True,
-        ),  # filtered to empty with mask — same bug could affect mask field
-    ],
-    ids=[
-        "canonical_empty",
-        "non_empty_no_tracker",
-        "filtered_empty_with_tracker",
-        "one_remaining_after_filter",
-        "filtered_empty_with_mask",
+            id="filtered-empty-with-mask",
+        ),
     ],
 )
 def test_is_empty(detections: Detections, expected: bool) -> None:

--- a/tests/detection/utils/test_boxes.py
+++ b/tests/detection/utils/test_boxes.py
@@ -364,7 +364,10 @@ def test_oriented_box_anchors_axis_aligned_matches_envelope(
     assert np.allclose(result, [expected])
 
 
-@pytest.mark.parametrize("anchor", _ALL_ANCHORS, ids=lambda a: a.value.lower())
+@pytest.mark.parametrize(
+    "anchor",
+    [pytest.param(anchor, id=anchor.value.lower()) for anchor in _ALL_ANCHORS],
+)
 def test_oriented_box_anchors_are_rotation_covariant(anchor: Position) -> None:
     """Rotating the box rotates each anchor by the same angle about the center."""
     base = np.array([[[0, 0], [10, 0], [10, 4], [0, 4]]], dtype=np.float64)
@@ -419,7 +422,10 @@ def test_oriented_box_anchors_center_of_mass_unsupported() -> None:
         oriented_box_anchors(np.zeros((1, 4, 2)), Position.CENTER_OF_MASS)
 
 
-@pytest.mark.parametrize("anchor", _ALL_ANCHORS, ids=lambda a: a.value.lower())
+@pytest.mark.parametrize(
+    "anchor",
+    [pytest.param(anchor, id=anchor.value.lower()) for anchor in _ALL_ANCHORS],
+)
 def test_oriented_box_anchors_at_90_degrees_on_box(anchor: Position) -> None:
     """All anchors of a 90-deg-rotated box lie on the box (exercises is_width=False)."""
     base = np.array([[0, 0], [10, 0], [10, 4], [0, 4]], dtype=np.float64)

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -167,22 +167,25 @@ def test_read_txt_file(
 @pytest.mark.parametrize(
     ("filenames_to_create", "extension", "expected_names"),
     [
-        (["image.jpg", "image.png"], ".jpg", {"image.jpg"}),
-        (["image.JPG"], "jpg", {"image.JPG"}),
-        (["archive.tar.gz"], "tar.gz", {"archive.tar.gz"}),
-        (
+        pytest.param(
+            ["image.jpg", "image.png"], ".jpg", {"image.jpg"}, id="leading-dot"
+        ),
+        pytest.param(["image.JPG"], "jpg", {"image.JPG"}, id="case-insensitive"),
+        pytest.param(
+            ["archive.tar.gz"], "tar.gz", {"archive.tar.gz"}, id="multi-part-full"
+        ),
+        pytest.param(
             ["archive.backup.tar.gz", "archive.backup.gz"],
             "tar.gz",
             {"archive.backup.tar.gz"},
+            id="multi-part-filename-tail",
         ),
-        (["archive.tar.gz", "data.gz"], "gz", {"archive.tar.gz", "data.gz"}),
-    ],
-    ids=[
-        "leading_dot",
-        "case_insensitive",
-        "multi_part_full",
-        "multi_part_filename_tail",
-        "multi_part_suffix",
+        pytest.param(
+            ["archive.tar.gz", "data.gz"],
+            "gz",
+            {"archive.tar.gz", "data.gz"},
+            id="multi-part-suffix",
+        ),
     ],
 )
 def test_list_files_with_extensions_normalization(


### PR DESCRIPTION
Changes:
- Align contributor and agent guidance with co-located pytest parameter IDs.
- Replace every separate ids argument with bare literals or pytest.param IDs.

Impact:
- Test node names remain clear while IDs cannot drift from their cases.

Verification:
- 64 affected tests passed.
- Targeted pre-commit and canonical lint, format, type, test, and review gates passed.

Residual limits:
- Full repository test suite not run.
