### PR TITLE
fix(csv): preserve metadata after leading empty frames

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ date_modified: 2026-09-03
 
 ### Fixed
 
+- `sv.CSVSink` now ignores empty detection batches, so leading empty video frames no longer omit metadata columns from later rows. The first non-empty batch determines the CSV header; runs containing only empty batches leave an empty file.
 - Versioned documentation banners now adjust MkDocs Material’s desktop sidebar inline layout and scroll height without shifting the mobile navigation drawer.
 - Versioned documentation builds now emit a valid `/latest/search/` SearchAction URL when Mike removes the trailing slash from `site_url`; docs CI renders the custom theme under Mike version contexts to protect the URL, version banners, and star JSON-LD. This source change applies to future builds; existing published archive trees require a separately approved backfill.
 - `sv.xcycwh_to_xyxy` no longer truncates coordinates for integer input arrays. Half of an odd width or height is fractional, and the previous implementation wrote those values into a copy of the integer input, silently rounding them; the converted boxes are now exact.

--- a/src/supervision/detection/tools/csv_sink.py
+++ b/src/supervision/detection/tools/csv_sink.py
@@ -202,6 +202,10 @@ class CSVSink:
         """
         Append detection data to the CSV file.
 
+        Empty batches are ignored. The first non-empty batch determines the
+        header, so leading empty frames cannot discard later metadata columns.
+        If every batch is empty, the output file remains empty.
+
         Args:
             detections: The detection data.
             custom_data: Custom data to include. Scalars, dictionaries, and
@@ -214,6 +218,9 @@ class CSVSink:
             raise Exception(
                 f"Cannot append to CSV: The file '{self.file_name}' is not open."
             )
+        if len(detections) == 0:
+            return
+
         field_names = CSVSink.parse_field_names(detections, custom_data)
         if not self.header_written:
             self.field_names = field_names

--- a/tests/detection/test_csv.py
+++ b/tests/detection/test_csv.py
@@ -1,5 +1,6 @@
 import csv
 import os
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -562,6 +563,71 @@ def test_csv_sink_broadcasts_ndarray_when_length_mismatches_detection_count(
     assert len(rows) == 2
     np.testing.assert_array_equal(rows[0]["embedding"], expected_value)
     np.testing.assert_array_equal(rows[1]["embedding"], expected_value)
+
+
+class TestCSVSinkEmptyFrames:
+    """Empty frames must not determine the columns of later detection rows."""
+
+    @pytest.mark.parametrize("empty_frame_count", [0, 1, 3])
+    @pytest.mark.parametrize("metadata_source", ["detections", "custom"])
+    def test_preserves_metadata_after_empty_frames(
+        self, tmp_path: Path, empty_frame_count: int, metadata_source: str
+    ) -> None:
+        """Export every populated row's metadata after leading or intervening gaps."""
+        path = tmp_path / "detections.csv"
+        detections = sv.Detections(
+            xyxy=np.array([[10, 20, 30, 40]]),
+            class_id=np.array([0]),
+        )
+        custom_data: dict[str, Any] = {"frame": empty_frame_count}
+        if metadata_source == "detections":
+            detections.data["class_name"] = ["person"]
+        else:
+            custom_data["class_name"] = ["person"]
+
+        with sv.CSVSink(str(path)) as sink:
+            for frame in range(empty_frame_count):
+                sink.append(sv.Detections.empty(), custom_data={"frame": frame})
+            sink.append(detections, custom_data=custom_data)
+            sink.append(sv.Detections.empty())
+            sink.append(detections, custom_data=custom_data)
+
+        with path.open(newline="") as file:
+            rows = list(csv.DictReader(file))
+        assert (
+            rows
+            == [
+                {
+                    "x_min": "10",
+                    "y_min": "20",
+                    "x_max": "30",
+                    "y_max": "40",
+                    "class_id": "0",
+                    "confidence": "",
+                    "tracker_id": "",
+                    "class_name": "person",
+                    "frame": str(empty_frame_count),
+                }
+            ]
+            * 2
+        )
+
+    def test_all_empty_frames_produce_an_empty_file(self, tmp_path: Path) -> None:
+        """An empty run must not invent a schema before any detections arrive."""
+        path = tmp_path / "detections.csv"
+
+        with sv.CSVSink(str(path)) as sink:
+            sink.append(sv.Detections.empty(), custom_data={"frame": 0})
+            sink.append(sv.Detections.empty(), custom_data={"frame": 1})
+
+        assert path.read_bytes() == b""
+
+    def test_unopened_sink_rejects_empty_frames(self, tmp_path: Path) -> None:
+        """Empty batches still require an open output file."""
+        sink = sv.CSVSink(str(tmp_path / "detections.csv"))
+
+        with pytest.raises(Exception, match="Cannot append to CSV"):
+            sink.append(sv.Detections.empty())
 
 
 class TestCSVSinkLifecycle:


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated the docstring and changelog
- [x] Added regression tests
- [x] All tests pass locally

</details>

### Description

When a video starts with an empty detection frame, `CSVSink.append()` writes a header before metadata such as `class_name` is available. Later populated frames emit a schema-mismatch warning and drop those values from the CSV.

Ignore empty batches so the first populated batch determines the header. For example, appending `Detections.empty()` followed by a person detection with `data={"class_name": ["person"]}` now preserves the `class_name` column and value. Caller-supplied custom metadata is covered too.

### Type of change

Bug fix with one observable change for empty output: an all-empty run now leaves an empty file instead of a header-only file. This is documented in the method and changelog. The existing open-file check still applies to empty batches.

### Testing

- Added eight cases covering leading and intervening empty frames, metadata from both supported sources, entirely empty output, and an unopened sink.
- On the original implementation, four metadata-preservation regressions fail; the all-empty output test also fails under the old behavior. The three control cases pass.
- `uv run pytest -q tests/detection/test_csv.py tests/detection/test_json.py`: **44 passed**.
- `uv run pytest --color=no --cov=supervision`: **3,665 passed, 20 skipped**. The unmodified baseline was **3,657 passed, 20 skipped**.
- `PATH="$HOME/.local/bin:$PATH" uv run pre-commit run --all-files`: **all checks passed**, including Ruff, mypy, and documentation formatting.
- A standalone reproduction writes a real temporary CSV and reads it back using `csv.DictReader`; no inference model, GPU, network, or external dataset is needed.

Local validation used Python 3.13.12 on macOS with Supervision's NumPy fallback backend. Implementation, review, and tests were performed with Codex assistance.

