### PR TITLE
ci(docs): wire banner version, backup gh-pages before canonical rewrite

### DIFF
--- a/.github/_tests/conftest.py
+++ b/.github/_tests/conftest.py
@@ -12,8 +12,10 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 import pytest
+import yaml
 
 REPO_ROOT: Path = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR: Path = REPO_ROOT / ".github" / "scripts"
@@ -71,3 +73,25 @@ def load_script() -> Callable[[str], ModuleType]:
 def updater(load_script: Callable[[str], ModuleType]) -> ModuleType:
     """Load the docs-stat refresh utility exercised by the star-count tests."""
     return load_script("update_docs_stats")
+
+
+@pytest.fixture
+def workflow_step(
+    workflows_dir: Path,
+) -> Callable[[str, str, str], dict[str, Any]]:
+    """Return a lookup for one workflow step, addressed by job id and step name.
+
+    Steps are looked up by name rather than list position so that inserting a step
+    into a workflow cannot silently repoint an existing test at a different step.
+    """
+
+    def lookup(workflow_file: str, job: str, step_name: str) -> dict[str, Any]:
+        workflow = yaml.safe_load(
+            (workflows_dir / workflow_file).read_text(encoding="utf-8")
+        )
+        steps: list[dict[str, Any]] = workflow["jobs"][job]["steps"]
+        matches = [step for step in steps if step.get("name") == step_name]
+        assert len(matches) == 1, f"expected exactly one step named {step_name!r}"
+        return matches[0]
+
+    return lookup

--- a/.github/_tests/test_docs_canonical_workflow.py
+++ b/.github/_tests/test_docs_canonical_workflow.py
@@ -1,12 +1,23 @@
 """Regression tests for the versioned documentation canonical contract."""
 
+import os
 import subprocess
 import textwrap
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
-import yaml
 from mike.mkdocs_utils import load_config
