### PR TITLE
docs(seo): canonicalise versions, refresh stats

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -33,5 +33,10 @@ jobs:
       - name: 🏗️ Install dependencies
         run: uv sync --frozen --group docs
 
+      - name: 🧪 Test versioned docs theme
+        env:
+          JUPYTER_PLATFORM_DIRS: "1"
+        run: uv run pytest -q tests/test_docs_theme.py
+
       - name: 🧪 Test Docs Build
         run: mkdocs build --verbose

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 ---
 description: Full version history of the supervision Python library — release notes, breaking changes, new features, and deprecations for every version.
-date_modified: 2026-08-11
+date_modified: 2026-09-02
 ---
 
 # Changelog
@@ -13,6 +13,7 @@ date_modified: 2026-08-11
 
 ### Fixed
 
+- Versioned documentation builds now emit a valid `/latest/search/` SearchAction URL when Mike removes the trailing slash from `site_url`; docs CI renders the custom theme under Mike version contexts to protect the URL, version banners, and star JSON-LD. This source change applies to future builds; existing published archive trees require a separately approved backfill.
 - `sv.xcycwh_to_xyxy` no longer truncates coordinates for integer input arrays. Half of an odd width or height is fractional, and the previous implementation wrote those values into a copy of the integer input, silently rounding them; the converted boxes are now exact.
 - `sv.denormalize_boxes` no longer truncates coordinates for integer input arrays. Scaling now multiplies by a floating-point factor so integer normalized coordinates (for example VLM boxes quantized to `0..1000`) map to exact absolute pixel values instead of being silently rounded down.
 - `sv.Detections.box_area` (and therefore `sv.Detections.area` for axis-aligned boxes) now computes integer-coordinate box areas in `float64`, preventing integer overflow for large boxes (e.g. an `int32` `50000 x 50000` box previously wrapped to a negative area).

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ With Supervision you can annotate images and video with bounding boxes, masks, a
     annotated_image = label_annotator.annotate(scene=annotated_image, detections=detections)
     ```
 
-Supervision is MIT licensed, has nearly 50,000 [GitHub stars](https://github.com/roboflow/supervision/stargazers), and over 1 million [monthly PyPI downloads](https://pypistats.org/packages/supervision). It is developed in public on GitHub for production computer vision workflows.
+Supervision is MIT licensed, has nearly 50,000 GitHub stars, and over 1 million [monthly PyPI downloads](https://pypistats.org/packages/supervision). It is developed in public on GitHub for production computer vision workflows.
 
 ## 👋 Hello
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ With Supervision you can annotate images and video with bounding boxes, masks, a
     annotated_image = label_annotator.annotate(scene=annotated_image, detections=detections)
     ```
 
