### PR TITLE
fix: reject classification export filename collisions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,13 @@
 ---
 description: Full version history of the supervision Python library — release notes, breaking changes, new features, and deprecations for every version.
-date_modified: 2026-09-07
+date_modified: 2026-09-08
 ---
 
 # Changelog
 
 ### Unreleased <small>upcoming</small>
+
+- `sv.ClassificationDataset.as_folder_structure` now rejects images that would overwrite the same class-relative filename before writing any files. Identical basenames in different class directories remain supported.
 
 - `sv.Detections` now validates `xyxy` boxes for finite numeric coordinates (no NaN/inf), raising a clear `ValueError` for non-finite or unsupported-dtype values instead of failing silently downstream.
 

--- a/src/supervision/dataset/core.py
+++ b/src/supervision/dataset/core.py
@@ -1212,30 +1212,48 @@ class ClassificationDataset(BaseDataset):
         """
         Saves the dataset as a multi-class folder structure.
 
+        Images assigned to the same class must have unique basenames
+        (case-insensitive). Conflicts are rejected before any files are written.
+
         Args:
             root_directory_path: The path to the directory
                 where the dataset will be saved.
             show_progress: If True, display a progress bar during saving.
+
+        Raises:
+            ValueError: If two images would be saved to the same output path.
         """
-        os.makedirs(root_directory_path, exist_ok=True)
-
-        for class_name in self.classes:
-            os.makedirs(os.path.join(root_directory_path, class_name), exist_ok=True)
-
-        for image_save_path, image, annotation in tqdm(
-            self,
-            total=len(self),
-            desc="Saving classification images",
-            disable=not show_progress,
-        ):
-            image_name = Path(image_save_path).name
+        output_paths = {}
+        for image_path in self.image_paths:
+            annotation = self.annotations[image_path]
             class_id = (
                 annotation.class_id[0]
                 if annotation.confidence is None
                 else annotation.get_top_k(1)[0][0]
             )
-            class_name = self.classes[class_id]
-            image_save_path = os.path.join(root_directory_path, class_name, image_name)
+            output_paths[image_path] = os.path.join(
+                self.classes[class_id], Path(image_path).name
+            )
+
+        check_no_basename_collisions(
+            image_paths=self.image_paths,
+            key=lambda path: output_paths[path],
+            output_kind="classification image",
+        )
+        os.makedirs(root_directory_path, exist_ok=True)
+
+        for class_name in self.classes:
+            os.makedirs(os.path.join(root_directory_path, class_name), exist_ok=True)
+
+        for image_path, image, _ in tqdm(
+            self,
+            total=len(self),
+            desc="Saving classification images",
+            disable=not show_progress,
+        ):
+            image_save_path = os.path.join(
+                root_directory_path, output_paths[image_path]
+            )
             cv2.imwrite(image_save_path, image)
 
     @classmethod

--- a/src/supervision/dataset/utils.py
+++ b/src/supervision/dataset/utils.py
@@ -185,7 +185,7 @@ def check_no_basename_collisions(
             raise ValueError(
                 f"Cannot export dataset: image paths {first_path!r} and "
                 f"{image_path!r} both map to {output_kind} file {first_name!r}. "
-                "Ensure all image basenames are unique before exporting."
+                "Ensure all output paths are unique before exporting."
             )
         seen[case_key] = (output_name, image_path)
 

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -721,15 +721,22 @@ class TestClassificationDatasetExportCollisions:
     ) -> None:
         """Resolve the winning class and reject duplicate output paths up front."""
         paths = ["first/image.png", f"second/{second_name}"]
-        annotation = Classifications(class_id=np.array([0]))
+        annotations = {
+            p: Classifications(class_id=np.array([0])) for p in paths
+        }
         if with_confidence:
-            annotation = Classifications(
-                class_id=np.array([1, 0]), confidence=np.array([0.1, 0.9])
-            )
+            annotations = {
+                paths[0]: Classifications(
+                    class_id=np.array([1, 0]), confidence=np.array([0.1, 0.9])
+                ),
+                paths[1]: Classifications(
+                    class_id=np.array([0, 1]), confidence=np.array([0.9, 0.1])
+                ),
+            }
         dataset = ClassificationDataset(
             classes=["cats", "dogs"],
             images={p: np.zeros((4, 4, 3), dtype=np.uint8) for p in paths},
-            annotations={p: annotation for p in paths},
+            annotations=annotations,
         )
         output = tmp_path / "export"
 

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -721,9 +721,7 @@ class TestClassificationDatasetExportCollisions:
     ) -> None:
         """Resolve the winning class and reject duplicate output paths up front."""
         paths = ["first/image.png", f"second/{second_name}"]
