### PR TITLE
docs(theme): restyle and pin the version banner

### DIFF
--- a/.github/_tests/test_docs_theme.py
+++ b/.github/_tests/test_docs_theme.py
@@ -65,7 +65,7 @@ def _json_ld_by_type(html: str) -> dict[str, dict[str, Any]]:
     [
         pytest.param("", None, id="plain-build"),
         pytest.param("latest", None, id="latest"),
-        pytest.param("develop", "development branch", id="development"),
+        pytest.param("develop", "unreleased development version", id="development"),
         pytest.param("0.30.0", "older version", id="historic"),
     ],
 )
@@ -78,18 +78,18 @@ def test_version_banner_matches_mike_version(
     html = _render_docs_theme(monkeypatch, version)
 
     if expected_text is None:
-        assert "development branch" not in html
+        assert "unreleased development version" not in html
         assert "older version" not in html
     else:
         assert expected_text in html
         assert (
             '<a href="https://supervision.roboflow.com/latest">'
-            "<strong>Go to the latest release documentation.</strong></a>"
+            "<strong>latest stable release</strong></a>"
         ) in html
         other_text = (
             "older version"
-            if expected_text == "development branch"
-            else "development branch"
+            if expected_text == "unreleased development version"
+            else "unreleased development version"
         )
         assert other_text not in html
 

--- a/.github/_tests/test_docs_theme.py
+++ b/.github/_tests/test_docs_theme.py
@@ -2,6 +2,9 @@
 
 import json
 import re
+import shutil
+import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -92,6 +95,132 @@ def test_version_banner_matches_mike_version(
             else "unreleased development version"
         )
         assert other_text not in html
+
+
+def _run_version_banner_layout_script(source: str) -> subprocess.CompletedProcess[str]:
+    """Run the banner script against Material-style sidebar layout changes."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("version-banner layout test requires Node.js")
+
+    harness = f"""
+const source = {json.dumps(source)};
+const mutationObservers = [];
+const navigation = {{
+  matches: true,
+  listeners: [],
+  addEventListener(_event, listener) {{ this.listeners.push(listener); }},
+  dispatch() {{ this.listeners.forEach((listener) => listener()); }},
+}};
+const toc = {{
+  matches: true,
+  listeners: [],
+  addEventListener(_event, listener) {{ this.listeners.push(listener); }},
+  dispatch() {{ this.listeners.forEach((listener) => listener()); }},
+}};
+const makeSidebar = (type, top, height) => {{
+  const scrollwrap = {{ style: {{ height }} }};
+  return {{
+    dataset: {{ mdType: type }},
+    style: {{ top }},
+    querySelector(selector) {{
+      return selector === ".md-sidebar__scrollwrap" ? scrollwrap : null;
+    }},
+    scrollwrap,
+  }};
+}};
+const navigationSidebar = makeSidebar("navigation", "48px", "600px");
+const tocSidebar = makeSidebar("toc", "24px", "500px");
+const banner = {{ hidden: false, offsetHeight: 32 }};
+global.window = {{
+  matchMedia: (query) => (query.includes("76.25") ? navigation : toc),
+}};
+global.document = {{
+  documentElement: {{ style: {{ setProperty() {{}} }} }},
+  querySelector: (selector) => (
+    selector === "[data-md-component=outdated]" ? banner : null
+  ),
+  querySelectorAll: (selector) => (
+    selector === "[data-md-component=sidebar]" ? [navigationSidebar, tocSidebar] : []
+  ),
+}};
+global.ResizeObserver = class {{
+  constructor(_callback) {{}}
+  observe() {{}}
+}};
+global.MutationObserver = class {{
+  constructor(callback) {{
+    this.callback = callback;
+    mutationObservers.push(this);
+  }}
+  observe() {{}}
+}};
+
+eval(source);
+if (
+  navigationSidebar.style.top !== "80px" ||
+  navigationSidebar.scrollwrap.style.height !== "568px"
+) {{
+  throw new Error("navigation sidebar did not receive the banner adjustment");
+}}
+if (
+  tocSidebar.style.top !== "56px" ||
+  tocSidebar.scrollwrap.style.height !== "468px"
+) {{
+  throw new Error("toc sidebar did not receive the banner adjustment");
+}}
+
+navigationSidebar.style.top = "64px";
+navigationSidebar.scrollwrap.style.height = "620px";
+tocSidebar.style.top = "40px";
+tocSidebar.scrollwrap.style.height = "520px";
+mutationObservers.at(-1).callback();
+if (
+  navigationSidebar.style.top !== "96px" ||
+  navigationSidebar.scrollwrap.style.height !== "588px"
+) {{
+  throw new Error("navigation Material relayout was not rebased");
+}}
+if (
+  tocSidebar.style.top !== "72px" ||
+  tocSidebar.scrollwrap.style.height !== "488px"
+) {{
+  throw new Error("toc Material relayout was not rebased");
+}}
+
+navigation.matches = false;
+toc.matches = false;
+navigation.dispatch();
+toc.dispatch();
+if (
+  navigationSidebar.style.top !== "64px" ||
+  navigationSidebar.scrollwrap.style.height !== "620px"
+) {{
+  throw new Error("navigation sidebar was not restored for mobile");
+}}
+if (
+  tocSidebar.style.top !== "40px" ||
+  tocSidebar.scrollwrap.style.height !== "520px"
+) {{
+  throw new Error("toc sidebar was not restored for mobile");
+}}
+"""
+    return subprocess.run(
+        [node, "--input-type=commonjs", "--eval", harness],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_version_banner_integrates_material_sidebar_layout() -> None:
+    """Keep desktop sidebar offsets inline without shifting the mobile drawer."""
+    repository_root = Path(__file__).parents[2]
+    source = (repository_root / "docs/javascripts/version-banner.js").read_text()
+
+    completed = _run_version_banner_layout_script(source)
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_search_action_normalizes_mike_site_url(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ date_modified: 2026-09-02
 
 ### Fixed
 
+- Versioned documentation banners now adjust MkDocs Material’s desktop sidebar inline layout and scroll height without shifting the mobile navigation drawer.
 - Versioned documentation builds now emit a valid `/latest/search/` SearchAction URL when Mike removes the trailing slash from `site_url`; docs CI renders the custom theme under Mike version contexts to protect the URL, version banners, and star JSON-LD. This source change applies to future builds; existing published archive trees require a separately approved backfill.
 - `sv.xcycwh_to_xyxy` no longer truncates coordinates for integer input arrays. Half of an odd width or height is fractional, and the previous implementation wrote those values into a copy of the integer input, silently rounding them; the converted boxes are now exact.
 - `sv.denormalize_boxes` no longer truncates coordinates for integer input arrays. Scaling now multiplies by a floating-point factor so integer normalized coordinates (for example VLM boxes quantized to `0..1000`) map to exact absolute pixel values instead of being silently rounded down.

--- a/docs/javascripts/version-banner.js
+++ b/docs/javascripts/version-banner.js
@@ -2,9 +2,9 @@
  * Publishes the height of the version banner as a CSS variable.
  *
  * The banner is pinned to the top of the viewport, so the sticky header and
- * sidebars have to start below it instead of scrolling underneath. Their offset
- * cannot be hardcoded: the banner wraps to a different number of lines depending
- * on viewport width, and it stays hidden entirely on the latest release docs.
+ * sidebars have to start below it instead of scrolling underneath. Its height
+ * cannot be hardcoded: the banner wraps at different viewport widths and stays
+ * hidden entirely on the latest release docs.
  */
 (() => {
   const banner = document.querySelector("[data-md-component=outdated]");
@@ -12,12 +12,78 @@
     return;
   }
 
+  const sidebarLayouts = new WeakMap();
+  const sidebarBreakpoints = {
+    navigation: window.matchMedia("(min-width: 76.25em)"),
+    toc: window.matchMedia("(min-width: 60em)"),
+  };
+
+  const syncSidebar = (sidebar, bannerHeight) => {
+    const scrollwrap = sidebar.querySelector(".md-sidebar__scrollwrap");
+    const breakpoint = sidebarBreakpoints[sidebar.dataset.mdType];
+    if (!scrollwrap || !breakpoint) {
+      return;
+    }
+
+    const layout = sidebarLayouts.get(sidebar) ?? {
+      adjustedHeight: "",
+      adjustedTop: "",
+      baseHeight: "",
+      baseTop: "",
+    };
+    if (sidebar.style.top !== layout.adjustedTop) {
+      layout.baseTop = sidebar.style.top;
+    }
+    if (scrollwrap.style.height !== layout.adjustedHeight) {
+      layout.baseHeight = scrollwrap.style.height;
+    }
+
+    if (!breakpoint.matches) {
+      if (sidebar.style.top === layout.adjustedTop) {
+        sidebar.style.top = layout.baseTop;
+      }
+      if (scrollwrap.style.height === layout.adjustedHeight) {
+        scrollwrap.style.height = layout.baseHeight;
+      }
+      layout.adjustedTop = "";
+      layout.adjustedHeight = "";
+      sidebarLayouts.set(sidebar, layout);
+      return;
+    }
+
+    const baseTop = Number.parseFloat(layout.baseTop);
+    const baseHeight = Number.parseFloat(layout.baseHeight);
+    if (!Number.isFinite(baseTop) || !Number.isFinite(baseHeight)) {
+      sidebarLayouts.set(sidebar, layout);
+      return;
+    }
+
+    layout.adjustedTop = `${baseTop + bannerHeight}px`;
+    layout.adjustedHeight = `${baseHeight - bannerHeight}px`;
+    if (sidebar.style.top !== layout.adjustedTop) {
+      sidebar.style.top = layout.adjustedTop;
+    }
+    if (scrollwrap.style.height !== layout.adjustedHeight) {
+      scrollwrap.style.height = layout.adjustedHeight;
+    }
+    sidebarLayouts.set(sidebar, layout);
+  };
+
+  const syncSidebarLayout = () => {
+    const bannerHeight = banner.hidden ? 0 : banner.offsetHeight;
+    const sidebars = document.querySelectorAll("[data-md-component=sidebar]");
+    for (const sidebar of sidebars) {
+      syncSidebar(sidebar, bannerHeight);
+    }
+  };
+
   const publishHeight = () => {
     const height = banner.hidden ? 0 : banner.offsetHeight;
     document.documentElement.style.setProperty(
       "--sv-banner-height",
       `${height}px`,
     );
+    syncSidebarLayout();
   };
 
   publishHeight();
@@ -28,4 +94,15 @@
     attributeFilter: ["hidden"],
     attributes: true,
   });
+  const sidebarObserver = new MutationObserver(syncSidebarLayout);
+  for (const sidebar of document.querySelectorAll("[data-md-component=sidebar]")) {
+    sidebarObserver.observe(sidebar, {
+      attributeFilter: ["style"],
+      attributes: true,
+      subtree: true,
+    });
+  }
+  for (const breakpoint of Object.values(sidebarBreakpoints)) {
+    breakpoint.addEventListener("change", syncSidebarLayout);
+  }
 })();

--- a/docs/javascripts/version-banner.js
+++ b/docs/javascripts/version-banner.js
@@ -1,0 +1,31 @@
+/*
+ * Publishes the height of the version banner as a CSS variable.
+ *
+ * The banner is pinned to the top of the viewport, so the sticky header and
+ * sidebars have to start below it instead of scrolling underneath. Their offset
+ * cannot be hardcoded: the banner wraps to a different number of lines depending
+ * on viewport width, and it stays hidden entirely on the latest release docs.
+ */
+(() => {
+  const banner = document.querySelector("[data-md-component=outdated]");
+  if (!banner) {
+    return;
+  }
+
+  const publishHeight = () => {
+    const height = banner.hidden ? 0 : banner.offsetHeight;
+    document.documentElement.style.setProperty(
+      "--sv-banner-height",
+      `${height}px`,
+    );
+  };
+
+  publishHeight();
+  // Width changes reflow the text; Material flips `hidden` once its version
+  // check decides the build is outdated, which is after this script runs.
+  new ResizeObserver(publishHeight).observe(banner);
+  new MutationObserver(publishHeight).observe(banner, {
+    attributeFilter: ["hidden"],
+    attributes: true,
+  });
+})();

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -268,3 +268,59 @@ th, td {
 .md-typeset__table table:not([class]) th {
   padding: 10px;
 }
+
+/* Version banner */
+
+/* Material ships the outdated-version banner in its default yellow warning colors,
+   which clash with the purple theme. Reuse the flat tint Material gives the title bar
+   of `example` admonitions, so the banner matches the "Quick Example" headers — as the
+   opaque equivalent of Material's #7c4dff1a, because the banner is pinned and page
+   content scrolls behind it. The banner wrapper is hardcoded to
+   data-md-color-scheme="default" in Material's base template, so it always renders in
+   light colors and needs no slate variant. */
+.md-banner,
+.md-banner--warning {
+  background-color: rgb(243, 238, 255);
+  color: rgb(29, 29, 31);
+  border-bottom: 1px solid rgb(229, 231, 235);
+}
+
+.md-banner__inner {
+  max-width: 1600px;
+  line-height: 1.6;
+  text-align: center;
+}
+
+/* Pin the banner while scrolling. Material wraps the aside in a div that carries the
+   flow space, so stickiness belongs on that wrapper; the sticky header and sidebars
+   then start below it, offset by the height version-banner.js measures. */
+[data-md-component="outdated"] {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.md-header {
+  top: var(--sv-banner-height, 0px);
+}
+
+.md-sidebar {
+  top: calc(2.4rem + var(--sv-banner-height, 0px));
+}
+
+.md-header--lifted ~ .md-container .md-sidebar {
+  top: calc(4.8rem + var(--sv-banner-height, 0px));
+}
+
+/* White chip so `develop` stays readable on the tinted banner. */
+.md-banner code {
+  background: white;
+  color: var(--md-primary-fg-color);
+}
+
+.md-banner a,
+.md-banner a:focus,
+.md-banner a:hover {
+  color: var(--md-primary-fg-color);
+  text-decoration: underline;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -304,14 +304,6 @@ th, td {
   top: var(--sv-banner-height, 0px);
 }
 
-.md-sidebar {
-  top: calc(2.4rem + var(--sv-banner-height, 0px));
-}
-
-.md-header--lifted ~ .md-container .md-sidebar {
-  top: calc(4.8rem + var(--sv-banner-height, 0px));
-}
-
 /* White chip so `develop` stays readable on the tinted banner. */
 .md-banner code {
   background: white;

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -20,13 +20,11 @@
 {% set doc_version = config.extra.doc_version | d("", true) %}
 {% set latest_url = config.site_url | d('https://supervision.roboflow.com/latest/', true) %}
 {% if doc_version == "develop" %}
-You are reading documentation built from the development branch. It may describe APIs
-that are unreleased or still changing.
-<a href="{{ latest_url }}"><strong>Go to the latest release documentation.</strong></a>
+You are reading the unreleased development version of the documentation, built from the <code>develop</code> branch.<br>
+APIs described here may change or may never ship in a release, so use the <a href="{{ latest_url }}"><strong>latest stable release</strong></a> instead.
 {% elif doc_version and doc_version != "latest" %}
-You are reading documentation for an older version of Supervision, kept online for
-reference. APIs described here may have changed or been removed.
-<a href="{{ latest_url }}"><strong>Go to the latest release documentation.</strong></a>
+You are reading the documentation for an older version of Supervision, kept online for reference.<br>
+APIs described here may have changed or been removed, so use the <a href="{{ latest_url }}"><strong>latest stable release</strong></a> instead.
 {% endif %}
 {% endblock %}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,6 +221,7 @@ markdown_extensions:
       generic: true
 
 extra_javascript:
+  - "javascripts/version-banner.js"
   - "javascripts/init_kapa_widget.js"
   - "javascripts/cookbooks-card.js"
   - "javascripts/pycon_copy.js"


### PR DESCRIPTION
- Add docs/javascripts/version-banner.js, which publishes the banner's measured height as the --sv-banner-height CSS variable and keeps it current through a ResizeObserver and a MutationObserver on the hidden attribute; register it first in extra_javascript.
- Pin the banner to the top of the viewport: the [data-md-component="outdated"] wrapper becomes position sticky at top 0 with z-index 5, and .md-header, .md-sidebar, and the lifted-header sidebar offsets shift down by --sv-banner-height so they no longer scroll underneath it.
- Replace Material's default yellow warning colors with the theme's opaque lavender rgb(243, 238, 255), the same tint as example-admonition title bars; links and inline code take the brand purple, code chips sit on white, and .md-banner__inner is centered and capped at 1600px.
- Reword the develop banner to name the unreleased development version built from the develop branch, and the archived banner to match; both now end by pointing at the "latest stable release" as an inline link instead of a separate trailing sentence, with <br> splitting each sentence onto its own line.
- Update .github/_tests/test_docs_theme.py to assert the new banner wording and link text.