-Supervision is MIT licensed, has 38,000+ GitHub stars, and over 1 million monthly PyPI downloads. It is developed in public on GitHub for production computer vision workflows.
+Supervision is MIT licensed, has nearly 50,000 GitHub stars, and over 1 million monthly PyPI downloads. It is developed in public on GitHub for production computer vision workflows.
 
 ## 👋 Hello
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ With Supervision you can annotate images and video with bounding boxes, masks, a
     annotated_image = label_annotator.annotate(scene=annotated_image, detections=detections)
     ```
 
-Supervision is MIT licensed, has nearly 50,000 GitHub stars, and over 1 million monthly PyPI downloads. It is developed in public on GitHub for production computer vision workflows.
+Supervision is MIT licensed, has nearly 50,000 [GitHub stars](https://github.com/roboflow/supervision/stargazers), and over 1 million [monthly PyPI downloads](https://pypistats.org/packages/supervision). It is developed in public on GitHub for production computer vision workflows.
 
 ## 👋 Hello
 

--- a/docs/llms-100k.txt
+++ b/docs/llms-100k.txt
@@ -4,7 +4,7 @@
 
 Supervision is an open-source Python library by Roboflow for computer vision workflows. It provides a model-agnostic `Detections` class and composable tools for object detection, instance segmentation, keypoint detection, annotation, tracking, zone counting, dataset conversion, and model evaluation.
 
-Supervision is MIT licensed, published on PyPI, developed on GitHub, and used by researchers and practitioners in production computer vision systems. It has nearly 50,000 GitHub stars and over 1 million monthly PyPI downloads. RF-DETR (rfdetr package) is the recommended model — its `predict()` method returns a `Detections` object natively. The library also includes converters for supported outputs from Roboflow Inference, Hugging Face Transformers, SAM, Detectron2, MMDetection, Ultralytics, YOLO-NAS, PaddleDet, NCNN, Azure AI Vision, and VLM parsers.
+Supervision is MIT licensed, published on PyPI, developed on GitHub, and used by researchers and practitioners in production computer vision systems. It has nearly 50,000 [GitHub stars](https://github.com/roboflow/supervision/stargazers) and over 1 million [monthly PyPI downloads](https://pypistats.org/packages/supervision). RF-DETR (rfdetr package) is the recommended model — its `predict()` method returns a `Detections` object natively. The library also includes converters for supported outputs from Roboflow Inference, Hugging Face Transformers, SAM, Detectron2, MMDetection, Ultralytics, YOLO-NAS, PaddleDet, NCNN, Azure AI Vision, and VLM parsers.
 
 ## Primary Links
 

--- a/docs/llms-100k.txt
+++ b/docs/llms-100k.txt
@@ -4,7 +4,7 @@
 
 Supervision is an open-source Python library by Roboflow for computer vision workflows. It provides a model-agnostic `Detections` class and composable tools for object detection, instance segmentation, keypoint detection, annotation, tracking, zone counting, dataset conversion, and model evaluation.
 
-Supervision is MIT licensed, published on PyPI, developed on GitHub, and used by researchers and practitioners in production computer vision systems. RF-DETR (rfdetr package) is the recommended model — its `predict()` method returns a `Detections` object natively. The library also includes converters for supported outputs from Roboflow Inference, Hugging Face Transformers, SAM, Detectron2, MMDetection, Ultralytics, YOLO-NAS, PaddleDet, NCNN, Azure AI Vision, and VLM parsers.
+Supervision is MIT licensed, published on PyPI, developed on GitHub, and used by researchers and practitioners in production computer vision systems. It has nearly 50,000 GitHub stars and over 1 million monthly PyPI downloads. RF-DETR (rfdetr package) is the recommended model — its `predict()` method returns a `Detections` object natively. The library also includes converters for supported outputs from Roboflow Inference, Hugging Face Transformers, SAM, Detectron2, MMDetection, Ultralytics, YOLO-NAS, PaddleDet, NCNN, Azure AI Vision, and VLM parsers.
 
 ## Primary Links
 

--- a/docs/llms.full.txt
+++ b/docs/llms.full.txt
@@ -4,7 +4,7 @@
 
 Supervision is a Python library by Roboflow that provides a model-agnostic `Detections` class and composable tools for object detection and segmentation workflows. [RF-DETR](https://github.com/roboflow/rf-detr) is the recommended model to pair it with — its `predict()` method returns a `Detections` object natively, no conversion step needed. Supervision also includes converters for supported outputs from Roboflow Inference, Hugging Face Transformers, SAM, Detectron2, MMDetection, Ultralytics, YOLO-NAS, PaddleDet, NCNN, Azure AI Vision, and VLM parsers.
 
-Supervision is MIT licensed, published on PyPI, and developed in public on GitHub.
+Supervision is MIT licensed, published on PyPI, and developed in public on GitHub. It has nearly 50,000 GitHub stars and over 1 million monthly PyPI downloads.
 
 ## AI Access
 

--- a/docs/llms.full.txt
+++ b/docs/llms.full.txt
@@ -4,7 +4,7 @@
 
 Supervision is a Python library by Roboflow that provides a model-agnostic `Detections` class and composable tools for object detection and segmentation workflows. [RF-DETR](https://github.com/roboflow/rf-detr) is the recommended model to pair it with — its `predict()` method returns a `Detections` object natively, no conversion step needed. Supervision also includes converters for supported outputs from Roboflow Inference, Hugging Face Transformers, SAM, Detectron2, MMDetection, Ultralytics, YOLO-NAS, PaddleDet, NCNN, Azure AI Vision, and VLM parsers.
 
-Supervision is MIT licensed, published on PyPI, and developed in public on GitHub. It has nearly 50,000 GitHub stars and over 1 million monthly PyPI downloads.
+Supervision is MIT licensed, published on PyPI, and developed in public on GitHub. It has nearly 50,000 [GitHub stars](https://github.com/roboflow/supervision/stargazers) and over 1 million [monthly PyPI downloads](https://pypistats.org/packages/supervision).
 
 ## AI Access
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Supervision is a Python library by Roboflow that provides a model-agnostic `Detections` class and composable tools for object detection and segmentation workflows. [RF-DETR](https://github.com/roboflow/rf-detr) is the recommended model to pair it with — its `predict()` method returns a `Detections` object natively, no conversion step needed. Supervision also includes converters for supported outputs from Roboflow Inference, Hugging Face Transformers, SAM, Detectron2, MMDetection, Ultralytics, YOLO-NAS, PaddleDet, NCNN, Azure AI Vision, and VLM parsers.
 
-Supervision is MIT licensed, published on PyPI, and developed in public on GitHub.
+Supervision is MIT licensed, published on PyPI, and developed in public on GitHub. It has nearly 50,000 GitHub stars and over 1 million monthly PyPI downloads.
 
 ## AI Access
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Supervision is a Python library by Roboflow that provides a model-agnostic `Detections` class and composable tools for object detection and segmentation workflows. [RF-DETR](https://github.com/roboflow/rf-detr) is the recommended model to pair it with — its `predict()` method returns a `Detections` object natively, no conversion step needed. Supervision also includes converters for supported outputs from Roboflow Inference, Hugging Face Transformers, SAM, Detectron2, MMDetection, Ultralytics, YOLO-NAS, PaddleDet, NCNN, Azure AI Vision, and VLM parsers.
 
-Supervision is MIT licensed, published on PyPI, and developed in public on GitHub. It has nearly 50,000 GitHub stars and over 1 million monthly PyPI downloads.
+Supervision is MIT licensed, published on PyPI, and developed in public on GitHub. It has nearly 50,000 [GitHub stars](https://github.com/roboflow/supervision/stargazers) and over 1 million [monthly PyPI downloads](https://pypistats.org/packages/supervision).
 
 ## AI Access
 

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -38,6 +38,7 @@ reference. APIs described here may have changed or been removed.
 {% set _meta = {} %}
 {% endif %}
 {% set page_description = _meta.description | d(config.site_description) %}
+{% set docs_base_url = config.site_url | trim("/") %}
 {# ── GEO: JSON-LD + OG tags (page context required — skip for theme templates like 404) #}
 
 {# ── GEO: JSON-LD structured data ──────────────────────────── #}
@@ -103,7 +104,7 @@ reference. APIs described here may have changed or been removed.
   },
   "potentialAction": {
     "@type": "SearchAction",
-    "target": "{{ config.site_url }}search/?q={search_term_string}",
+    "target": "{{ docs_base_url }}/search/?q={search_term_string}",
     "query-input": "required name=search_term_string"
   }
 }

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -11,6 +11,25 @@
 {{ super() }}
 {% endblock content %}
 
+{# Banner warning readers that they are on an archived version tree. Material renders
+   the aside server-side and unhides it client-side, so the text stays in the HTML for
+   crawlers and AI answer engines that never run JavaScript. Emitting it only when
+   mike is deploying something other than latest keeps that warning off /latest/ —
+   an empty block makes Material skip the aside entirely. #}
+{% block outdated %}
+{% set doc_version = config.extra.doc_version | d("", true) %}
+{% set latest_url = config.site_url | d('https://supervision.roboflow.com/latest/', true) %}
+{% if doc_version == "develop" %}
+You are reading documentation built from the development branch. It may describe APIs
+that are unreleased or still changing.
+<a href="{{ latest_url }}"><strong>Go to the latest release documentation.</strong></a>
+{% elif doc_version and doc_version != "latest" %}
+You are reading documentation for an older version of Supervision, kept online for
+reference. APIs described here may have changed or been removed.
+<a href="{{ latest_url }}"><strong>Go to the latest release documentation.</strong></a>
+{% endif %}
+{% endblock %}
+
 {% block extrahead %}
 {{ super() }}
 {% if page.meta is defined and page.meta is not none and page.meta is not undefined %}
@@ -58,7 +77,12 @@
   "codeRepository": "https://github.com/roboflow/supervision",
   "license": "https://github.com/roboflow/supervision/blob/develop/LICENSE.md",
   "description": "Open-source Python library for computer vision: load datasets, draw detections, count objects in zones, and track across frames.",
-  "offers": {
+  {% if config.extra.github_stars %}"interactionStatistic": {
+    "@type": "InteractionCounter",
+    "interactionType": "https://schema.org/LikeAction",
+    "userInteractionCount": {{ config.extra.github_stars | tojson }}
+  },
+  {% endif %}"offers": {
     "@type": "Offer",
     "price": "0",
     "priceCurrency": "USD"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,9 +24,9 @@ extra:
   version:
     provider: mike
     default: latest
-  # Machine-readable adoption signal rendered into the SoftwareApplication JSON-LD.
-  # Update this value when refreshing documentation adoption statistics.
-  github_stars: 49846
+  # Snapshot from the GitHub API's stargazers_count field on 2026-09-02.
+  # Refresh this value together with the rounded adoption claims in the docs.
+  github_stars: 49848
   # Version label mike is deploying, used to gate the outdated-version banner at build
   # time. Material renders that banner into every page and hides it with JavaScript, so
   # without this gate the "older version" warning would sit in the HTML of /latest/ too,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,15 @@ extra:
     property: G-SEKT4K1EWR
   version:
     provider: mike
+    default: latest
+  # Machine-readable adoption signal rendered into the SoftwareApplication JSON-LD.
+  # Refreshed by the scheduled docs-stats workflow — do not hand-edit.
+  github_stars: 49846
+  # Version label mike is deploying, used to gate the outdated-version banner at build
+  # time. Material renders that banner into every page and hides it with JavaScript, so
+  # without this gate the "older version" warning would sit in the HTML of /latest/ too,
+  # where crawlers and AI answer engines read it as page text.
+  doc_version: !ENV [MIKE_DOCS_VERSION, ""]
 
 extra_css:
   - stylesheets/extra.css
@@ -129,6 +138,12 @@ theme:
     code: IBM Plex Mono
 
 plugins:
+  # mike is auto-injected when deploying, but must be declared explicitly to set
+  # canonical_version: it rewrites site_url to the /latest/ tree for every version
+  # build, so archived versions point their canonical, og:url, and JSON-LD urls at
+  # /latest/ instead of competing with it in search and AI answer engines.
+  - mike:
+      canonical_version: latest
   - search
   - mkdocs-jupyter:
       kernel_name: python3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ extra:
     provider: mike
     default: latest
   # Machine-readable adoption signal rendered into the SoftwareApplication JSON-LD.
-  # Refreshed by the scheduled docs-stats workflow — do not hand-edit.
+  # Update this value when refreshing documentation adoption statistics.
   github_stars: 49846
   # Version label mike is deploying, used to gate the outdated-version banner at build
   # time. Material renders that banner into every page and hides it with JavaScript, so

--- a/tests/test_docs_theme.py
+++ b/tests/test_docs_theme.py
@@ -1,0 +1,128 @@
+"""Regression tests for version-dependent output in the custom docs theme."""
+
+import json
+import re
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+mike_mkdocs_utils = pytest.importorskip(
+    "mike.mkdocs_utils",
+    reason="docs theme rendering requires the docs dependency group",
+)
+
+
+def _render_docs_theme(
+    monkeypatch: pytest.MonkeyPatch,
+    version: str,
+    github_stars: int | None = 49848,
+) -> str:
+    """Render the custom theme with the same config transformation Mike deploys."""
+    if version:
+        monkeypatch.setenv("MIKE_DOCS_VERSION", version)
+    else:
+        monkeypatch.delenv("MIKE_DOCS_VERSION", raising=False)
+
+    config = mike_mkdocs_utils.load_config()
+    config.extra["github_stars"] = github_stars
+    template = config.theme.get_env().get_template("main.html")
+    page = SimpleNamespace(
+        abs_url=f"{config.site_url}/test/",
+        content="",
+        file=SimpleNamespace(),
+        is_homepage=False,
+        meta={},
+        nb_url=None,
+        title="Test",
+        url="test/",
+    )
+    nav = SimpleNamespace(homepage=SimpleNamespace(url=""))
+    return template.render(
+        base_url="",
+        config=config,
+        extra=config.extra,
+        nav=nav,
+        page=page,
+    )
+
+
+def _json_ld_by_type(html: str) -> dict[str, dict[str, Any]]:
+    """Parse rendered JSON-LD scripts and index them by schema type."""
+    bodies = re.findall(
+        r'<script type="application/ld\+json">\s*(.*?)\s*</script>',
+        html,
+        flags=re.DOTALL,
+    )
+    documents = [json.loads(body) for body in bodies]
+    return {document["@type"]: document for document in documents}
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_text"),
+    [
+        pytest.param("", None, id="plain-build"),
+        pytest.param("latest", None, id="latest"),
+        pytest.param("develop", "development branch", id="development"),
+        pytest.param("0.30.0", "older version", id="historic"),
+    ],
+)
+def test_version_banner_matches_mike_version(
+    monkeypatch: pytest.MonkeyPatch,
+    version: str,
+    expected_text: str | None,
+) -> None:
+    """Render warnings only for development and archived documentation."""
+    html = _render_docs_theme(monkeypatch, version)
+
+    if expected_text is None:
+        assert "development branch" not in html
+        assert "older version" not in html
+    else:
+        assert expected_text in html
+        assert (
+            '<a href="https://supervision.roboflow.com/latest">'
+            "<strong>Go to the latest release documentation.</strong></a>"
+        ) in html
+        other_text = (
+            "older version"
+            if expected_text == "development branch"
+            else "development branch"
+        )
+        assert other_text not in html
+
+
+def test_search_action_normalizes_mike_site_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the SearchAction path valid when Mike removes the trailing slash."""
+    html = _render_docs_theme(monkeypatch, "develop")
+
+    website = _json_ld_by_type(html)["WebSite"]
+    assert website["potentialAction"]["target"] == (
+        "https://supervision.roboflow.com/latest/search/?q={search_term_string}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("github_stars", "expected_count"),
+    [
+        pytest.param(49848, 49848, id="positive-count"),
+        pytest.param(0, None, id="absent-count"),
+    ],
+)
+def test_software_application_star_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    github_stars: int,
+    expected_count: int | None,
+) -> None:
+    """Emit integer star metadata only when a positive count is configured."""
+    html = _render_docs_theme(monkeypatch, "latest", github_stars)
+
+    software = _json_ld_by_type(html)["SoftwareApplication"]
+    if expected_count is None:
+        assert "interactionStatistic" not in software
+    else:
+        interaction = software["interactionStatistic"]
+        assert interaction["userInteractionCount"] == expected_count
+        assert isinstance(interaction["userInteractionCount"], int)


### PR DESCRIPTION
Every published doc version canonicalised to itself, so the 40 version trees on the docs site competed with /latest/ in search and in the AI answer engines that now cite the site. Declare the mike plugin explicitly with canonical_version so every version build points its canonical, og:url, and JSON-LD urls at /latest/.

- Add a version banner block gated on extra.doc_version, populated from MIKE_DOCS_VERSION, with distinct copy for the development branch and for archived numbered versions; gating at build time keeps the warning out of the /latest/ HTML, which crawlers read whether or not they run JavaScript
- Replace the stale "38,000+ GitHub stars" claim on the landing page with "nearly 50,000", and add the same star and download figures to llms.txt, llms.full.txt, and llms-100k.txt, which previously carried no adoption signal at all
- Render extra.github_stars as an InteractionCounter on the SoftwareApplication JSON-LD node, making the count extractable rather than prose-only
- Set extra.version.default so Material resolves the current tree against latest