+
+StepLookup = Callable[[str, str, str], dict[str, Any]]
+
+BACKFILL_WORKFLOW = "docs-canonical-backfill.yml"
+REWRITE_STEP = "\N{LINK SYMBOL} Rewrite canonical tags"
+REPORT_STEP = (
+    "\N{RIGHT-POINTING MAGNIFYING GLASS} Report canonicals with no page under latest/"
+)
+COMMIT_STEP = "\N{OUTBOX TRAY} Commit and push"
 
 
 def test_mike_resolves_a_versioned_build_to_latest(
@@ -21,12 +32,10 @@ def test_mike_resolves_a_versioned_build_to_latest(
 
 
 def test_backfill_rewrites_both_hosts_but_not_version_links(
-    tmp_path: Path, workflows_dir: Path
+    tmp_path: Path, workflow_step: StepLookup
 ) -> None:
     """Ensure historical and current canonical hosts are rewritten narrowly."""
-    backfill = workflows_dir / "docs-canonical-backfill.yml"
-    workflow = yaml.safe_load(backfill.read_text(encoding="utf-8"))
-    rewrite_step = workflow["jobs"]["backfill"]["steps"][2]["run"]
+    rewrite_step = workflow_step(BACKFILL_WORKFLOW, "backfill", REWRITE_STEP)["run"]
 
     version_dir = tmp_path / "0.10.0"
     version_dir.mkdir()
@@ -72,3 +81,64 @@ def test_backfill_rewrites_both_hosts_but_not_version_links(
         'href="https://roboflow.github.io/supervision/0.10.0/" />' in page.read_text()
     )
     assert 'href="https://supervision.roboflow.com/latest/"' in current_page.read_text()
+
+
+def test_backfill_snapshots_gh_pages_before_rewriting_it(
+    workflow_step: StepLookup,
+) -> None:
+    """Push the untouched gh-pages tip to a backup branch before committing over it."""
+    commit_step = workflow_step(BACKFILL_WORKFLOW, "backfill", COMMIT_STEP)["run"]
+
+    backup_push = commit_step.index('git push origin "HEAD:refs/heads/$backup"')
+    assert commit_step.index('backup="gh-pages-backup-$(date -u') < backup_push
+    assert backup_push < commit_step.index("git commit -m")
+    assert backup_push < commit_step.index("git push origin gh-pages")
+
+
+def _run_report_step(
+    script: str, tree: Path, summary: Path
+) -> subprocess.CompletedProcess[str]:
+    """Run the resolution-check step against a fixture gh-pages tree."""
+    return subprocess.run(
+        # -e mirrors the shell GitHub Actions runs `run:` blocks under, where a
+        # failing test in a `cmd && other` line would abort the whole step.
+        ["/bin/bash", "-e", "-c", textwrap.dedent(script)],
+        capture_output=True,
+        check=True,
+        cwd=tree,
+        env={**os.environ, "GITHUB_STEP_SUMMARY": str(summary)},
+        text=True,
+    )
+
+
+def _write_page(path: Path, canonical_path: str) -> None:
+    """Write a published page carrying a canonical link to the given latest/ path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '<link rel="canonical" '
+        f'href="https://supervision.roboflow.com/latest/{canonical_path}" />'
+    )
+
+
+@pytest.mark.parametrize(
+    ("canonical_path", "expected"),
+    [
+        pytest.param(
+            "kept/", "None — every rewritten canonical resolves", id="resolves"
+        ),
+        pytest.param("dropped/", "- `/latest/dropped/`", id="missing"),
+    ],
+)
+def test_backfill_reports_canonicals_missing_from_latest(
+    tmp_path: Path, workflow_step: StepLookup, canonical_path: str, expected: str
+) -> None:
+    """Name every rewritten canonical whose target page is absent from latest/."""
+    report_step = workflow_step(BACKFILL_WORKFLOW, "backfill", REPORT_STEP)["run"]
+    _write_page(tmp_path / "latest" / "kept" / "index.html", "kept/")
+    _write_page(tmp_path / "0.10.0" / "index.html", canonical_path)
+    summary = tmp_path / "summary.md"
+    summary.touch()
+
+    _run_report_step(report_step, tmp_path, summary)
+
+    assert expected in summary.read_text()

--- a/.github/_tests/test_docs_publish_workflow.py
+++ b/.github/_tests/test_docs_publish_workflow.py
@@ -1,0 +1,69 @@
+"""Regression tests for the version wiring in the docs publish workflow."""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+StepLookup = Callable[[str, str, str], dict[str, Any]]
+
+PUBLISH_WORKFLOW = "publish-docs.yml"
+PUBLISH_JOB = "docs-build-deploy"
+
+
+@pytest.mark.parametrize(
+    ("step_name", "deploy_target", "expected_version"),
+    [
+        pytest.param(
+            "\N{ROCKET} Deploy Development Docs",
+            "mike deploy --push develop",
+            "develop",
+            id="develop",
+        ),
+        pytest.param(
+            "\N{ROCKET} Deploy Latest Docs",
+            "mike deploy --push latest",
+            "latest",
+            id="latest",
+        ),
+        pytest.param(
+            "\N{ROCKET} Deploy Release Docs",
+            "steps.release_metadata.outputs.release_tag",
+            "steps.release_metadata.outputs.release_tag",
+            id="release-tag",
+        ),
+    ],
+)
+def test_deploy_steps_export_the_version_they_deploy(
+    workflow_step: StepLookup,
+    step_name: str,
+    deploy_target: str,
+    expected_version: str,
+) -> None:
+    """Gate the outdated-version banner on the version each step hands to Mike."""
+    step = workflow_step(PUBLISH_WORKFLOW, PUBLISH_JOB, step_name)
+
+    assert deploy_target in step["run"]
+    assert expected_version in step["env"]["MIKE_DOCS_VERSION"]
+
+
+def test_every_mike_deploy_step_exports_the_banner_version(
+    workflows_dir: Path,
+) -> None:
+    """Catch a future deploy step that would publish a tree carrying no banner."""
+    workflow = yaml.safe_load(
+        (workflows_dir / PUBLISH_WORKFLOW).read_text(encoding="utf-8")
+    )
+    deploy_steps = [
+        step
+        for step in workflow["jobs"][PUBLISH_JOB]["steps"]
+        if "mike deploy" in step.get("run", "")
+    ]
+
+    assert deploy_steps
+    unwired = [
+        step["name"] for step in deploy_steps if "MIKE_DOCS_VERSION" not in step["env"]
+    ]
+    assert not unwired

--- a/.github/_tests/test_docs_publish_workflow.py
+++ b/.github/_tests/test_docs_publish_workflow.py
@@ -31,7 +31,7 @@ PUBLISH_JOB = "docs-build-deploy"
         pytest.param(
             "\N{ROCKET} Deploy Release Docs",
             "steps.release_metadata.outputs.release_tag",
-            "steps.release_metadata.outputs.release_tag",
+            "${{ steps.release_metadata.outputs.release_tag }}",
             id="release-tag",
         ),
     ],
@@ -46,7 +46,7 @@ def test_deploy_steps_export_the_version_they_deploy(
     step = workflow_step(PUBLISH_WORKFLOW, PUBLISH_JOB, step_name)
 
     assert deploy_target in step["run"]
-    assert expected_version in step["env"]["MIKE_DOCS_VERSION"]
+    assert step["env"]["MIKE_DOCS_VERSION"] == expected_version
 
 
 def test_every_mike_deploy_step_exports_the_banner_version(

--- a/.github/workflows/docs-canonical-backfill.yml
+++ b/.github/workflows/docs-canonical-backfill.yml
@@ -96,7 +96,7 @@ jobs:
               echo "None — every rewritten canonical resolves to a published page."
             else
               echo "$missing_count path(s) do not exist under \`latest/\`:"
-              printf '%s' "$missing" | sed 's|^|- `|; s|$|`|' | head -20
+              printf '%s' "$missing" | sed 's|^|- `|; s|$|`|' | sed -n '1,20p'
               if [[ "$missing_count" -gt 20 ]]; then
                 echo "- … and $((missing_count - 20)) more"
               fi

--- a/.github/workflows/docs-canonical-backfill.yml
+++ b/.github/workflows/docs-canonical-backfill.yml
@@ -7,6 +7,9 @@
 # until their published HTML is rewritten in place. This job does that rewrite.
 #
 # Manual trigger only. Safe to re-run: rewriting an already-correct file is a no-op.
+# Every run that changes something first pushes the pre-rewrite gh-pages tip to a
+# `gh-pages-backup-<timestamp>` branch, named in the job summary; delete that branch
+# once the published site is verified.
 
 name: Backfill Docs Canonicals
 
@@ -56,6 +59,50 @@ jobs:
           done
           git diff --stat | tail -5
 
+      - name: 🔎 Report canonicals with no page under latest/
+        run: |
+          # A rewritten canonical can now point at a page /latest/ does not have: an API
+          # an archived version documents may since have been removed. Google ignores a
+          # canonical whose target 404s, so those pages keep competing with /latest/ in
+          # search. Report-only — the rewrite still fixes every page that does resolve.
+          shopt -s nullglob
+          version_dirs=()
+          for dir in develop [0-9]*; do
+            [[ -d "$dir" ]] || continue
+            version_dirs+=("$dir")
+          done
+          if [[ ! -d latest || ${#version_dirs[@]} -eq 0 ]]; then
+            echo "no latest/ tree or no version trees — skipping the resolution check"
+            exit 0
+          fi
+          canonicals="$(grep -rho \
+            'rel="canonical" href="https://supervision.roboflow.com/latest/[^"]*"' \
+            "${version_dirs[@]}" | sed -e 's|.*/latest/||' -e 's|"$||' | sort -u || true)"
+          missing=""
+          missing_count=0
+          if [[ -n "$canonicals" ]]; then
+            while IFS= read -r target; do
+              # Canonicals are directory URLs, so the page behind one is its index.html.
+              if [[ -f "latest/${target}index.html" ]]; then
+                continue
+              fi
+              missing="${missing}/latest/${target}"$'\n'
+              missing_count=$((missing_count + 1))
+            done <<< "$canonicals"
+          fi
+          {
+            echo "### Canonical targets missing from \`latest/\`"
+            if [[ "$missing_count" -eq 0 ]]; then
+              echo "None — every rewritten canonical resolves to a published page."
+            else
+              echo "$missing_count path(s) do not exist under \`latest/\`:"
+              printf '%s' "$missing" | sed 's|^|- `|; s|$|`|' | head -20
+              if [[ "$missing_count" -gt 20 ]]; then
+                echo "- … and $((missing_count - 20)) more"
+              fi
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: 📤 Commit and push
         run: |
           git config user.name "github-actions[bot]"
@@ -65,5 +112,13 @@ jobs:
             echo "canonicals already point at /latest/ — nothing to do"
             exit 0
           fi
+          # Snapshot the pre-rewrite tree before replacing it. gh-pages holds the only
+          # copy of the archived version trees — the tags that produced them no longer
+          # build against current dependencies — so a bad rewrite has no rebuild path.
+          # HEAD is still the untouched tip here: the rewrite only touched the worktree.
+          backup="gh-pages-backup-$(date -u +%Y%m%dT%H%M%SZ)"
+          git push origin "HEAD:refs/heads/$backup"
+          echo "Pre-rewrite snapshot pushed to \`$backup\`; delete it once /latest/ is verified." \
+            >> "$GITHUB_STEP_SUMMARY"
           git commit -m "chore(docs): canonicalise archived versions to /latest/"
           git push origin gh-pages

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -50,10 +50,15 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
+      # MIKE_DOCS_VERSION feeds `extra.doc_version` in mkdocs.yml, which gates the
+      # outdated-version banner the theme renders server-side. It must name the version
+      # being deployed: mike itself never exports it, so an unset value silently builds
+      # every tree without the banner. Keep it in sync with the `mike deploy` argument.
       - name: 🚀 Deploy Development Docs
         if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || github.event_name == 'workflow_dispatch'
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
+          MIKE_DOCS_VERSION: develop
         run: |
           mike deploy --push develop
 
@@ -61,6 +66,7 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/release/latest'
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
+          MIKE_DOCS_VERSION: latest
         run: |
           # `latest` may exist as a real version or as an alias (e.g. `0.28.0 [latest]`),
           # which the `mike list` grep cannot detect. Always delete it first, tolerating
@@ -89,6 +95,7 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'published' && steps.release_metadata.outputs.is_rc != 'true'
         env:
           MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
+          MIKE_DOCS_VERSION: ${{ steps.release_metadata.outputs.release_tag }}
         run: |
           mike deploy --push "${{ steps.release_metadata.outputs.release_tag }}"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 ---
 description: Full version history of the supervision Python library — release notes, breaking changes, new features, and deprecations for every version.
-date_modified: 2026-09-02
+date_modified: 2026-09-03
 ---
 
 # Changelog
@@ -19,6 +19,8 @@ date_modified: 2026-09-02
 - `sv.denormalize_boxes` no longer truncates coordinates for integer input arrays. Scaling now multiplies by a floating-point factor so integer normalized coordinates (for example VLM boxes quantized to `0..1000`) map to exact absolute pixel values instead of being silently rounded down.
 - `sv.Detections.box_area` (and therefore `sv.Detections.area` for axis-aligned boxes) now computes integer-coordinate box areas in `float64`, preventing integer overflow for large boxes (e.g. an `int32` `50000 x 50000` box previously wrapped to a negative area).
 - Docs deployment for `latest` no longer fails with `error: version 'latest' already exists` when `latest` exists as an alias of a released version; the publish workflow now always deletes `latest` before redeploying it ([#2512](https://github.com/roboflow/supervision/issues/2512)).
+- Versioned documentation deploys now export the version being deployed to the docs build, so the outdated-version banner reaches readers of the `develop` tree and of archived release trees. The publish workflow never set `MIKE_DOCS_VERSION`, which gates the banner, so every tree was built without it. This applies to future builds; already-published archive trees keep their current markup.
+- The canonical backfill workflow now pushes the pre-rewrite `gh-pages` tip to a timestamped backup branch before committing over it, and reports rewritten canonicals whose target page does not exist under `latest/` — a canonical pointing at a removed page is ignored by search engines, so those pages keep competing with `/latest/`.
 - `sv.InferenceSlicer` now merges slice results in source order when `thread_workers > 1`, restoring the ordering guarantee its docstring documents. Results were previously collected in thread-completion order, so the row order of the returned `Detections` — and, for tied confidences, which overlapping box survived `with_nms`/`with_nmm` — varied between runs on identical input. Both the per-slice and `batch_size > 1` paths are affected ([#2517](https://github.com/roboflow/supervision/pull/2517)).
 
 ### 0.30.1 <small>Aug 24, 2026</small>


### PR DESCRIPTION
This pull request enhances the documentation workflows and their test coverage, focusing on improving the reliability and transparency of versioned documentation deployment. The main changes include exporting the deployed version to the documentation build (enabling the outdated-version banner), adding safety and reporting features to the canonical backfill workflow, and introducing new and refactored regression tests to ensure these mechanisms work as intended.

**Documentation workflow improvements:**

* The publish workflow now exports the deployed version as `MIKE_DOCS_VERSION` for every versioned documentation deploy step, ensuring the outdated-version banner appears on `develop`, `latest`, and archived release trees. Previously, the banner was missing from all builds because this environment variable was unset. [[1]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544R53-R69) [[2]](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544R98) [[3]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R22-R23)
* The canonical backfill workflow now pushes the pre-rewrite `gh-pages` tip to a timestamped backup branch before overwriting it, providing a recovery path if a rewrite goes wrong. It also reports any rewritten canonical links that point to missing pages under `latest/`, helping maintain search engine consistency. [[1]](diffhunk://#diff-d709116b867cc6905e684aebf1e20dc7004cbc58ce9c8b94d6f0b25616ad5e49R10-R12) [[2]](diffhunk://#diff-d709116b867cc6905e684aebf1e20dc7004cbc58ce9c8b94d6f0b25616ad5e49R62-R105) [[3]](diffhunk://#diff-d709116b867cc6905e684aebf1e20dc7004cbc58ce9c8b94d6f0b25616ad5e49R115-R122) [[4]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R22-R23)

**Test suite enhancements and refactoring:**

* Added and refactored regression tests to verify that deploy steps correctly export the deployed version, that the backup and reporting steps in the backfill workflow function as intended, and that any future deploy steps are checked for proper version wiring. This includes a new test file `test_docs_publish_workflow.py` and expanded tests in `test_docs_canonical_workflow.py`. [[1]](diffhunk://#diff-d87528defcaa5c581fae6f5538cddff210900cb12af8581db3c33cad4352b811R1-R69) [[2]](diffhunk://#diff-4e5b7aaf7f6f5e79abe6808390abcbbfbf11526146ec489733631fc62e8737c8L24-R38) [[3]](diffhunk://#diff-4e5b7aaf7f6f5e79abe6808390abcbbfbf11526146ec489733631fc62e8737c8R84-R144)
* Introduced a reusable `workflow_step` pytest fixture for robustly querying workflow steps by name in tests, making the test suite more maintainable and less brittle against workflow YAML changes. [[1]](diffhunk://#diff-934a72133a55e265928e8683ba08d512b4f144fcb2f32fab85a23f5fd0d59e77R76-R97) [[2]](diffhunk://#diff-4e5b7aaf7f6f5e79abe6808390abcbbfbf11526146ec489733631fc62e8737c8R3-R21)

**Documentation:**

* Updated the changelog to reflect the new workflow behaviors and their impact on documentation deployment and search engine visibility. [[1]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05L3-R3) [[2]](diffhunk://#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05R22-R23)