-        annotations = {
-            p: Classifications(class_id=np.array([0])) for p in paths
-        }
+        annotations = {p: Classifications(class_id=np.array([0])) for p in paths}
         if with_confidence:
             annotations = {
                 paths[0]: Classifications(

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -738,9 +738,13 @@ class TestClassificationDatasetExportCollisions:
         )
         output = tmp_path / "export"
 
-        with pytest.raises(ValueError, match="Cannot export dataset"):
+        with pytest.raises(
+            ValueError, match="Ensure all output paths are unique before exporting"
+        ) as error:
             dataset.as_folder_structure(str(output))
 
+        assert paths[0] in str(error.value)
+        assert paths[1] in str(error.value)
         assert not output.exists()
 
     def test_allows_same_basename_in_different_classes(self, tmp_path: Path) -> None:

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -711,6 +711,56 @@ class TestDetectionDatasetSplit:
 # ---------------------------------------------------------------------------
 
 
+class TestClassificationDatasetExportCollisions:
+    """Folder exports must not overwrite images assigned to the same class."""
+
+    @pytest.mark.parametrize("second_name", ["image.png", "IMAGE.png"])
+    @pytest.mark.parametrize("with_confidence", [False, True])
+    def test_rejects_collisions_before_writing(
+        self, tmp_path: Path, second_name: str, with_confidence: bool
+    ) -> None:
+        """Resolve the winning class and reject duplicate output paths up front."""
+        paths = ["first/image.png", f"second/{second_name}"]
+        annotation = Classifications(class_id=np.array([0]))
+        if with_confidence:
+            annotation = Classifications(
+                class_id=np.array([1, 0]), confidence=np.array([0.1, 0.9])
+            )
+        dataset = ClassificationDataset(
+            classes=["cats", "dogs"],
+            images={p: np.zeros((4, 4, 3), dtype=np.uint8) for p in paths},
+            annotations={p: annotation for p in paths},
+        )
+        output = tmp_path / "export"
+
+        with pytest.raises(ValueError, match="Cannot export dataset"):
+            dataset.as_folder_structure(str(output))
+
+        assert not output.exists()
+
+    def test_allows_same_basename_in_different_classes(self, tmp_path: Path) -> None:
+        """Distinct class directories preserve both images with a shared basename."""
+        from supervision import _cv2
+
+        paths = ["first/image.png", "second/image.png"]
+        images = {
+            p: np.full((4, 4, 3), i * 255, dtype=np.uint8) for i, p in enumerate(paths)
+        }
+        dataset = ClassificationDataset(
+            classes=["cats", "dogs"],
+            images=images,
+            annotations={
+                p: Classifications(class_id=np.array([i])) for i, p in enumerate(paths)
+            },
+        )
+
+        dataset.as_folder_structure(str(tmp_path))
+
+        for class_name, path in zip(dataset.classes, paths):
+            saved = _cv2.imread(str(tmp_path / class_name / "image.png"))
+            np.testing.assert_array_equal(saved, images[path])
+
+
 class TestClassificationDatasetFolderRoundTrip:
     """from_folder_structure -> as_folder_structure -> reload reproduces the dataset."""
 


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated documentation with the new exception behavior
- [x] Added docs entry for autogeneration (not applicable: no new public symbols)
- [x] Added/updated tests
- [x] All tests pass locally

</details>

## Description

Classification folder exports now reject two images that would overwrite the same file, before creating directories or writing images. Identical basenames in different class directories remain supported.

## Type of Change

- Bug fix

## Motivation and Context

Images such as `first/image.png` and `second/image.png`, both assigned to `cats`, previously produced only one `cats/image.png`. This silently discarded an image during export. The existing detection export collision guard provides the same protection needed here.

## Changes Made

- Check the selected class and basename together, including case-insensitive collisions.
- Preserve highest-confidence class selection and lazy image loading.
- Document the `ValueError` in the method and changelog.

## Testing

- [x] Tested locally: `pytest --cov=supervision --cov-report=term-missing tests` — 3700 passed, 20 skipped on Python 3.13.
- [x] Added four regression cases that fail before the fix, plus a real write/read check preserving both images when their classes differ.
- [x] Final dataset suite: `pytest tests/dataset/test_core.py -q` — 49 passed.
- [x] All 21 pre-commit hooks passed with their pinned versions and arguments. Native Windows required a private config using Python 3.11 for the default hook interpreter instead of 3.10; repository configuration is unchanged.

## Additional Notes

Installed the committed dependency lock with `uv sync --frozen --extra metrics`: `--locked` reports that the existing lock needs updating. No dependency files changed.

No service deployment or new telemetry is involved; the regression tests verify rejection before any export writes.

Agent-assisted: Codex prepared the patch and ran the local checks listed above.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
