### PR TITLE
ci(pre-commit): add docformatter hook with tomli dependency

### DIFF
--- a/.github/_tests/conftest.py
+++ b/.github/_tests/conftest.py
@@ -1,4 +1,5 @@
-"""Shared fixtures for the tests covering ``.github`` scripts and workflows.
+"""
+Shared fixtures for the tests covering ``.github`` scripts and workflows.
 
 The scripts under ``.github/scripts`` are standalone files rather than an installed
 package, so every test that exercises one has to load it from disk. Centralizing that
@@ -27,11 +28,12 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 @pytest.fixture(autouse=True)
 def _jupyter_platform_dirs(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Opt into Jupyter's platform directories for every test in this directory.
+    """
+    Opt into Jupyter's platform directories for every test in this directory.
 
-    Loading the MkDocs config pulls in Jupyter, which warns about its legacy paths.
-    The suite promotes ``DeprecationWarning`` to an error, so without this the docs
-    tests fail on a warning that has nothing to do with what they assert.
+    Loading the MkDocs config pulls in Jupyter, which warns about its legacy paths. The
+    suite promotes ``DeprecationWarning`` to an error, so without this the docs tests
+    fail on a warning that has nothing to do with what they assert.
     """
     monkeypatch.setenv("JUPYTER_PLATFORM_DIRS", "1")
 
@@ -50,7 +52,8 @@ def workflows_dir() -> Path:
 
 @pytest.fixture
 def load_script() -> Callable[[str], ModuleType]:
-    """Return a loader for a ``.github/scripts`` module, given its stem.
+    """
+    Return a loader for a ``.github/scripts`` module, given its stem.
 
     The loaded module never runs its CLI: the scripts guard that behind
     ``if __name__ == "__main__"``, and importing under the stem name leaves the guard
@@ -79,10 +82,11 @@ def updater(load_script: Callable[[str], ModuleType]) -> ModuleType:
 def workflow_step(
     workflows_dir: Path,
 ) -> Callable[[str, str, str], dict[str, Any]]:
-    """Return a lookup for one workflow step, addressed by job id and step name.
+    """
+    Return a lookup for one workflow step, addressed by job id and step name.
 
-    Steps are looked up by name rather than list position so that inserting a step
-    into a workflow cannot silently repoint an existing test at a different step.
+    Steps are looked up by name rather than list position so that inserting a step into
+    a workflow cannot silently repoint an existing test at a different step.
     """
 
     def lookup(workflow_file: str, job: str, step_name: str) -> dict[str, Any]:

--- a/.github/_tests/conftest.py
+++ b/.github/_tests/conftest.py
@@ -1,5 +1,4 @@
-"""
-Shared fixtures for the tests covering ``.github`` scripts and workflows.
+"""Shared fixtures for the tests covering ``.github`` scripts and workflows.
 
 The scripts under ``.github/scripts`` are standalone files rather than an installed
 package, so every test that exercises one has to load it from disk. Centralizing that
@@ -28,8 +27,7 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 @pytest.fixture(autouse=True)
 def _jupyter_platform_dirs(monkeypatch: pytest.MonkeyPatch) -> None:
-    """
-    Opt into Jupyter's platform directories for every test in this directory.
+    """Opt into Jupyter's platform directories for every test in this directory.
 
     Loading the MkDocs config pulls in Jupyter, which warns about its legacy paths. The
     suite promotes ``DeprecationWarning`` to an error, so without this the docs tests
@@ -52,8 +50,7 @@ def workflows_dir() -> Path:
 
 @pytest.fixture
 def load_script() -> Callable[[str], ModuleType]:
-    """
-    Return a loader for a ``.github/scripts`` module, given its stem.
+    """Return a loader for a ``.github/scripts`` module, given its stem.
 
     The loaded module never runs its CLI: the scripts guard that behind
     ``if __name__ == "__main__"``, and importing under the stem name leaves the guard
@@ -82,8 +79,7 @@ def updater(load_script: Callable[[str], ModuleType]) -> ModuleType:
 def workflow_step(
     workflows_dir: Path,
 ) -> Callable[[str, str, str], dict[str, Any]]:
-    """
-    Return a lookup for one workflow step, addressed by job id and step name.
+    """Return a lookup for one workflow step, addressed by job id and step name.
 
     Steps are looked up by name rather than list position so that inserting a step into
     a workflow cannot silently repoint an existing test at a different step.

--- a/.github/_tests/test_ci_helpers.py
+++ b/.github/_tests/test_ci_helpers.py
@@ -85,8 +85,7 @@ class TestValidateManifest:
     """Guard on the wheel smoke-test manifest."""
 
     def test_accepts_the_checked_in_manifest(self, repo_root: Path) -> None:
-        """
-        The production fallback contract contains every required check exactly once.
+        """The production fallback contract contains every required check exactly once.
 
         This pins the happy path alongside the invalid-manifest guard.
         """

--- a/.github/_tests/test_ci_helpers.py
+++ b/.github/_tests/test_ci_helpers.py
@@ -85,7 +85,8 @@ class TestValidateManifest:
     """Guard on the wheel smoke-test manifest."""
 
     def test_accepts_the_checked_in_manifest(self, repo_root: Path) -> None:
-        """The production fallback contract contains every required check exactly once.
+        """
+        The production fallback contract contains every required check exactly once.
 
         This pins the happy path alongside the invalid-manifest guard.
         """

--- a/.github/_tests/test_compute_is_latest_release.py
+++ b/.github/_tests/test_compute_is_latest_release.py
@@ -60,8 +60,7 @@ class TestIsLatestRelease:
     def test_includes_its_own_tag_among_the_candidates(
         self, compute: ModuleType
     ) -> None:
-        """
-        The release's own (already-pushed) tag does not make it look superseded.
+        """The release's own (already-pushed) tag does not make it look superseded.
 
         `git tag --list` in CI already includes the tag that triggered the release
         event, so the comparison must treat `release_tag` appearing in `existing_tags`

--- a/.github/_tests/test_compute_is_latest_release.py
+++ b/.github/_tests/test_compute_is_latest_release.py
@@ -60,10 +60,11 @@ class TestIsLatestRelease:
     def test_includes_its_own_tag_among_the_candidates(
         self, compute: ModuleType
     ) -> None:
-        """The release's own (already-pushed) tag does not make it look superseded.
+        """
+        The release's own (already-pushed) tag does not make it look superseded.
 
         `git tag --list` in CI already includes the tag that triggered the release
-        event, so the comparison must treat `release_tag` appearing in
-        `existing_tags` as a tie, not as evidence something newer exists.
+        event, so the comparison must treat `release_tag` appearing in `existing_tags`
+        as a tie, not as evidence something newer exists.
         """
         assert compute.is_latest_release("1.2.0", ["v1.0.0", "v1.2.0"]) is True

--- a/.github/_tests/test_docs_backfill_workflow.py
+++ b/.github/_tests/test_docs_backfill_workflow.py
@@ -250,11 +250,12 @@ def test_inject_banner_skips_latest_and_already_patched_pages(
 def test_inject_banner_replaces_stale_wording_on_rerun(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """A later wording/style edit reaches a page an earlier run already patched.
+    """
+    A later wording/style edit reaches a page an earlier run already patched.
 
-    Iterating on the banner text after the first backfill dispatch is expected;
-    a second dispatch must overwrite the stale copy, not leave it stuck forever
-    behind the marker that made the page look "already handled".
+    Iterating on the banner text after the first backfill dispatch is expected; a second
+    dispatch must overwrite the stale copy, not leave it stuck forever behind the marker
+    that made the page look "already handled".
     """
     module = load_script("inject_outdated_banner")
     page = tmp_path / "0.10.0" / "index.html"
@@ -277,11 +278,12 @@ def test_inject_banner_replaces_stale_wording_on_rerun(
 def test_inject_banner_leaves_a_genuine_material_build_untouched(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """Never rewrite a div holding real Material output instead of our injection.
+    """
+    Never rewrite a div holding real Material output instead of our injection.
 
     A future rebuild of an archived version would render this div for real
-    (config.extra.version now set), with no ``sv:outdated-banner`` marker; that
-    content is unrelated to our injection and must survive untouched.
+    (config.extra.version now set), with no ``sv:outdated-banner`` marker; that content
+    is unrelated to our injection and must survive untouched.
     """
     module = load_script("inject_outdated_banner")
     real_markup = (
@@ -302,11 +304,12 @@ def test_inject_banner_leaves_a_genuine_material_build_untouched(
 def test_patch_stylesheets_appends_banner_css_to_an_archived_version(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """Append the purple/centered/sticky rules to a frozen archived extra.css.
+    """
+    Append the purple/centered/sticky rules to a frozen archived extra.css.
 
-    The archived stylesheet predates the rules that give the banner its project
-    colors — Material's stock yellow, left-aligned, non-sticky banner is what a
-    reader sees without them.
+    The archived stylesheet predates the rules that give the banner its project colors —
+    Material's stock yellow, left-aligned, non-sticky banner is what a reader sees
+    without them.
     """
     module = load_script("inject_outdated_banner")
     css_file = tmp_path / "0.10.0" / "stylesheets" / "extra.css"
@@ -327,10 +330,11 @@ def test_patch_stylesheets_appends_banner_css_to_an_archived_version(
 def test_patch_stylesheets_skips_develop_and_versions_without_the_file(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """Leave develop's own current CSS alone, and skip a version with no stylesheet.
+    """
+    Leave develop's own current CSS alone, and skip a version with no stylesheet.
 
-    develop rebuilds on every push and already carries the current rules
-    natively; only a frozen archived tree needs the backfill.
+    develop rebuilds on every push and already carries the current rules natively; only
+    a frozen archived tree needs the backfill.
     """
     module = load_script("inject_outdated_banner")
     develop_css = tmp_path / "develop" / "stylesheets" / "extra.css"
@@ -368,10 +372,11 @@ def test_patch_stylesheets_replaces_stale_css_on_rerun(
 def test_patch_scripts_copies_and_references_the_offset_script_at_page_root(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """A version-root page gets version-banner.js copied in and referenced directly.
+    """
+    A version-root page gets version-banner.js copied in and referenced directly.
 
-    Without this script the banner still sticks (pure CSS alone), but the header
-    can briefly overlap it before a reader scrolls, since nothing else offsets it.
+    Without this script the banner still sticks (pure CSS alone), but the header can
+    briefly overlap it before a reader scrolls, since nothing else offsets it.
     """
     module = load_script("inject_outdated_banner")
     page = tmp_path / "0.10.0" / "index.html"
@@ -467,10 +472,11 @@ def test_newest_version_dir_orders_releases_numerically(
 def test_inject_banner_skips_the_current_release(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """Never warn a reader of the newest release that they are reading old docs.
+    """
+    Never warn a reader of the newest release that they are reading old docs.
 
-    The highest-numbered version tree holds the same documentation /latest/ serves,
-    so the banner, its styling, and its offset script all have nothing to present.
+    The highest-numbered version tree holds the same documentation /latest/ serves, so
+    the banner, its styling, and its offset script all have nothing to present.
     """
     module = load_script("inject_outdated_banner")
     page = tmp_path / CURRENT_RELEASE / "index.html"
@@ -577,15 +583,16 @@ def test_backfill_only_commits_on_a_real_dispatch(workflow_step: StepLookup) -> 
 
 
 def _write_genuinely_built_release_tree(root: Path, version: str) -> tuple[Path, Path]:
-    """Simulate a real, post-403f35a1 release tree right after a newer one demotes it.
+    """
+    Simulate a real, post-403f35a1 release tree right after a newer one demotes it.
 
-    Unlike the pre-infra fixtures above, this tree's stylesheet and script already
-    carry the genuine, unmarked banner rules — `mkdocs.yml`'s `extra_css` and
+    Unlike the pre-infra fixtures above, this tree's stylesheet and script already carry
+    the genuine, unmarked banner rules — `mkdocs.yml`'s `extra_css` and
     `extra_javascript` are unconditional, so every build gets them regardless of
-    `doc_version`. Only the banner div is empty, because it was built while this
-    version was still `is_latest_release`. A newer sibling directory is created
-    alongside it so `version` is no longer the highest — otherwise the module would
-    treat it as the current release and skip it outright, defeating the fixture.
+    `doc_version`. Only the banner div is empty, because it was built while this version
+    was still `is_latest_release`. A newer sibling directory is created alongside it so
+    `version` is no longer the highest — otherwise the module would treat it as the
+    current release and skip it outright, defeating the fixture.
     """
     version_dir = root / version
     page = version_dir / "index.html"
@@ -613,10 +620,11 @@ def test_main_banner_only_patches_text_without_touching_genuine_css(
     load_script: Callable[[str], ModuleType],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """`--banner-only` fills the banner text but leaves already-correct assets alone.
+    """
+    `--banner-only` fills the banner text but leaves already-correct assets alone.
 
-    This is what `publish-docs.yml` runs against the just-demoted release tree: its
-    CSS and JS are already genuine, so only the div content needs backfilling.
+    This is what `publish-docs.yml` runs against the just-demoted release tree: its CSS
+    and JS are already genuine, so only the div content needs backfilling.
     """
     module = load_script("inject_outdated_banner")
     page, css_file = _write_genuinely_built_release_tree(tmp_path, "0.30.2")
@@ -639,11 +647,12 @@ def test_main_without_banner_only_duplicates_genuine_css(
     load_script: Callable[[str], ModuleType],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Document the exact risk `--banner-only` exists to avoid.
+    """
+    Document the exact risk `--banner-only` exists to avoid.
 
-    `patch_stylesheets` only checks for its own marker, not for content already
-    matching it, so running the default (marker-driven) path against a tree that
-    already carries the genuine banner CSS appends a redundant second copy.
+    `patch_stylesheets` only checks for its own marker, not for content already matching
+    it, so running the default (marker-driven) path against a tree that already carries
+    the genuine banner CSS appends a redundant second copy.
     """
     module = load_script("inject_outdated_banner")
     _page, css_file = _write_genuinely_built_release_tree(tmp_path, "0.30.2")

--- a/.github/_tests/test_docs_backfill_workflow.py
+++ b/.github/_tests/test_docs_backfill_workflow.py
@@ -250,8 +250,7 @@ def test_inject_banner_skips_latest_and_already_patched_pages(
 def test_inject_banner_replaces_stale_wording_on_rerun(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """
-    A later wording/style edit reaches a page an earlier run already patched.
+    """A later wording/style edit reaches a page an earlier run already patched.
 
     Iterating on the banner text after the first backfill dispatch is expected; a second
     dispatch must overwrite the stale copy, not leave it stuck forever behind the marker
@@ -278,8 +277,7 @@ def test_inject_banner_replaces_stale_wording_on_rerun(
 def test_inject_banner_leaves_a_genuine_material_build_untouched(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """
-    Never rewrite a div holding real Material output instead of our injection.
+    """Never rewrite a div holding real Material output instead of our injection.
 
     A future rebuild of an archived version would render this div for real
     (config.extra.version now set), with no ``sv:outdated-banner`` marker; that content
@@ -304,8 +302,7 @@ def test_inject_banner_leaves_a_genuine_material_build_untouched(
 def test_patch_stylesheets_appends_banner_css_to_an_archived_version(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """
-    Append the purple/centered/sticky rules to a frozen archived extra.css.
+    """Append the purple/centered/sticky rules to a frozen archived extra.css.
 
     The archived stylesheet predates the rules that give the banner its project colors —
     Material's stock yellow, left-aligned, non-sticky banner is what a reader sees
@@ -330,8 +327,7 @@ def test_patch_stylesheets_appends_banner_css_to_an_archived_version(
 def test_patch_stylesheets_skips_develop_and_versions_without_the_file(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """
-    Leave develop's own current CSS alone, and skip a version with no stylesheet.
+    """Leave develop's own current CSS alone, and skip a version with no stylesheet.
 
     develop rebuilds on every push and already carries the current rules natively; only
     a frozen archived tree needs the backfill.
@@ -372,8 +368,7 @@ def test_patch_stylesheets_replaces_stale_css_on_rerun(
 def test_patch_scripts_copies_and_references_the_offset_script_at_page_root(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """
-    A version-root page gets version-banner.js copied in and referenced directly.
+    """A version-root page gets version-banner.js copied in and referenced directly.
 
     Without this script the banner still sticks (pure CSS alone), but the header can
     briefly overlap it before a reader scrolls, since nothing else offsets it.
@@ -472,8 +467,7 @@ def test_newest_version_dir_orders_releases_numerically(
 def test_inject_banner_skips_the_current_release(
     tmp_path: Path, load_script: Callable[[str], ModuleType]
 ) -> None:
-    """
-    Never warn a reader of the newest release that they are reading old docs.
+    """Never warn a reader of the newest release that they are reading old docs.
 
     The highest-numbered version tree holds the same documentation /latest/ serves, so
     the banner, its styling, and its offset script all have nothing to present.
@@ -583,8 +577,7 @@ def test_backfill_only_commits_on_a_real_dispatch(workflow_step: StepLookup) -> 
 
 
 def _write_genuinely_built_release_tree(root: Path, version: str) -> tuple[Path, Path]:
-    """
-    Simulate a real, post-403f35a1 release tree right after a newer one demotes it.
+    """Simulate a real, post-403f35a1 release tree right after a newer one demotes it.
 
     Unlike the pre-infra fixtures above, this tree's stylesheet and script already carry
     the genuine, unmarked banner rules — `mkdocs.yml`'s `extra_css` and
@@ -620,8 +613,7 @@ def test_main_banner_only_patches_text_without_touching_genuine_css(
     load_script: Callable[[str], ModuleType],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    `--banner-only` fills the banner text but leaves already-correct assets alone.
+    """`--banner-only` fills the banner text but leaves already-correct assets alone.
 
     This is what `publish-docs.yml` runs against the just-demoted release tree: its CSS
     and JS are already genuine, so only the div content needs backfilling.
@@ -647,8 +639,7 @@ def test_main_without_banner_only_duplicates_genuine_css(
     load_script: Callable[[str], ModuleType],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    Document the exact risk `--banner-only` exists to avoid.
+    """Document the exact risk `--banner-only` exists to avoid.
 
     `patch_stylesheets` only checks for its own marker, not for content already matching
     it, so running the default (marker-driven) path against a tree that already carries

--- a/.github/_tests/test_docs_publish_workflow.py
+++ b/.github/_tests/test_docs_publish_workflow.py
@@ -52,12 +52,13 @@ def test_deploy_steps_export_the_version_they_deploy(
 def test_release_deploy_step_forwards_is_latest_release(
     workflow_step: StepLookup,
 ) -> None:
-    """The release deploy step passes through the is-latest-release verdict.
+    """
+    The release deploy step passes through the is-latest-release verdict.
 
-    A release tag's own docs tree must know whether it is the newest stable
-    release to suppress its own outdated-version banner (see
-    `docs/theme/main.html`'s `is_latest_release` check) — this wiring is what a
-    future refactor could silently drop.
+    A release tag's own docs tree must know whether it is the newest stable release to
+    suppress its own outdated-version banner (see `docs/theme/main.html`'s
+    `is_latest_release` check) — this wiring is what a future refactor could silently
+    drop.
     """
     step = workflow_step(
         PUBLISH_WORKFLOW, PUBLISH_JOB, "\N{ROCKET} Deploy Release Docs"
@@ -72,11 +73,12 @@ def test_release_deploy_step_forwards_is_latest_release(
 def test_release_metadata_step_computes_is_latest_release(
     workflow_step: StepLookup,
 ) -> None:
-    """The metadata step delegates the version comparison to the shared script.
+    """
+    The metadata step delegates the version comparison to the shared script.
 
     Keeps the workflow YAML and the comparison logic from drifting apart, since
-    `.github/_tests/test_compute_is_latest_release.py` covers the comparison
-    itself and this test only covers that the workflow actually calls it.
+    `.github/_tests/test_compute_is_latest_release.py` covers the comparison itself and
+    this test only covers that the workflow actually calls it.
     """
     step = workflow_step(
         PUBLISH_WORKFLOW,
@@ -97,11 +99,12 @@ ARCHIVE_STEP = (
 def test_archive_step_only_runs_when_this_release_is_the_new_latest(
     workflow_step: StepLookup,
 ) -> None:
-    """A backport release for an older line must not touch the real /latest/ tree.
+    """
+    A backport release for an older line must not touch the real /latest/ tree.
 
-    Only promoting a release to the newest actually demotes something — a patch
-    release for an older minor line leaves the current /latest/ untouched, so
-    nothing needs archiving.
+    Only promoting a release to the newest actually demotes something — a patch release
+    for an older minor line leaves the current /latest/ untouched, so nothing needs
+    archiving.
     """
     step = workflow_step(PUBLISH_WORKFLOW, PUBLISH_JOB, ARCHIVE_STEP)
 
@@ -115,7 +118,8 @@ def test_archive_step_only_runs_when_this_release_is_the_new_latest(
 def test_archive_step_runs_the_banner_script_in_banner_only_mode(
     workflow_step: StepLookup,
 ) -> None:
-    """The demoted tree's own CSS/JS are already genuine — only its text is stale.
+    """
+    The demoted tree's own CSS/JS are already genuine — only its text is stale.
 
     `--banner-only` skips `patch_stylesheets`/`patch_scripts`, which would
     otherwise append a redundant second copy of banner rules the tree already

--- a/.github/_tests/test_docs_publish_workflow.py
+++ b/.github/_tests/test_docs_publish_workflow.py
@@ -52,8 +52,7 @@ def test_deploy_steps_export_the_version_they_deploy(
 def test_release_deploy_step_forwards_is_latest_release(
     workflow_step: StepLookup,
 ) -> None:
-    """
-    The release deploy step passes through the is-latest-release verdict.
+    """The release deploy step passes through the is-latest-release verdict.
 
     A release tag's own docs tree must know whether it is the newest stable release to
     suppress its own outdated-version banner (see `docs/theme/main.html`'s
@@ -73,8 +72,7 @@ def test_release_deploy_step_forwards_is_latest_release(
 def test_release_metadata_step_computes_is_latest_release(
     workflow_step: StepLookup,
 ) -> None:
-    """
-    The metadata step delegates the version comparison to the shared script.
+    """The metadata step delegates the version comparison to the shared script.
 
     Keeps the workflow YAML and the comparison logic from drifting apart, since
     `.github/_tests/test_compute_is_latest_release.py` covers the comparison itself and
@@ -99,8 +97,7 @@ ARCHIVE_STEP = (
 def test_archive_step_only_runs_when_this_release_is_the_new_latest(
     workflow_step: StepLookup,
 ) -> None:
-    """
-    A backport release for an older line must not touch the real /latest/ tree.
+    """A backport release for an older line must not touch the real /latest/ tree.
 
     Only promoting a release to the newest actually demotes something — a patch release
     for an older minor line leaves the current /latest/ untouched, so nothing needs
@@ -118,8 +115,7 @@ def test_archive_step_only_runs_when_this_release_is_the_new_latest(
 def test_archive_step_runs_the_banner_script_in_banner_only_mode(
     workflow_step: StepLookup,
 ) -> None:
-    """
-    The demoted tree's own CSS/JS are already genuine — only its text is stale.
+    """The demoted tree's own CSS/JS are already genuine — only its text is stale.
 
     `--banner-only` skips `patch_stylesheets`/`patch_scripts`, which would
     otherwise append a redundant second copy of banner rules the tree already

--- a/.github/_tests/test_docs_theme.py
+++ b/.github/_tests/test_docs_theme.py
@@ -86,7 +86,8 @@ def test_version_banner_matches_mike_version(
     is_latest_release: bool,
     expected_text: str | None,
 ) -> None:
-    """Render warnings only for development and archived documentation.
+    """
+    Render warnings only for development and archived documentation.
 
     The `current-release` case guards the bug where a release's own docs tree
     warned its own readers away from itself: `mike deploy <tag>` always sets

--- a/.github/_tests/test_docs_theme.py
+++ b/.github/_tests/test_docs_theme.py
@@ -86,8 +86,7 @@ def test_version_banner_matches_mike_version(
     is_latest_release: bool,
     expected_text: str | None,
 ) -> None:
-    """
-    Render warnings only for development and archived documentation.
+    """Render warnings only for development and archived documentation.
 
     The `current-release` case guards the bug where a release's own docs tree
     warned its own readers away from itself: `mike deploy <tag>` always sets

--- a/.github/scripts/augment_links.py
+++ b/.github/scripts/augment_links.py
@@ -14,8 +14,7 @@ def get_repo_root() -> str:
 
 
 def augment_links_in_file(file_path: str, branch: str = "main") -> None:
-    """
-    Augment relative links in a markdown file to GitHub URLs.
+    """Augment relative links in a markdown file to GitHub URLs.
 
     Args:
         file_path: Path to the markdown file.

--- a/.github/scripts/augment_links.py
+++ b/.github/scripts/augment_links.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""
-Script to augment relative links in markdown files to GitHub URLs.
-"""
+"""Script to augment relative links in markdown files to GitHub URLs."""
 
 import argparse
 import os

--- a/.github/scripts/compute_is_latest_release.py
+++ b/.github/scripts/compute_is_latest_release.py
@@ -1,5 +1,4 @@
-"""
-Decide whether a release tag is the newest published stable version.
+"""Decide whether a release tag is the newest published stable version.
 
 Purpose:
     Gate the outdated-version banner (``docs/theme/main.html``) so a release's own
@@ -38,8 +37,7 @@ _RC_SUFFIX_RE = re.compile(r"(^|[._-])rc\d+$|\drc\d+$")
 
 
 def _normalize_tag(tag: str) -> str:
-    """
-    Strip the release workflow's `v` prefix and `.postN` suffix from a git tag.
+    """Strip the release workflow's `v` prefix and `.postN` suffix from a git tag.
 
     Mirrors the bash normalization publish-docs.yml already applies to ``release_tag``,
     so a raw tag from ``git tag --list`` compares on equal footing.
@@ -48,8 +46,7 @@ def _normalize_tag(tag: str) -> str:
 
 
 def _parse_stable_version(tag: str) -> Version | None:
-    """
-    Return the parsed version for a stable release tag, or None to skip it.
+    """Return the parsed version for a stable release tag, or None to skip it.
 
     Skips release-candidate tags and anything that does not parse as a version — the
     same two exclusions publish-docs.yml applies to ``release_tag`` itself.
@@ -64,8 +61,7 @@ def _parse_stable_version(tag: str) -> Version | None:
 
 
 def is_latest_release(release_tag: str, existing_tags: Iterable[str]) -> bool:
-    """
-    Return whether `release_tag` is the newest stable version among `existing_tags`.
+    """Return whether `release_tag` is the newest stable version among `existing_tags`.
 
     Examples:
         >>> is_latest_release("1.2.0", ["v1.0.0", "v1.2.0", "v1.1.0rc1"])

--- a/.github/scripts/compute_is_latest_release.py
+++ b/.github/scripts/compute_is_latest_release.py
@@ -1,4 +1,5 @@
-"""Decide whether a release tag is the newest published stable version.
+"""
+Decide whether a release tag is the newest published stable version.
 
 Purpose:
     Gate the outdated-version banner (``docs/theme/main.html``) so a release's own
@@ -37,19 +38,21 @@ _RC_SUFFIX_RE = re.compile(r"(^|[._-])rc\d+$|\drc\d+$")
 
 
 def _normalize_tag(tag: str) -> str:
-    """Strip the release workflow's `v` prefix and `.postN` suffix from a git tag.
+    """
+    Strip the release workflow's `v` prefix and `.postN` suffix from a git tag.
 
-    Mirrors the bash normalization publish-docs.yml already applies to
-    ``release_tag``, so a raw tag from ``git tag --list`` compares on equal footing.
+    Mirrors the bash normalization publish-docs.yml already applies to ``release_tag``,
+    so a raw tag from ``git tag --list`` compares on equal footing.
     """
     return re.sub(r"\.post\d+$", "", tag.removeprefix("v"))
 
 
 def _parse_stable_version(tag: str) -> Version | None:
-    """Return the parsed version for a stable release tag, or None to skip it.
+    """
+    Return the parsed version for a stable release tag, or None to skip it.
 
-    Skips release-candidate tags and anything that does not parse as a version —
-    the same two exclusions publish-docs.yml applies to ``release_tag`` itself.
+    Skips release-candidate tags and anything that does not parse as a version — the
+    same two exclusions publish-docs.yml applies to ``release_tag`` itself.
     """
     normalized = _normalize_tag(tag)
     if _RC_SUFFIX_RE.search(normalized.lower()):
@@ -61,7 +64,8 @@ def _parse_stable_version(tag: str) -> Version | None:
 
 
 def is_latest_release(release_tag: str, existing_tags: Iterable[str]) -> bool:
-    """Return whether `release_tag` is the newest stable version among `existing_tags`.
+    """
+    Return whether `release_tag` is the newest stable version among `existing_tags`.
 
     Examples:
         >>> is_latest_release("1.2.0", ["v1.0.0", "v1.2.0", "v1.1.0rc1"])

--- a/.github/scripts/inject_outdated_banner.py
+++ b/.github/scripts/inject_outdated_banner.py
@@ -1,4 +1,5 @@
-"""Backfill the outdated-version banner into already-published gh-pages trees.
+"""
+Backfill the outdated-version banner into already-published gh-pages trees.
 
 Purpose:
     Populate the empty ``data-md-component="outdated"`` banner div that archived
@@ -148,7 +149,8 @@ BANNER_CSS = """.md-banner,
 
 
 def _version_key(name: str) -> Version:
-    """Order a version directory name by PEP 440: `0.9.0` sorts below `0.10.0`.
+    """
+    Order a version directory name by PEP 440: `0.9.0` sorts below `0.10.0`.
 
     A pre-release directory sorts below the release it precedes, so `0.31.0` wins
     over `0.31.0rc1` should both trees ever sit on the branch at once. A name PEP 440
@@ -174,7 +176,8 @@ def _newest_version_dir(root: Path) -> Path | None:
 
 
 def _archived_version_dirs(root: Path) -> list[Path]:
-    """Return the superseded numeric version directories under `root`.
+    """
+    Return the superseded numeric version directories under `root`.
 
     The highest-numbered directory is excluded: it holds the current release, which
     is not outdated, so it gets neither the banner nor the styling and script that
@@ -193,7 +196,8 @@ def _version_dirs(root: Path) -> list[Path]:
 
 
 def patch_tree(root: Path) -> list[Path]:
-    """Inject banner markup into every unpatched page under `root`.
+    """
+    Inject banner markup into every unpatched page under `root`.
 
     Returns the HTML files that were changed, for the caller to report against.
     """
@@ -213,7 +217,8 @@ def patch_tree(root: Path) -> list[Path]:
 
 
 def patch_stylesheets(root: Path) -> list[Path]:
-    """Give the banner its purple/centered/sticky styling in each archived extra.css.
+    """
+    Give the banner its purple/centered/sticky styling in each archived extra.css.
 
     Returns the stylesheets that were changed, for the caller to report against.
     """
@@ -357,11 +362,12 @@ def _relative_prefix(html_file: Path, version_dir: Path) -> str:
 
 
 def patch_scripts(root: Path) -> list[Path]:
-    """Copy version-banner.js into each archived version, referenced from every page.
+    """
+    Copy version-banner.js into each archived version, referenced from every page.
 
-    Without it the banner still sticks (pure CSS), but the header can briefly
-    overlap it before a reader scrolls, since nothing offsets the header below it.
-    Returns the files that were changed, for the caller to report against.
+    Without it the banner still sticks (pure CSS), but the header can briefly overlap it
+    before a reader scrolls, since nothing offsets the header below it. Returns the
+    files that were changed, for the caller to report against.
     """
     changed: list[Path] = []
     for version_dir in _archived_version_dirs(root):
@@ -397,12 +403,13 @@ INJECTED_BANNER_RE = re.compile(
 
 
 def unpatch_newest_version(root: Path) -> list[Path]:
-    """Strip an injected banner from the current release tree under `root`.
+    """
+    Strip an injected banner from the current release tree under `root`.
 
-    A run made before the newest release was excluded left an "older version"
-    banner on the docs `latest` serves. The div is restored to the whitespace-only
-    interior a build emits, so the next release — which demotes this tree to
-    archived — patches it again through the normal path.
+    A run made before the newest release was excluded left an "older version" banner on
+    the docs `latest` serves. The div is restored to the whitespace-only interior a
+    build emits, so the next release — which demotes this tree to archived — patches it
+    again through the normal path.
     """
     newest = _newest_version_dir(root)
     if newest is None:
@@ -422,11 +429,12 @@ def unpatch_newest_version(root: Path) -> list[Path]:
 
 
 def main() -> int:
-    """Entry point: patch the tree at `root` and report how many files changed.
+    """
+    Entry point: patch the tree at `root` and report how many files changed.
 
-    `--banner-only` (any position in argv) skips `patch_stylesheets`/`patch_scripts`
-    — see the module docstring's Usage section for why a genuinely-built release
-    tree needs that.
+    `--banner-only` (any position in argv) skips `patch_stylesheets`/`patch_scripts` —
+    see the module docstring's Usage section for why a genuinely-built release tree
+    needs that.
     """
     args = sys.argv[1:]
     banner_only = "--banner-only" in args

--- a/.github/scripts/inject_outdated_banner.py
+++ b/.github/scripts/inject_outdated_banner.py
@@ -1,5 +1,4 @@
-"""
-Backfill the outdated-version banner into already-published gh-pages trees.
+"""Backfill the outdated-version banner into already-published gh-pages trees.
 
 Purpose:
     Populate the empty ``data-md-component="outdated"`` banner div that archived
@@ -149,8 +148,7 @@ BANNER_CSS = """.md-banner,
 
 
 def _version_key(name: str) -> Version:
-    """
-    Order a version directory name by PEP 440: `0.9.0` sorts below `0.10.0`.
+    """Order a version directory name by PEP 440: `0.9.0` sorts below `0.10.0`.
 
     A pre-release directory sorts below the release it precedes, so `0.31.0` wins
     over `0.31.0rc1` should both trees ever sit on the branch at once. A name PEP 440
@@ -176,8 +174,7 @@ def _newest_version_dir(root: Path) -> Path | None:
 
 
 def _archived_version_dirs(root: Path) -> list[Path]:
-    """
-    Return the superseded numeric version directories under `root`.
+    """Return the superseded numeric version directories under `root`.
 
     The highest-numbered directory is excluded: it holds the current release, which
     is not outdated, so it gets neither the banner nor the styling and script that
@@ -196,8 +193,7 @@ def _version_dirs(root: Path) -> list[Path]:
 
 
 def patch_tree(root: Path) -> list[Path]:
-    """
-    Inject banner markup into every unpatched page under `root`.
+    """Inject banner markup into every unpatched page under `root`.
 
     Returns the HTML files that were changed, for the caller to report against.
     """
@@ -217,8 +213,7 @@ def patch_tree(root: Path) -> list[Path]:
 
 
 def patch_stylesheets(root: Path) -> list[Path]:
-    """
-    Give the banner its purple/centered/sticky styling in each archived extra.css.
+    """Give the banner its purple/centered/sticky styling in each archived extra.css.
 
     Returns the stylesheets that were changed, for the caller to report against.
     """
@@ -362,8 +357,7 @@ def _relative_prefix(html_file: Path, version_dir: Path) -> str:
 
 
 def patch_scripts(root: Path) -> list[Path]:
-    """
-    Copy version-banner.js into each archived version, referenced from every page.
+    """Copy version-banner.js into each archived version, referenced from every page.
 
     Without it the banner still sticks (pure CSS), but the header can briefly overlap it
     before a reader scrolls, since nothing offsets the header below it. Returns the
@@ -403,8 +397,7 @@ INJECTED_BANNER_RE = re.compile(
 
 
 def unpatch_newest_version(root: Path) -> list[Path]:
-    """
-    Strip an injected banner from the current release tree under `root`.
+    """Strip an injected banner from the current release tree under `root`.
 
     A run made before the newest release was excluded left an "older version" banner on
     the docs `latest` serves. The div is restored to the whitespace-only interior a
@@ -429,8 +422,7 @@ def unpatch_newest_version(root: Path) -> list[Path]:
 
 
 def main() -> int:
-    """
-    Entry point: patch the tree at `root` and report how many files changed.
+    """Entry point: patch the tree at `root` and report how many files changed.
 
     `--banner-only` (any position in argv) skips `patch_stylesheets`/`patch_scripts` —
     see the module docstring's Usage section for why a genuinely-built release tree

--- a/.github/scripts/update_docs_stats.py
+++ b/.github/scripts/update_docs_stats.py
@@ -1,4 +1,5 @@
-"""Refresh the documented GitHub star-count phrase.
+"""
+Refresh the documented GitHub star-count phrase.
 
 Purpose:
     Keep every documented GitHub star claim aligned with the repository's live
@@ -105,7 +106,8 @@ def _write_if_changed(
 
 
 def apply_updates(stars: int, *, check_only: bool) -> list[str]:
-    """Update every contract target and return the names that changed.
+    """
+    Update every contract target and return the names that changed.
 
     Raises:
         ValueError: If a configured target no longer carries its star-count marker.

--- a/.github/scripts/update_docs_stats.py
+++ b/.github/scripts/update_docs_stats.py
@@ -1,5 +1,4 @@
-"""
-Refresh the documented GitHub star-count phrase.
+"""Refresh the documented GitHub star-count phrase.
 
 Purpose:
     Keep every documented GitHub star claim aligned with the repository's live
@@ -106,8 +105,7 @@ def _write_if_changed(
 
 
 def apply_updates(stars: int, *, check_only: bool) -> list[str]:
-    """
-    Update every contract target and return the names that changed.
+    """Update every contract target and return the names that changed.
 
     Raises:
         ValueError: If a configured target no longer carries its star-count marker.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,13 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
 
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.8
+    hooks:
+      - id: docformatter
+        additional_dependencies:
+          - "tomli>=2.0.1"
+
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.8
+    rev: v1.7.7
     hooks:
       - id: docformatter
         additional_dependencies:

--- a/examples/compact_mask/bench_inference_api.py
+++ b/examples/compact_mask/bench_inference_api.py
@@ -1,5 +1,4 @@
-"""
-Benchmark dense vs compact Roboflow RLE ingestion.
+"""Benchmark dense vs compact Roboflow RLE ingestion.
 
 Run with:
     uv run python examples/compact_mask/bench_inference_api.py
@@ -127,8 +126,7 @@ def count_rle_predictions(result: dict[str, Any]) -> int:
 
 
 def synthetic_dense_small_result() -> tuple[np.ndarray, str, dict[str, Any]]:
-    """
-    Return a small dense-mask adversarial payload where compact parsing is slower.
+    """Return a small dense-mask adversarial payload where compact parsing is slower.
 
     Uses a 64x64 image with 4 fully-filled masks. At this scale the dense ``(N, H, W)``
     allocation cost is negligible; Python RLE arithmetic dominates, making compact

--- a/examples/compact_mask/bench_inference_api.py
+++ b/examples/compact_mask/bench_inference_api.py
@@ -1,4 +1,5 @@
-"""Benchmark dense vs compact Roboflow RLE ingestion.
+"""
+Benchmark dense vs compact Roboflow RLE ingestion.
 
 Run with:
     uv run python examples/compact_mask/bench_inference_api.py
@@ -126,13 +127,14 @@ def count_rle_predictions(result: dict[str, Any]) -> int:
 
 
 def synthetic_dense_small_result() -> tuple[np.ndarray, str, dict[str, Any]]:
-    """Return a small dense-mask adversarial payload where compact parsing is slower.
+    """
+    Return a small dense-mask adversarial payload where compact parsing is slower.
 
-    Uses a 64x64 image with 4 fully-filled masks. At this scale the dense
-    ``(N, H, W)`` allocation cost is negligible; Python RLE arithmetic dominates,
-    making compact ingestion slower than the dense NumPy path. Included as a
-    clearly labeled adversarial row in the default benchmark run to show that
-    the ``speedup`` column reflects allocation savings, not decode speed.
+    Uses a 64x64 image with 4 fully-filled masks. At this scale the dense ``(N, H, W)``
+    allocation cost is negligible; Python RLE arithmetic dominates, making compact
+    ingestion slower than the dense NumPy path. Included as a clearly labeled
+    adversarial row in the default benchmark run to show that the ``speedup`` column
+    reflects allocation savings, not decode speed.
     """
     height, width = 64, 64
     image = np.zeros((height, width, 3), dtype=np.uint8)

--- a/examples/compact_mask/benchmark.py
+++ b/examples/compact_mask/benchmark.py
@@ -1,5 +1,4 @@
-"""
-CompactMask demo & benchmark.
+"""CompactMask demo & benchmark.
 
 Demonstrates that ``CompactMask`` is a drop-in replacement for dense
 ``(N, H, W)`` bool arrays in ``supervision.Detections``, while using
@@ -146,8 +145,7 @@ def _make_polygon_mask(
     rng: np.random.Generator,
     num_vertices: int,
 ) -> np.ndarray:
-    """
-    Random polygon mask.
+    """Random polygon mask.
 
     *num_vertices* is a direct complexity proxy: more vertices → more independent radius
     samples → jaggier boundary → more RLE runs per row. No smoothing is applied so the
@@ -179,8 +177,7 @@ def make_detections(
     num_vertices: int = 20,
     seed: int = 0,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Return ``(xyxy, masks_dense, class_ids)`` with random polygon masks.
+    """Return ``(xyxy, masks_dense, class_ids)`` with random polygon masks.
 
     *num_vertices* controls mask complexity: more vertices → jaggier boundary.
     """
@@ -241,8 +238,7 @@ def compact_memory_bytes_theoretical(compact_mask: CompactMask) -> int:
 
 
 def measure_peak_bytes(func: Callable[[], object]) -> int:
-    """
-    Wrapper that runs *func* under tracemalloc and returns peak allocation.
+    """Wrapper that runs *func* under tracemalloc and returns peak allocation.
 
     tracemalloc captures every Python-level allocation — numpy buffers, list nodes,
     object headers — giving the true heap cost of anything *func* builds. The return
@@ -281,8 +277,7 @@ def time_reps(
     repeats: int = REPETITIONS,
     parallel: int = PARALLEL,
 ) -> float:
-    """
-    Run *func* *reps* times and return mean wall-clock seconds per call.
+    """Run *func* *reps* times and return mean wall-clock seconds per call.
 
     When ``parallel > 1``, up to ``parallel`` calls run simultaneously in threads. Numpy
     and OpenCV release the GIL for their C-level work, so threads can execute in
@@ -335,8 +330,7 @@ def stage_build(
 
 
 def _resize_dense_to_shape(masks: np.ndarray, new_h: int, new_w: int) -> np.ndarray:
-    """
-    Nearest-neighbour resize of (N, H, W) bool masks to (N, new_h, new_w).
+    """Nearest-neighbour resize of (N, H, W) bool masks to (N, new_h, new_w).
 
     Uses floor-division indexing (``arange * src // dst``) to match the strategy in
     ``_rle_resize``, ensuring pixel-exact parity for correctness comparisons in
@@ -355,8 +349,7 @@ def stage_encode(
     image_height: int,
     image_width: int,
 ) -> float:
-    """
-    Per-mask encode time: encode each mask individually and average over N.
+    """Per-mask encode time: encode each mask individually and average over N.
 
     Calling from_dense one mask at a time (rather than batching all N) isolates the per-
     shape cost — each polygon has a different RLE run count, so the average reflects
@@ -375,8 +368,7 @@ def stage_encode(
 
 
 def stage_decode(compact_mask: CompactMask) -> float:
-    """
-    Per-mask decode time: decode each mask individually and average over N.
+    """Per-mask decode time: decode each mask individually and average over N.
 
     Building a list via compact_mask[i] decodes each crop separately, giving the per-
     mask cost of materialising a single RLE back to a dense array.
@@ -441,8 +433,7 @@ def stage_iou(
     compact_mask: CompactMask,
     iou_dense_skipped: bool,
 ) -> tuple[float, float, bool | None]:
-    """
-    Time pairwise self-IoU using dense (N,H,W) AND and compact crop filter.
+    """Time pairwise self-IoU using dense (N,H,W) AND and compact crop filter.
 
     Correctness is checked on the first 10 masks only to keep it fast, regardless of
     whether full dense IoU timing is skipped.
@@ -476,8 +467,7 @@ def stage_nms(
     dense_skipped: bool,
     iou_dense_skipped: bool,
 ) -> tuple[float, float, bool | None, int]:
-    """
-    Time mask NMS.
+    """Time mask NMS.
 
     Dense resizes to 640 before IoU; compact uses exact crop IoU.
         Compact NMS is strictly more accurate than dense: it computes pixel-level IoU
@@ -518,8 +508,7 @@ def stage_merge(
     det_compact: sv.Detections,
     dense_skipped: bool,
 ) -> tuple[float, float, bool | None]:
-    """
-    Time Detections.merge on two half-splits.
+    """Time Detections.merge on two half-splits.
 
     Dense: np.vstack; compact: RLE concat.
     Splits are pre-computed so the timed lambda measures only the merge.
@@ -598,8 +587,7 @@ def stage_resize(
     image_width: int,
     dense_skipped: bool,
 ) -> tuple[float, float, bool | None]:
-    """
-    Time resize to half resolution; check pixel-level correctness.
+    """Time resize to half resolution; check pixel-level correctness.
 
     Dense path uses numpy fancy-indexing via ``_resize_dense_to_shape``. Compact path
     times ``CompactMask.resize()``, which uses direct RLE arithmetic for sparse masks
@@ -891,8 +879,7 @@ _OPS = (
 
 
 def _build_summary_df(results: list[ScenarioResult]) -> pd.DataFrame:
-    """
-    Compute derived summary columns from scenario results.
+    """Compute derived summary columns from scenario results.
 
     Returns a DataFrame with all ScenarioResult fields plus derived columns (ratios,
     speedups, ok) as raw floats.  Consumers apply their own formatting.
@@ -936,8 +923,7 @@ def _build_summary_df(results: list[ScenarioResult]) -> pd.DataFrame:
 
 
 def _fmt_ratio(ratio: float) -> str:
-    """
-    Format a speedup/compression ratio with colour coding.
+    """Format a speedup/compression ratio with colour coding.
 
     ≥10 → green (large win), 1-10 → yellow (modest win), <1 → red (regression). Integer
     for ≥10, two decimals otherwise.
@@ -1072,8 +1058,7 @@ def print_summary(results: list[ScenarioResult]) -> None:
 
 
 def _append_result(result: ScenarioResult, path: Path) -> None:
-    """
-    Append one scenario result as a JSON line to *path*.
+    """Append one scenario result as a JSON line to *path*.
 
     ``math.nan`` (used for skipped dense timings) is serialised as ``null`` so the file
     is valid JSON-Lines and can be read back with any JSON parser.
@@ -1087,8 +1072,7 @@ def _append_result(result: ScenarioResult, path: Path) -> None:
 
 
 def save_results_csv(results: list[ScenarioResult], path: Path) -> None:
-    """
-    Write the summary table to *path* as a CSV file.
+    """Write the summary table to *path* as a CSV file.
 
     Each row mirrors the Rich summary table: scenario metadata, memory ratios,
     encode/decode overhead, and per-operation speedups. Columns whose dense

--- a/examples/compact_mask/benchmark.py
+++ b/examples/compact_mask/benchmark.py
@@ -1,4 +1,5 @@
-"""CompactMask demo & benchmark.
+"""
+CompactMask demo & benchmark.
 
 Demonstrates that ``CompactMask`` is a drop-in replacement for dense
 ``(N, H, W)`` bool arrays in ``supervision.Detections``, while using
@@ -145,11 +146,12 @@ def _make_polygon_mask(
     rng: np.random.Generator,
     num_vertices: int,
 ) -> np.ndarray:
-    """Random polygon mask.
+    """
+    Random polygon mask.
 
-    *num_vertices* is a direct complexity proxy: more vertices → more
-    independent radius samples → jaggier boundary → more RLE runs per row.
-    No smoothing is applied so the relationship is monotone.
+    *num_vertices* is a direct complexity proxy: more vertices → more independent radius
+    samples → jaggier boundary → more RLE runs per row. No smoothing is applied so the
+    relationship is monotone.
     """
     angles = np.sort(rng.uniform(0, 2 * np.pi, num_vertices))
     radii = rng.uniform(0.3, 1.0, num_vertices)
@@ -177,7 +179,8 @@ def make_detections(
     num_vertices: int = 20,
     seed: int = 0,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Return ``(xyxy, masks_dense, class_ids)`` with random polygon masks.
+    """
+    Return ``(xyxy, masks_dense, class_ids)`` with random polygon masks.
 
     *num_vertices* controls mask complexity: more vertices → jaggier boundary.
     """
@@ -238,12 +241,12 @@ def compact_memory_bytes_theoretical(compact_mask: CompactMask) -> int:
 
 
 def measure_peak_bytes(func: Callable[[], object]) -> int:
-    """Wrapper that runs *func* under tracemalloc and returns peak allocation.
+    """
+    Wrapper that runs *func* under tracemalloc and returns peak allocation.
 
-    tracemalloc captures every Python-level allocation — numpy buffers, list
-    nodes, object headers — giving the true heap cost of anything *func*
-    builds. The return value of *func* is discarded so the object does not
-    stay alive.
+    tracemalloc captures every Python-level allocation — numpy buffers, list nodes,
+    object headers — giving the true heap cost of anything *func* builds. The return
+    value of *func* is discarded so the object does not stay alive.
     """
     tracemalloc.start()
     tracemalloc.clear_traces()
@@ -278,18 +281,19 @@ def time_reps(
     repeats: int = REPETITIONS,
     parallel: int = PARALLEL,
 ) -> float:
-    """Run *func* *reps* times and return mean wall-clock seconds per call.
+    """
+    Run *func* *reps* times and return mean wall-clock seconds per call.
 
-    When ``parallel > 1``, up to ``parallel`` calls run simultaneously in
-    threads. Numpy and OpenCV release the GIL for their C-level work, so
-    threads can execute in parallel on multi-core machines. Each thread
-    records its own elapsed time; the mean across all *reps* is returned.
+    When ``parallel > 1``, up to ``parallel`` calls run simultaneously in threads. Numpy
+    and OpenCV release the GIL for their C-level work, so threads can execute in
+    parallel on multi-core machines. Each thread records its own elapsed time; the mean
+    across all *reps* is returned.
 
-    When ``parallel == 1`` the original sequential loop is used, avoiding
-    any thread-scheduling overhead and improving accuracy for cheap functions.
+    When ``parallel == 1`` the original sequential loop is used, avoiding any thread-
+    scheduling overhead and improving accuracy for cheap functions.
 
-    A full GC cycle is run before timing so accumulated garbage from earlier
-    stages does not trigger collection mid-measurement and inflate results.
+    A full GC cycle is run before timing so accumulated garbage from earlier stages does
+    not trigger collection mid-measurement and inflate results.
     """
     gc.collect()
     if parallel <= 1:
@@ -331,11 +335,12 @@ def stage_build(
 
 
 def _resize_dense_to_shape(masks: np.ndarray, new_h: int, new_w: int) -> np.ndarray:
-    """Nearest-neighbour resize of (N, H, W) bool masks to (N, new_h, new_w).
+    """
+    Nearest-neighbour resize of (N, H, W) bool masks to (N, new_h, new_w).
 
-    Uses floor-division indexing (``arange * src // dst``) to match the
-    strategy in ``_rle_resize``, ensuring pixel-exact parity for correctness
-    comparisons in :func:`stage_resize`.
+    Uses floor-division indexing (``arange * src // dst``) to match the strategy in
+    ``_rle_resize``, ensuring pixel-exact parity for correctness comparisons in
+    :func:`stage_resize`.
     """
     orig_h, orig_w = masks.shape[1], masks.shape[2]
     x = np.arange(new_w) * orig_w // new_w
@@ -350,11 +355,12 @@ def stage_encode(
     image_height: int,
     image_width: int,
 ) -> float:
-    """Per-mask encode time: encode each mask individually and average over N.
+    """
+    Per-mask encode time: encode each mask individually and average over N.
 
-    Calling from_dense one mask at a time (rather than batching all N) isolates
-    the per-shape cost — each polygon has a different RLE run count, so the
-    average reflects true shape variance.
+    Calling from_dense one mask at a time (rather than batching all N) isolates the per-
+    shape cost — each polygon has a different RLE run count, so the average reflects
+    true shape variance.
     """
     num_masks = len(masks_dense)
     image_shape = (image_height, image_width)
@@ -369,10 +375,11 @@ def stage_encode(
 
 
 def stage_decode(compact_mask: CompactMask) -> float:
-    """Per-mask decode time: decode each mask individually and average over N.
+    """
+    Per-mask decode time: decode each mask individually and average over N.
 
-    Building a list via compact_mask[i] decodes each crop separately, giving
-    the per-mask cost of materialising a single RLE back to a dense array.
+    Building a list via compact_mask[i] decodes each crop separately, giving the per-
+    mask cost of materialising a single RLE back to a dense array.
     """
     num_masks = len(compact_mask)
     return time_reps(lambda: [compact_mask[i] for i in range(num_masks)]) / max(
@@ -434,10 +441,11 @@ def stage_iou(
     compact_mask: CompactMask,
     iou_dense_skipped: bool,
 ) -> tuple[float, float, bool | None]:
-    """Time pairwise self-IoU using dense (N,H,W) AND and compact crop filter.
+    """
+    Time pairwise self-IoU using dense (N,H,W) AND and compact crop filter.
 
-    Correctness is checked on the first 10 masks only to keep it fast,
-    regardless of whether full dense IoU timing is skipped.
+    Correctness is checked on the first 10 masks only to keep it fast, regardless of
+    whether full dense IoU timing is skipped.
     """
     correct_n = min(len(compact_mask), 10)
     iou_compact_small = sv.mask_iou_batch(
@@ -468,21 +476,23 @@ def stage_nms(
     dense_skipped: bool,
     iou_dense_skipped: bool,
 ) -> tuple[float, float, bool | None, int]:
-    """Time mask NMS. Dense resizes to 640 before IoU; compact uses exact crop IoU.
+    """
+    Time mask NMS.
 
-    Compact NMS is strictly more accurate than dense: it computes pixel-level IoU
-    directly on the full-resolution RLE crops instead of a lossy 640px-downsampled
-    approximation.  For pairs whose true IoU is very close to the 0.5 threshold,
-    the resize step in the dense path can flip a keep/suppress decision.
+    Dense resizes to 640 before IoU; compact uses exact crop IoU.
+        Compact NMS is strictly more accurate than dense: it computes pixel-level IoU
+        directly on the full-resolution RLE crops instead of a lossy 640px-downsampled
+        approximation.  For pairs whose true IoU is very close to the 0.5 threshold,
+        the resize step in the dense path can flip a keep/suppress decision.
 
-    ``n_diff`` counts detections whose decision differs between the two paths.
-    ``nms_ok`` is True when ``n_diff == 0``.
+        ``n_diff`` counts detections whose decision differs between the two paths.
+        ``nms_ok`` is True when ``n_diff == 0``.
 
-    Dense NMS is skipped when ``dense_skipped`` *or* ``iou_dense_skipped`` is True:
-    NMS calls mask_iou_batch internally so the cost is the same as IoU.
+        Dense NMS is skipped when ``dense_skipped`` *or* ``iou_dense_skipped`` is True:
+        NMS calls mask_iou_batch internally so the cost is the same as IoU.
 
-    Returns:
-        Tuple of ``(dense_nms_s, compact_nms_s, nms_ok, n_diff)``.
+        Returns:
+            Tuple of ``(dense_nms_s, compact_nms_s, nms_ok, n_diff)``.
     """
     predictions = np.c_[xyxy, confidence, class_ids.astype(float)]
 
@@ -508,7 +518,8 @@ def stage_merge(
     det_compact: sv.Detections,
     dense_skipped: bool,
 ) -> tuple[float, float, bool | None]:
-    """Time Detections.merge on two half-splits.
+    """
+    Time Detections.merge on two half-splits.
 
     Dense: np.vstack; compact: RLE concat.
     Splits are pre-computed so the timed lambda measures only the merge.
@@ -587,14 +598,14 @@ def stage_resize(
     image_width: int,
     dense_skipped: bool,
 ) -> tuple[float, float, bool | None]:
-    """Time resize to half resolution; check pixel-level correctness.
+    """
+    Time resize to half resolution; check pixel-level correctness.
 
-    Dense path uses numpy fancy-indexing via ``_resize_dense_to_shape``.
-    Compact path times ``CompactMask.resize()``, which uses direct RLE
-    arithmetic for sparse masks (below ``_L3_DENSITY_THRESHOLD``) and
-    falls back to ``cv2.INTER_NEAREST`` decode/resize/re-encode for dense
-    masks.  The two nearest-neighbour strategies can differ by 1 px at
-    bbox boundaries, so correctness is checked with 1-pixel tolerance.
+    Dense path uses numpy fancy-indexing via ``_resize_dense_to_shape``. Compact path
+    times ``CompactMask.resize()``, which uses direct RLE arithmetic for sparse masks
+    (below ``_L3_DENSITY_THRESHOLD``) and falls back to ``cv2.INTER_NEAREST``
+    decode/resize/re-encode for dense masks.  The two nearest-neighbour strategies can
+    differ by 1 px at bbox boundaries, so correctness is checked with 1-pixel tolerance.
     """
     new_h, new_w = image_height // 2, image_width // 2
     new_shape = (new_h, new_w)
@@ -880,10 +891,11 @@ _OPS = (
 
 
 def _build_summary_df(results: list[ScenarioResult]) -> pd.DataFrame:
-    """Compute derived summary columns from scenario results.
+    """
+    Compute derived summary columns from scenario results.
 
-    Returns a DataFrame with all ScenarioResult fields plus derived columns
-    (ratios, speedups, ok) as raw floats.  Consumers apply their own formatting.
+    Returns a DataFrame with all ScenarioResult fields plus derived columns (ratios,
+    speedups, ok) as raw floats.  Consumers apply their own formatting.
     """
     df = pd.DataFrame([dataclasses.asdict(r) for r in results])
     df["ratio_theory"] = df["dense_bytes"] / df["compact_bytes_theoretical"].clip(
@@ -924,10 +936,11 @@ def _build_summary_df(results: list[ScenarioResult]) -> pd.DataFrame:
 
 
 def _fmt_ratio(ratio: float) -> str:
-    """Format a speedup/compression ratio with colour coding.
+    """
+    Format a speedup/compression ratio with colour coding.
 
-    ≥10 → green (large win), 1-10 → yellow (modest win), <1 → red (regression).
-    Integer for ≥10, two decimals otherwise.
+    ≥10 → green (large win), 1-10 → yellow (modest win), <1 → red (regression). Integer
+    for ≥10, two decimals otherwise.
     """
     fmt = f"{ratio:.0f}x" if ratio >= 10 else f"{ratio:.2f}x"
     if ratio >= 10:
@@ -1059,10 +1072,11 @@ def print_summary(results: list[ScenarioResult]) -> None:
 
 
 def _append_result(result: ScenarioResult, path: Path) -> None:
-    """Append one scenario result as a JSON line to *path*.
+    """
+    Append one scenario result as a JSON line to *path*.
 
-    ``math.nan`` (used for skipped dense timings) is serialised as ``null``
-    so the file is valid JSON-Lines and can be read back with any JSON parser.
+    ``math.nan`` (used for skipped dense timings) is serialised as ``null`` so the file
+    is valid JSON-Lines and can be read back with any JSON parser.
     """
     row = {
         k: (None if isinstance(v, float) and math.isnan(v) else v)
@@ -1073,7 +1087,8 @@ def _append_result(result: ScenarioResult, path: Path) -> None:
 
 
 def save_results_csv(results: list[ScenarioResult], path: Path) -> None:
-    """Write the summary table to *path* as a CSV file.
+    """
+    Write the summary table to *path* as a CSV file.
 
     Each row mirrors the Rich summary table: scenario metadata, memory ratios,
     encode/decode overhead, and per-operation speedups. Columns whose dense

--- a/examples/count_people_in_zone/inference_example.py
+++ b/examples/count_people_in_zone/inference_example.py
@@ -67,7 +67,7 @@ def detect(
 ) -> sv.Detections:
     """
     Detect objects in a frame using Inference model, filtering detections by class ID
-        and confidence threshold.
+    and confidence threshold.
 
     Args:
         frame (np.ndarray): The frame to process, expected to be a NumPy array.

--- a/examples/count_people_in_zone/inference_example.py
+++ b/examples/count_people_in_zone/inference_example.py
@@ -12,8 +12,7 @@ COLORS = sv.ColorPalette.DEFAULT
 
 
 def load_zones_config(file_path: str) -> list[np.ndarray]:
-    """
-    Load polygon zone configurations from a JSON file.
+    """Load polygon zone configurations from a JSON file.
 
     This function reads a JSON file which contains polygon coordinates, and
     converts them into a list of NumPy arrays. Each polygon is represented as
@@ -65,8 +64,7 @@ def detect(
     confidence_threshold: float = 0.5,
     iou_threshold: float = 0.7,
 ) -> sv.Detections:
-    """
-    Detect objects in a frame using Inference model, filtering detections by class ID
+    """Detect objects in a frame using Inference model, filtering detections by class ID
     and confidence threshold.
 
     Args:
@@ -99,8 +97,7 @@ def annotate(
     box_annotators: list[sv.BoxAnnotator],
     detections: sv.Detections,
 ) -> np.ndarray:
-    """
-    Annotate a frame with zone and box annotations based on given detections.
+    """Annotate a frame with zone and box annotations based on given detections.
 
     Args:
         frame (np.ndarray): The original frame to be annotated.
@@ -135,8 +132,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Counting people in zones with Inference and Supervision.
+    """Counting people in zones with Inference and Supervision.
 
     Args:
         zone_configuration_path: Path to the zone configuration JSON file

--- a/examples/count_people_in_zone/rfdetr_example.py
+++ b/examples/count_people_in_zone/rfdetr_example.py
@@ -71,7 +71,7 @@ def detect(
 ) -> sv.Detections:
     """
     Detect objects in a frame using an RF-DETR model, filtering detections by class ID
-        and confidence threshold.
+    and confidence threshold.
 
     Args:
         frame (np.ndarray): The frame to process, expected to be a NumPy array.

--- a/examples/count_people_in_zone/rfdetr_example.py
+++ b/examples/count_people_in_zone/rfdetr_example.py
@@ -15,8 +15,7 @@ PERSON_CLASS_ID = 1
 
 
 def load_zones_config(file_path: str) -> list[np.ndarray]:
-    """
-    Load polygon zone configurations from a JSON file.
+    """Load polygon zone configurations from a JSON file.
 
     This function reads a JSON file which contains polygon coordinates, and
     converts them into a list of NumPy arrays. Each polygon is represented as
@@ -69,9 +68,8 @@ def detect(
     confidence_threshold: float = 0.5,
     iou_threshold: float = 0.7,
 ) -> sv.Detections:
-    """
-    Detect objects in a frame using an RF-DETR model, filtering detections by class ID
-    and confidence threshold.
+    """Detect objects in a frame using an RF-DETR model, filtering detections by class
+    ID and confidence threshold.
 
     Args:
         frame (np.ndarray): The frame to process, expected to be a NumPy array.
@@ -103,8 +101,7 @@ def annotate(
     box_annotators: list[sv.BoxAnnotator],
     detections: sv.Detections,
 ) -> np.ndarray:
-    """
-    Annotate a frame with zone and box annotations based on given detections.
+    """Annotate a frame with zone and box annotations based on given detections.
 
     Args:
         frame (np.ndarray): The original frame to be annotated.
@@ -138,8 +135,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Counting people in zones with RF-DETR and Supervision.
+    """Counting people in zones with RF-DETR and Supervision.
 
     Args:
         zone_configuration_path: Path to the zone configuration JSON file

--- a/examples/count_people_in_zone/ultralytics_example.py
+++ b/examples/count_people_in_zone/ultralytics_example.py
@@ -65,7 +65,7 @@ def detect(
 ) -> sv.Detections:
     """
     Detect objects in a frame using a YOLO model, filtering detections by class ID and
-        confidence threshold.
+    confidence threshold.
 
     Args:
         frame (np.ndarray): The frame to process, expected to be a NumPy array.

--- a/examples/count_people_in_zone/ultralytics_example.py
+++ b/examples/count_people_in_zone/ultralytics_example.py
@@ -10,8 +10,7 @@ COLORS = sv.ColorPalette.DEFAULT
 
 
 def load_zones_config(file_path: str) -> list[np.ndarray]:
-    """
-    Load polygon zone configurations from a JSON file.
+    """Load polygon zone configurations from a JSON file.
 
     This function reads a JSON file which contains polygon coordinates, and
     converts them into a list of NumPy arrays. Each polygon is represented as
@@ -63,9 +62,8 @@ def detect(
     confidence_threshold: float = 0.5,
     iou_threshold: float = 0.7,
 ) -> sv.Detections:
-    """
-    Detect objects in a frame using a YOLO model, filtering detections by class ID and
-    confidence threshold.
+    """Detect objects in a frame using a YOLO model, filtering detections by class ID
+    and confidence threshold.
 
     Args:
         frame (np.ndarray): The frame to process, expected to be a NumPy array.
@@ -98,8 +96,7 @@ def annotate(
     box_annotators: list[sv.BoxAnnotator],
     detections: sv.Detections,
 ) -> np.ndarray:
-    """
-    Annotate a frame with zone and box annotations based on given detections.
+    """Annotate a frame with zone and box annotations based on given detections.
 
     Args:
         frame (np.ndarray): The original frame to be annotated.
@@ -133,8 +130,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Counting people in zones with YOLO and Supervision.
+    """Counting people in zones with YOLO and Supervision.
 
     Args:
         zone_configuration_path: Path to the zone configuration JSON file

--- a/examples/heatmap_and_track/rfdetr_example.py
+++ b/examples/heatmap_and_track/rfdetr_example.py
@@ -27,8 +27,7 @@ def main(
     track_seconds: int = 5,
     minimum_matching_threshold: float = 0.99,
 ) -> None:
-    """
-    Heatmap and Tracking with RF-DETR and Supervision.
+    """Heatmap and Tracking with RF-DETR and Supervision.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/heatmap_and_track/script.py
+++ b/examples/heatmap_and_track/script.py
@@ -22,8 +22,7 @@ def main(
     track_seconds: int = 5,
     minimum_matching_threshold: float = 0.99,
 ) -> None:
-    """
-    Heatmap and Tracking with Supervision.
+    """Heatmap and Tracking with Supervision.
 
     Args:
         source_weights_path: Path to the source weights file

--- a/examples/speed_estimation/inference_example.py
+++ b/examples/speed_estimation/inference_example.py
@@ -45,8 +45,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Vehicle Speed Estimation using Inference and Supervision.
+    """Vehicle Speed Estimation using Inference and Supervision.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/speed_estimation/rfdetr_example.py
+++ b/examples/speed_estimation/rfdetr_example.py
@@ -54,8 +54,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Vehicle Speed Estimation using RF-DETR and Supervision.
+    """Vehicle Speed Estimation using RF-DETR and Supervision.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/speed_estimation/ultralytics_example.py
+++ b/examples/speed_estimation/ultralytics_example.py
@@ -42,8 +42,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Vehicle Speed Estimation using Ultralytics and Supervision.
+    """Vehicle Speed Estimation using Ultralytics and Supervision.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/speed_estimation/yolo_nas_example.py
+++ b/examples/speed_estimation/yolo_nas_example.py
@@ -43,8 +43,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Vehicle Speed Estimation using YOLO-NAS and Supervision.
+    """Vehicle Speed Estimation using YOLO-NAS and Supervision.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/time_in_zone/inference_file_example.py
+++ b/examples/time_in_zone/inference_file_example.py
@@ -21,8 +21,7 @@ def main(
     classes: list[int] = [],
     roboflow_api_key: str = "",
 ) -> None:
-    """
-    Calculating detections dwell time in zones, using video file.
+    """Calculating detections dwell time in zones, using video file.
 
     Args:
         zone_configuration_path: Path to the zone configuration JSON file

--- a/examples/time_in_zone/inference_naive_stream_example.py
+++ b/examples/time_in_zone/inference_naive_stream_example.py
@@ -21,8 +21,7 @@ def main(
     classes: list[int] = [],
     roboflow_api_key: str = "",
 ) -> None:
-    """
-    Calculating detections dwell time in zones, using RTSP stream.
+    """Calculating detections dwell time in zones, using RTSP stream.
 
     Args:
         zone_configuration_path: Path to the zone configuration JSON file

--- a/examples/time_in_zone/inference_stream_example.py
+++ b/examples/time_in_zone/inference_stream_example.py
@@ -83,8 +83,7 @@ def main(
     classes: list[int] = [],
     roboflow_api_key: str = "",
 ) -> None:
-    """
-    Calculating detections dwell time in zones, using RTSP stream.
+    """Calculating detections dwell time in zones, using RTSP stream.
 
     Args:
         zone_configuration_path: Path to the zone configuration JSON file

--- a/examples/time_in_zone/rfdetr_file_example.py
+++ b/examples/time_in_zone/rfdetr_file_example.py
@@ -98,8 +98,7 @@ def main(
     iou_threshold: float = 0.7,
     classes: list[int] = [],
 ) -> None:
-    """
-    Calculating detections dwell time in zones, using video file.
+    """Calculating detections dwell time in zones, using video file.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/time_in_zone/rfdetr_naive_stream_example.py
+++ b/examples/time_in_zone/rfdetr_naive_stream_example.py
@@ -98,8 +98,7 @@ def main(
     iou_threshold: float = 0.7,
     classes: list[int] = [],
 ) -> None:
-    """
-    Calculating detections dwell time in zones, using RTSP stream.
+    """Calculating detections dwell time in zones, using RTSP stream.
 
     Args:
         rtsp_url: Complete RTSP URL for the video stream

--- a/examples/time_in_zone/rfdetr_stream_example.py
+++ b/examples/time_in_zone/rfdetr_stream_example.py
@@ -144,8 +144,7 @@ def main(
     iou_threshold: float = 0.7,
     classes: list[int] = [],
 ) -> None:
-    """
-    Calculating detections dwell time in zones using an RTSP stream.
+    """Calculating detections dwell time in zones using an RTSP stream.
 
     Args:
         rtsp_url: Complete RTSP URL for the video stream

--- a/examples/time_in_zone/scripts/download_from_youtube.py
+++ b/examples/time_in_zone/scripts/download_from_youtube.py
@@ -31,8 +31,7 @@ def _build_ydl_opts(output_path: str | None, file_name: str | None) -> dict[str,
 def main(
     url: str, output_path: str = "data/source", file_name: str = "video.mp4"
 ) -> None:
-    """
-    Download a specific YouTube video by providing its URL.
+    """Download a specific YouTube video by providing its URL.
 
     Args:
         url: The full URL of the YouTube video you wish to download.

--- a/examples/time_in_zone/scripts/draw_zones.py
+++ b/examples/time_in_zone/scripts/draw_zones.py
@@ -128,8 +128,7 @@ def save_polygons_to_json(
 
 
 def main(source_path: str, zone_configuration_path: str) -> None:
-    """
-    Interactively draw polygons on images or video frames and save the annotations.
+    """Interactively draw polygons on images or video frames and save the annotations.
 
     Args:
         source_path: Path to the source image or video file for drawing polygons.

--- a/examples/time_in_zone/scripts/stream_from_file.py
+++ b/examples/time_in_zone/scripts/stream_from_file.py
@@ -12,8 +12,7 @@ BASE_STREAM_URL = "rtsp://localhost:8554/live"
 
 
 def main(video_directory: str, number_of_streams: int = 6) -> None:
-    """
-    Script to stream videos using RTSP protocol.
+    """Script to stream videos using RTSP protocol.
 
     Args:
         video_directory: Directory containing video files to stream.

--- a/examples/time_in_zone/ultralytics_file_example.py
+++ b/examples/time_in_zone/ultralytics_file_example.py
@@ -21,8 +21,7 @@ def main(
     iou_threshold: float = 0.7,
     classes: list[int] = [],
 ) -> None:
-    """
-    Calculating detections dwell time in zones, using video file.
+    """Calculating detections dwell time in zones, using video file.
 
     Args:
         zone_configuration_path: Path to the zone configuration JSON file

--- a/examples/time_in_zone/ultralytics_naive_stream_example.py
+++ b/examples/time_in_zone/ultralytics_naive_stream_example.py
@@ -21,8 +21,7 @@ def main(
     iou_threshold: float = 0.7,
     classes: list[int] = [],
 ) -> None:
-    """
-    Calculating detections dwell time in zones, using RTSP stream.
+    """Calculating detections dwell time in zones, using RTSP stream.
 
     Args:
         zone_configuration_path: Path to the zone configuration JSON file

--- a/examples/time_in_zone/ultralytics_stream_example.py
+++ b/examples/time_in_zone/ultralytics_stream_example.py
@@ -83,8 +83,7 @@ def main(
     iou_threshold: float = 0.7,
     classes: list[int] = [],
 ) -> None:
-    """
-    Calculating detections dwell time in zones, using RTSP stream.
+    """Calculating detections dwell time in zones, using RTSP stream.
 
     Args:
         zone_configuration_path: Path to the zone configuration JSON file

--- a/examples/time_in_zone/utils/general.py
+++ b/examples/time_in_zone/utils/general.py
@@ -25,7 +25,8 @@ def load_zones_config(file_path: str) -> list[np.ndarray]:
 
 
 def find_in_list(array: np.ndarray, search_list: list[int]) -> np.ndarray:
-    """Determines if elements of a numpy array are present in a list.
+    """
+    Determines if elements of a numpy array are present in a list.
 
     Args:
         array (np.ndarray): The numpy array of integers to check.

--- a/examples/time_in_zone/utils/general.py
+++ b/examples/time_in_zone/utils/general.py
@@ -6,8 +6,7 @@ import numpy as np
 
 
 def load_zones_config(file_path: str) -> list[np.ndarray]:
-    """
-    Load polygon zone configurations from a JSON file.
+    """Load polygon zone configurations from a JSON file.
 
     This function reads a JSON file which contains polygon coordinates, and
     converts them into a list of NumPy arrays. Each polygon is represented as
@@ -25,8 +24,7 @@ def load_zones_config(file_path: str) -> list[np.ndarray]:
 
 
 def find_in_list(array: np.ndarray, search_list: list[int]) -> np.ndarray:
-    """
-    Determines if elements of a numpy array are present in a list.
+    """Determines if elements of a numpy array are present in a list.
 
     Args:
         array (np.ndarray): The numpy array of integers to check.
@@ -43,8 +41,7 @@ def find_in_list(array: np.ndarray, search_list: list[int]) -> np.ndarray:
 
 
 def get_stream_frames_generator(rtsp_url: str) -> Generator[np.ndarray, None, None]:
-    """
-    Generator function to yield frames from an RTSP stream.
+    """Generator function to yield frames from an RTSP stream.
 
     Args:
         rtsp_url (str): URL of the RTSP video stream.

--- a/examples/time_in_zone/utils/timers.py
+++ b/examples/time_in_zone/utils/timers.py
@@ -19,7 +19,8 @@ class FPSBasedTimer:
     """
 
     def __init__(self, fps: float = 30) -> None:
-        """Initializes the FPSBasedTimer with the specified frames per second rate.
+        """
+        Initializes the FPSBasedTimer with the specified frames per second rate.
 
         Args:
             fps (float): The frame rate of the video stream. Defaults to 30.
@@ -29,7 +30,8 @@ class FPSBasedTimer:
         self.tracker_id2frame_id: dict[int, int] = {}
 
     def tick(self, detections: sv.Detections) -> np.ndarray:
-        """Processes the current frame, updating time durations for each tracker.
+        """
+        Processes the current frame, updating time durations for each tracker.
 
         Args:
             detections: The detections for the current frame, including tracker IDs.
@@ -66,7 +68,8 @@ class ClockBasedTimer:
         self.tracker_id2start_time: dict[int, datetime] = {}
 
     def tick(self, detections: sv.Detections) -> np.ndarray:
-        """Processes the current frame, updating time durations for each tracker.
+        """
+        Processes the current frame, updating time durations for each tracker.
 
         Args:
             detections: The detections for the current frame, including tracker IDs.

--- a/examples/time_in_zone/utils/timers.py
+++ b/examples/time_in_zone/utils/timers.py
@@ -6,9 +6,8 @@ import supervision as sv
 
 
 class FPSBasedTimer:
-    """
-    A timer that calculates the duration each object has been detected based on frames
-    per second (FPS).
+    """A timer that calculates the duration each object has been detected based on
+    frames per second (FPS).
 
     Attributes:
         fps (float): The frame rate of the video stream, used to calculate
@@ -19,8 +18,7 @@ class FPSBasedTimer:
     """
 
     def __init__(self, fps: float = 30) -> None:
-        """
-        Initializes the FPSBasedTimer with the specified frames per second rate.
+        """Initializes the FPSBasedTimer with the specified frames per second rate.
 
         Args:
             fps (float): The frame rate of the video stream. Defaults to 30.
@@ -30,8 +28,7 @@ class FPSBasedTimer:
         self.tracker_id2frame_id: dict[int, int] = {}
 
     def tick(self, detections: sv.Detections) -> np.ndarray:
-        """
-        Processes the current frame, updating time durations for each tracker.
+        """Processes the current frame, updating time durations for each tracker.
 
         Args:
             detections: The detections for the current frame, including tracker IDs.
@@ -54,8 +51,7 @@ class FPSBasedTimer:
 
 
 class ClockBasedTimer:
-    """
-    A timer that calculates the duration each object has been detected based on the
+    """A timer that calculates the duration each object has been detected based on the
     system clock.
 
     Attributes:
@@ -68,8 +64,7 @@ class ClockBasedTimer:
         self.tracker_id2start_time: dict[int, datetime] = {}
 
     def tick(self, detections: sv.Detections) -> np.ndarray:
-        """
-        Processes the current frame, updating time durations for each tracker.
+        """Processes the current frame, updating time durations for each tracker.
 
         Args:
             detections: The detections for the current frame, including tracker IDs.

--- a/examples/tracking/inference_example.py
+++ b/examples/tracking/inference_example.py
@@ -14,8 +14,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Video Processing with Inference and ByteTrack.
+    """Video Processing with Inference and ByteTrack.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/tracking/rfdetr_example.py
+++ b/examples/tracking/rfdetr_example.py
@@ -12,8 +12,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Video Processing with RF-DETR and ByteTrack.
+    """Video Processing with RF-DETR and ByteTrack.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/tracking/ultralytics_example.py
+++ b/examples/tracking/ultralytics_example.py
@@ -11,8 +11,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Video Processing with YOLO and ByteTrack.
+    """Video Processing with YOLO and ByteTrack.
 
     Args:
         source_weights_path: Path to the source weights file

--- a/examples/traffic_analysis/inference_example.py
+++ b/examples/traffic_analysis/inference_example.py
@@ -186,8 +186,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Traffic Flow Analysis with Inference and ByteTrack.
+    """Traffic Flow Analysis with Inference and ByteTrack.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/traffic_analysis/rfdetr_example.py
+++ b/examples/traffic_analysis/rfdetr_example.py
@@ -193,8 +193,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Traffic Flow Analysis with RF-DETR and ByteTrack.
+    """Traffic Flow Analysis with RF-DETR and ByteTrack.
 
     Args:
         source_video_path: Path to the source video file

--- a/examples/traffic_analysis/ultralytics_example.py
+++ b/examples/traffic_analysis/ultralytics_example.py
@@ -182,8 +182,7 @@ def main(
     confidence_threshold: float = 0.3,
     iou_threshold: float = 0.7,
 ) -> None:
-    """
-    Traffic Flow Analysis with YOLO and ByteTrack.
+    """Traffic Flow Analysis with YOLO and ByteTrack.
 
     Args:
         source_weights_path: Path to the source weights file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,13 @@ skip = "*.ipynb"
 count = true
 quiet-level = 3
 
+[tool.docformatter]
+recursive = true
+wrap-summaries = 88
+wrap-descriptions = 88
+close-quotes-on-newline = true
+pre-summary-newline = true
+
 [tool.mypy]
 mypy_path = "src"
 explicit_package_bases = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,8 +197,6 @@ quiet-level = 3
 recursive = true
 wrap-summaries = 88
 wrap-descriptions = 88
-close-quotes-on-newline = true
-pre-summary-newline = true
 
 [tool.mypy]
 mypy_path = "src"

--- a/src/supervision/_cv2/_text.py
+++ b/src/supervision/_cv2/_text.py
@@ -1,11 +1,11 @@
-"""Private Pillow-based text fallback for the OpenCV compatibility facade.
+"""
+Private Pillow-based text fallback for the OpenCV compatibility facade.
 
-OpenCV renders text with built-in Hershey stroke fonts. The fallback instead
-draws a proportional TrueType face (DejaVu Sans, shipped with Matplotlib, an
-existing required dependency), so glyph shapes and text metrics differ from
-OpenCV within the documented visual-divergence tier. ``getTextSize`` derives
-its box from the same font ``putText`` renders with, so the reported rectangle
-always encloses the drawn text.
+OpenCV renders text with built-in Hershey stroke fonts. The fallback instead draws a
+proportional TrueType face (DejaVu Sans, shipped with Matplotlib, an existing required
+dependency), so glyph shapes and text metrics differ from OpenCV within the documented
+visual-divergence tier. ``getTextSize`` derives its box from the same font ``putText``
+renders with, so the reported rectangle always encloses the drawn text.
 """
 
 from __future__ import annotations
@@ -56,7 +56,8 @@ def _stroke_width(thickness: int) -> int:
 def _get_text_size(
     text: str, fontFace: int, fontScale: float, thickness: int
 ) -> tuple[tuple[int, int], int]:
-    """Return an OpenCV-shaped ``((width, height), baseline)`` for the face.
+    """
+    Return an OpenCV-shaped ``((width, height), baseline)`` for the face.
 
     Height is the font ascent and baseline the descent, both string-independent
     like OpenCV's contract, so consumers get stable row heights. Padding uses
@@ -85,11 +86,12 @@ def _put_text(
     lineType: int = _LINE_8,
     bottomLeftOrigin: bool = False,
 ) -> _ImageArray:
-    """Render text with a Pillow face, anchored at OpenCV's baseline origin.
+    """
+    Render text with a Pillow face, anchored at OpenCV's baseline origin.
 
     Thickness maps to a Pillow stroke width to emulate OpenCV's bolder strokes.
-    ``bottomLeftOrigin`` (an inverted-axis mode no Supervision caller uses) is
-    rejected rather than silently ignored.
+    ``bottomLeftOrigin`` (an inverted-axis mode no Supervision caller uses) is rejected
+    rather than silently ignored.
     """
     del lineType
     if bottomLeftOrigin:

--- a/src/supervision/_cv2/_text.py
+++ b/src/supervision/_cv2/_text.py
@@ -1,5 +1,4 @@
-"""
-Private Pillow-based text fallback for the OpenCV compatibility facade.
+"""Private Pillow-based text fallback for the OpenCV compatibility facade.
 
 OpenCV renders text with built-in Hershey stroke fonts. The fallback instead draws a
 proportional TrueType face (DejaVu Sans, shipped with Matplotlib, an existing required
@@ -56,8 +55,7 @@ def _stroke_width(thickness: int) -> int:
 def _get_text_size(
     text: str, fontFace: int, fontScale: float, thickness: int
 ) -> tuple[tuple[int, int], int]:
-    """
-    Return an OpenCV-shaped ``((width, height), baseline)`` for the face.
+    """Return an OpenCV-shaped ``((width, height), baseline)`` for the face.
 
     Height is the font ascent and baseline the descent, both string-independent
     like OpenCV's contract, so consumers get stable row heights. Padding uses
@@ -86,8 +84,7 @@ def _put_text(
     lineType: int = _LINE_8,
     bottomLeftOrigin: bool = False,
 ) -> _ImageArray:
-    """
-    Render text with a Pillow face, anchored at OpenCV's baseline origin.
+    """Render text with a Pillow face, anchored at OpenCV's baseline origin.
 
     Thickness maps to a Pillow stroke width to emulate OpenCV's bolder strokes.
     ``bottomLeftOrigin`` (an inverted-axis mode no Supervision caller uses) is rejected

--- a/src/supervision/_cv2/_video.py
+++ b/src/supervision/_cv2/_video.py
@@ -197,8 +197,7 @@ class _VideoWriter:
         frame_size: tuple[int, int],
         is_color: bool = True,
     ) -> None:
-        """
-        Open a PyAV writer for the requested codec and frame dimensions.
+        """Open a PyAV writer for the requested codec and frame dimensions.
 
         The PyAV fallback always encodes 3-channel BGR frames, so grayscale
         output is unsupported. ``is_color=False`` is rejected up front rather
@@ -282,8 +281,7 @@ def _timestamp_seconds(timestamp: int | None, time_base: Any) -> float | None:
 
 
 def _best_effort_cleanup(action: Callable[[], None], description: str) -> None:
-    """
-    Run a cleanup action, logging and suppressing any failure.
+    """Run a cleanup action, logging and suppressing any failure.
 
     Cleanup steps in a ``finally`` block must never raise, otherwise a failing
     ``container.close()`` (or file removal) would mask or replace the primary result or

--- a/src/supervision/_cv2/_video.py
+++ b/src/supervision/_cv2/_video.py
@@ -197,7 +197,8 @@ class _VideoWriter:
         frame_size: tuple[int, int],
         is_color: bool = True,
     ) -> None:
-        """Open a PyAV writer for the requested codec and frame dimensions.
+        """
+        Open a PyAV writer for the requested codec and frame dimensions.
 
         The PyAV fallback always encodes 3-channel BGR frames, so grayscale
         output is unsupported. ``is_color=False`` is rejected up front rather
@@ -281,11 +282,12 @@ def _timestamp_seconds(timestamp: int | None, time_base: Any) -> float | None:
 
 
 def _best_effort_cleanup(action: Callable[[], None], description: str) -> None:
-    """Run a cleanup action, logging and suppressing any failure.
+    """
+    Run a cleanup action, logging and suppressing any failure.
 
     Cleanup steps in a ``finally`` block must never raise, otherwise a failing
-    ``container.close()`` (or file removal) would mask or replace the primary
-    result or the original exception that sent control into ``finally``.
+    ``container.close()`` (or file removal) would mask or replace the primary result or
+    the original exception that sent control into ``finally``.
     """
     try:
         action()

--- a/src/supervision/annotators/base.py
+++ b/src/supervision/annotators/base.py
@@ -5,7 +5,8 @@ from supervision.detection.core import Detections
 
 
 class BaseAnnotator(ABC):
-    """Base class for annotators that consume :class:`Detections`.
+    """
+    Base class for annotators that consume :class:`Detections`.
 
     Attributes:
         requires_mask: Whether integrations must provide ``Detections.mask`` for

--- a/src/supervision/annotators/base.py
+++ b/src/supervision/annotators/base.py
@@ -5,8 +5,7 @@ from supervision.detection.core import Detections
 
 
 class BaseAnnotator(ABC):
-    """
-    Base class for annotators that consume :class:`Detections`.
+    """Base class for annotators that consume :class:`Detections`.
 
     Attributes:
         requires_mask: Whether integrations must provide ``Detections.mask`` for

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -70,8 +70,7 @@ def _load_icon_from_path(
 
 
 def _normalize_color_input(color: Color | ColorPalette | str) -> Color | ColorPalette:
-    """
-    Normalize accepted color inputs to internal color objects.
+    """Normalize accepted color inputs to internal color objects.
 
     Accepts `Color`, `ColorPalette`, or hex string input. Hex strings are parsed via
     `hex_to_rgba` and converted to `Color` (alpha channel is ignored because annotator
@@ -87,8 +86,7 @@ CV2_FONT = cv2.FONT_HERSHEY_SIMPLEX
 
 
 class _BaseLabelAnnotator(BaseAnnotator):
-    """
-    Base class for annotators that add labels to detections.
+    """Base class for annotators that add labels to detections.
 
     Attributes:
         color: The color to use for the label background.
@@ -118,8 +116,7 @@ class _BaseLabelAnnotator(BaseAnnotator):
         smart_position: bool = False,
         max_line_length: int | None = None,
     ):
-        """
-        Initializes the _BaseLabelAnnotator.
+        """Initializes the _BaseLabelAnnotator.
 
         Args:
             color: The color to use for the label
@@ -156,8 +153,8 @@ class _BaseLabelAnnotator(BaseAnnotator):
         labels: list[str],
         label_properties: npt.NDArray[np.float32],
     ) -> npt.NDArray[np.float32]:
-        """
-        Adjusts the position of labels to ensure they stay within the frame boundaries.
+        """Adjusts the position of labels to ensure they stay within the frame
+        boundaries.
 
         Args:
             resolution_wh: The width and height of the frame.
@@ -283,8 +280,7 @@ class BoxAnnotator(BaseAnnotator):
 
 class OrientedBoxAnnotator(BaseAnnotator):
     """A class for drawing oriented bounding boxes on an image using provided
-    detections.
-    """
+    detections."""
 
     def __init__(
         self,
@@ -391,8 +387,7 @@ class OrientedBoxAnnotator(BaseAnnotator):
 def _iter_mask_crops(
     detections: Detections,
 ) -> Iterator[tuple[int, npt.NDArray[np.bool_], npt.NDArray[np.int32] | None]]:
-    """
-    Yield ``(detection_idx, mask_or_crop, offset_or_None)`` for each mask.
+    """Yield ``(detection_idx, mask_or_crop, offset_or_None)`` for each mask.
 
     Encapsulates the ``CompactMask`` vs dense dispatch so individual annotators
     do not need inline ``isinstance`` checks. For ``CompactMask`` inputs yields
@@ -436,8 +431,7 @@ def _paint_masks_by_area(
     collect_union: bool = False,
     canvas_origin: tuple[int, int] = (0, 0),
 ) -> npt.NDArray[np.bool_] | None:
-    """
-    Paint each detection's mask into `canvas` in descending-area order.
+    """Paint each detection's mask into `canvas` in descending-area order.
 
     Smaller masks are drawn on top of larger ones. `CompactMask` detections
     are painted into their bounding-box crop only, avoiding a full `(H, W)`
@@ -513,8 +507,7 @@ def _paint_masks_by_area(
 
 
 class MaskAnnotator(BaseAnnotator):
-    """
-    A class for drawing masks on an image using provided detections.
+    """A class for drawing masks on an image using provided detections.
 
     !!! warning
 
@@ -622,8 +615,7 @@ class MaskAnnotator(BaseAnnotator):
 
 
 class PolygonAnnotator(BaseAnnotator):
-    """
-    A class for drawing polygons on an image using provided detections.
+    """A class for drawing polygons on an image using provided detections.
 
     !!! warning
 
@@ -819,8 +811,7 @@ class ColorAnnotator(BaseAnnotator):
 
 
 class HaloAnnotator(BaseAnnotator):
-    """
-    A class for drawing Halos on an image using provided detections.
+    """A class for drawing Halos on an image using provided detections.
 
     !!! warning
 
@@ -1212,8 +1203,7 @@ class CircleAnnotator(BaseAnnotator):
 
 class DotAnnotator(BaseAnnotator):
     """A class for drawing dots on an image at specific coordinates based on provided
-    detections.
-    """
+    detections."""
 
     def __init__(
         self,
@@ -1672,8 +1662,7 @@ class LabelAnnotator(_BaseLabelAnnotator):
 
 class RichLabelAnnotator(_BaseLabelAnnotator):
     """A class for annotating labels on an image using provided detections, with support
-    for Unicode characters by using a custom font.
-    """
+    for Unicode characters by using a custom font."""
 
     def __init__(
         self,
@@ -2118,8 +2107,7 @@ class BlurAnnotator(BaseAnnotator):
 
 
 class TraceAnnotator(BaseAnnotator):
-    """
-    A class for drawing trace paths on an image based on detection coordinates.
+    """A class for drawing trace paths on an image based on detection coordinates.
 
     !!! warning
 
@@ -2350,8 +2338,7 @@ class TraceAnnotator(BaseAnnotator):
 
 
 class HeatMapAnnotator(BaseAnnotator):
-    """
-    A class for drawing heatmaps on an image based on provided detections.
+    """A class for drawing heatmaps on an image based on provided detections.
 
     Heat accumulates over time and is drawn as a semi-transparent overlay of blurred
     circles.
@@ -2610,8 +2597,7 @@ class PixelateAnnotator(BaseAnnotator):
 
 class TriangleAnnotator(BaseAnnotator):
     """A class for drawing triangle markers on an image at specific coordinates based on
-    provided detections.
-    """
+    provided detections."""
 
     def __init__(
         self,
@@ -2731,8 +2717,7 @@ class TriangleAnnotator(BaseAnnotator):
 
 class RoundBoxAnnotator(BaseAnnotator):
     """A class for drawing bounding boxes with round edges on an image using provided
-    detections.
-    """
+    detections."""
 
     def __init__(
         self,
@@ -3240,8 +3225,7 @@ class CropAnnotator(BaseAnnotator):
 
 
 class BackgroundOverlayAnnotator(BaseAnnotator):
-    """
-    A class for drawing a colored overlay on the background of an image outside the
+    """A class for drawing a colored overlay on the background of an image outside the
     region of detections.
 
     If masks are provided, the background is colored outside the masks. If masks are not
@@ -3332,10 +3316,10 @@ class BackgroundOverlayAnnotator(BaseAnnotator):
 
 
 class ComparisonAnnotator:
-    """
-    Highlights the differences between two sets of detections. Useful for comparing
-    results from two different models, or the difference between a ground truth and a
-    prediction.
+    """Highlights the differences between two sets of detections.
+
+    Useful for comparing results from two different models, or the difference between a
+    ground truth and a prediction.
 
     If present, uses the oriented bounding box data. Otherwise, if present, uses a mask.
     Otherwise, uses the bounding box data.
@@ -3533,8 +3517,7 @@ class ComparisonAnnotator:
         return mask
 
     def _draw_labels(self, scene: npt.NDArray[np.uint8]) -> None:
-        """
-        Draw the labels, explaining what each color represents, with automatically
+        """Draw the labels, explaining what each color represents, with automatically
         computed positions.
 
         Args:

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -221,8 +221,8 @@ class BoxAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with bounding boxes based on the provided detections.
+        """Annotates the given scene with bounding boxes based on the provided
+        detections.
 
         Args:
             scene: The image where bounding boxes will be drawn. `ImageType`
@@ -307,9 +307,8 @@ class OrientedBoxAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with oriented bounding boxes based on the
-        provided detections.
+        """Annotates the given scene with oriented bounding boxes based on the provided
+        detections.
 
         Args:
             scene: The image where bounding boxes will be drawn.
@@ -541,8 +540,7 @@ class MaskAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with masks based on the provided detections.
+        """Annotates the given scene with masks based on the provided detections.
 
         Args:
             scene: The image where masks will be drawn.
@@ -649,8 +647,7 @@ class PolygonAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with polygons based on the provided detections.
+        """Annotates the given scene with polygons based on the provided detections.
 
         Args:
             scene: The image where polygons will be drawn.
@@ -748,8 +745,7 @@ class ColorAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with box masks based on the provided detections.
+        """Annotates the given scene with box masks based on the provided detections.
 
         Args:
             scene: The image where bounding boxes will be drawn.
@@ -849,8 +845,7 @@ class HaloAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with halos based on the provided detections.
+        """Annotates the given scene with halos based on the provided detections.
 
         Args:
             scene: The image where the halo effect will be applied.
@@ -956,8 +951,7 @@ class EllipseAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with ellipses based on the provided detections.
+        """Annotates the given scene with ellipses based on the provided detections.
 
         Args:
             scene: The image where ellipses will be drawn.
@@ -1050,8 +1044,7 @@ class BoxCornerAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with box corners based on the provided detections.
+        """Annotates the given scene with box corners based on the provided detections.
 
         Args:
             scene: The image where box corners will be drawn.
@@ -1140,8 +1133,7 @@ class CircleAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with circles based on the provided detections.
+        """Annotates the given scene with circles based on the provided detections.
 
         Args:
             scene: The image where box corners will be drawn.
@@ -1241,8 +1233,7 @@ class DotAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with dots based on the provided detections.
+        """Annotates the given scene with dots based on the provided detections.
 
         Args:
             scene: The image where dots will be drawn.
@@ -1370,8 +1361,7 @@ class LabelAnnotator(_BaseLabelAnnotator):
         labels: list[str] | None = None,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with labels based on the provided detections.
+        """Annotates the given scene with labels based on the provided detections.
 
         Args:
             scene: The image where labels will be drawn.
@@ -1722,9 +1712,8 @@ class RichLabelAnnotator(_BaseLabelAnnotator):
         labels: list[str] | None = None,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with labels based on the provided
-        detections, with support for Unicode characters.
+        """Annotates the given scene with labels based on the provided detections, with
+        support for Unicode characters.
 
         Args:
             scene: The image where labels will be drawn.
@@ -1958,8 +1947,7 @@ class IconAnnotator(BaseAnnotator):
         detections: Detections,
         icon_path: str | list[str] = "",
     ) -> ImageType:
-        """
-        Annotates the given scene with given icons.
+        """Annotates the given scene with given icons.
 
         Args:
             scene: The image where labels will be drawn.
@@ -2050,8 +2038,8 @@ class BlurAnnotator(BaseAnnotator):
         scene: ImageType,
         detections: Detections,
     ) -> ImageType:
-        """
-        Annotates the given scene by blurring regions based on the provided detections.
+        """Annotates the given scene by blurring regions based on the provided
+        detections.
 
         Args:
             scene: The image where blurring will be applied.
@@ -2147,10 +2135,8 @@ class TraceAnnotator(BaseAnnotator):
         self.color_lookup: ColorLookup = color_lookup
 
     def reset(self) -> None:
-        """
-        Clears the accumulated trace history so the annotator can be reused
-        across independent streams without carrying over points from a
-        previous stream.
+        """Clears the accumulated trace history so the annotator can be reused across
+        independent streams without carrying over points from a previous stream.
 
         Examples:
             ```pycon
@@ -2183,8 +2169,7 @@ class TraceAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Draws trace paths on the frame based on the detection coordinates provided.
+        """Draws trace paths on the frame based on the detection coordinates provided.
 
         Args:
             scene: The image on which the traces will be drawn.
@@ -2373,11 +2358,10 @@ class HeatMapAnnotator(BaseAnnotator):
         self.heat_mask: npt.NDArray[np.float32] | None = None
 
     def reset(self) -> None:
-        """
-        Clears the accumulated heat so the annotator can be reused across
-        independent streams. `annotate` already reinitializes the heat mask
-        when the scene resolution changes; call this to discard heat from a
-        previous stream that shares the same resolution.
+        """Clears the accumulated heat so the annotator can be reused across independent
+        streams. `annotate` already reinitializes the heat mask when the scene
+        resolution changes; call this to discard heat from a previous stream that shares
+        the same resolution.
 
         Examples:
             ```pycon
@@ -2402,8 +2386,7 @@ class HeatMapAnnotator(BaseAnnotator):
 
     @ensure_cv2_image_for_class_method
     def annotate(self, scene: ImageType, detections: Detections) -> ImageType:
-        """
-        Annotates the scene with a heatmap based on the provided detections.
+        """Annotates the scene with a heatmap based on the provided detections.
 
         Args:
             scene: The image where the heatmap will be drawn.
@@ -2521,9 +2504,8 @@ class PixelateAnnotator(BaseAnnotator):
         scene: ImageType,
         detections: Detections,
     ) -> ImageType:
-        """
-        Annotates the given scene by pixelating regions based on the provided
-            detections.
+        """Annotates the given scene by pixelating regions based on the provided
+        detections.
 
         Args:
             scene: The image where pixelating will be applied.
@@ -2638,8 +2620,7 @@ class TriangleAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with triangles based on the provided detections.
+        """Annotates the given scene with triangles based on the provided detections.
 
         Args:
             scene: The image where triangles will be drawn.
@@ -2752,9 +2733,8 @@ class RoundBoxAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with bounding boxes with rounded edges
-        based on the provided detections.
+        """Annotates the given scene with bounding boxes with rounded edges based on the
+        provided detections.
 
         Args:
             scene: The image where rounded bounding boxes will be drawn.
@@ -2895,8 +2875,7 @@ class PercentageBarAnnotator(BaseAnnotator):
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
         custom_values: npt.NDArray[np.float64] | None = None,
     ) -> ImageType:
-        """
-        Annotates the given scene with percentage bars based on the provided
+        """Annotates the given scene with percentage bars based on the provided
         detections. The percentage bars visually represent the confidence or custom
         values associated with each detection.
 
@@ -3093,12 +3072,10 @@ class CropAnnotator(BaseAnnotator):
         detections: Detections,
         custom_color_lookup: npt.NDArray[np.int_] | None = None,
     ) -> ImageType:
-        """
-        Annotates the provided scene with scaled and cropped parts of the image based
+        """Annotates the provided scene with scaled and cropped parts of the image based
         on the provided detections. Each detection is cropped from the original scene
         and scaled according to the annotator's scale factor before being placed back
         onto the scene at the specified position.
-
 
         Args:
             scene: The image where cropped detection will be placed.
@@ -3257,8 +3234,7 @@ class BackgroundOverlayAnnotator(BaseAnnotator):
 
     @ensure_cv2_image_for_class_method
     def annotate(self, scene: ImageType, detections: Detections) -> ImageType:
-        """
-        Applies a colored overlay to the scene outside of the detected regions.
+        """Applies a colored overlay to the scene outside of the detected regions.
 
         Args:
             scene: The image where masks will be drawn.
@@ -3368,8 +3344,7 @@ class ComparisonAnnotator:
     def annotate(
         self, scene: ImageType, detections_1: Detections, detections_2: Detections
     ) -> ImageType:
-        """
-        Highlights the differences between two sets of detections.
+        """Highlights the differences between two sets of detections.
 
         Args:
             scene: The image where detections will be drawn.

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -70,7 +70,8 @@ def _load_icon_from_path(
 
 
 def _normalize_color_input(color: Color | ColorPalette | str) -> Color | ColorPalette:
-    """Normalize accepted color inputs to internal color objects.
+    """
+    Normalize accepted color inputs to internal color objects.
 
     Accepts `Color`, `ColorPalette`, or hex string input. Hex strings are parsed via
     `hex_to_rgba` and converted to `Color` (alpha channel is ignored because annotator
@@ -196,9 +197,7 @@ class _BaseLabelAnnotator(BaseAnnotator):
 
 
 class BoxAnnotator(BaseAnnotator):
-    """
-    A class for drawing bounding boxes on an image using provided detections.
-    """
+    """A class for drawing bounding boxes on an image using provided detections."""
 
     def __init__(
         self,
@@ -283,8 +282,8 @@ class BoxAnnotator(BaseAnnotator):
 
 
 class OrientedBoxAnnotator(BaseAnnotator):
-    """
-    A class for drawing oriented bounding boxes on an image using provided detections.
+    """A class for drawing oriented bounding boxes on an image using provided
+    detections.
     """
 
     def __init__(
@@ -392,7 +391,8 @@ class OrientedBoxAnnotator(BaseAnnotator):
 def _iter_mask_crops(
     detections: Detections,
 ) -> Iterator[tuple[int, npt.NDArray[np.bool_], npt.NDArray[np.int32] | None]]:
-    """Yield ``(detection_idx, mask_or_crop, offset_or_None)`` for each mask.
+    """
+    Yield ``(detection_idx, mask_or_crop, offset_or_None)`` for each mask.
 
     Encapsulates the ``CompactMask`` vs dense dispatch so individual annotators
     do not need inline ``isinstance`` checks. For ``CompactMask`` inputs yields
@@ -436,7 +436,8 @@ def _paint_masks_by_area(
     collect_union: bool = False,
     canvas_origin: tuple[int, int] = (0, 0),
 ) -> npt.NDArray[np.bool_] | None:
-    """Paint each detection's mask into `canvas` in descending-area order.
+    """
+    Paint each detection's mask into `canvas` in descending-area order.
 
     Smaller masks are drawn on top of larger ones. `CompactMask` detections
     are painted into their bounding-box crop only, avoiding a full `(H, W)`
@@ -517,7 +518,7 @@ class MaskAnnotator(BaseAnnotator):
 
     !!! warning
 
-        This annotator uses `sv.Detections.mask`.
+    This annotator uses `sv.Detections.mask`.
     """
 
     requires_mask = True
@@ -626,7 +627,7 @@ class PolygonAnnotator(BaseAnnotator):
 
     !!! warning
 
-        This annotator uses `sv.Detections.mask`.
+    This annotator uses `sv.Detections.mask`.
     """
 
     requires_mask = True
@@ -728,9 +729,7 @@ class PolygonAnnotator(BaseAnnotator):
 
 
 class ColorAnnotator(BaseAnnotator):
-    """
-    A class for drawing box masks on an image using provided detections.
-    """
+    """A class for drawing box masks on an image using provided detections."""
 
     def __init__(
         self,
@@ -825,7 +824,7 @@ class HaloAnnotator(BaseAnnotator):
 
     !!! warning
 
-        This annotator uses `sv.Detections.mask`.
+    This annotator uses `sv.Detections.mask`.
     """
 
     requires_mask = True
@@ -933,9 +932,7 @@ class HaloAnnotator(BaseAnnotator):
 
 
 class EllipseAnnotator(BaseAnnotator):
-    """
-    A class for drawing ellipses on an image using provided detections.
-    """
+    """A class for drawing ellipses on an image using provided detections."""
 
     def __init__(
         self,
@@ -1032,9 +1029,7 @@ class EllipseAnnotator(BaseAnnotator):
 
 
 class BoxCornerAnnotator(BaseAnnotator):
-    """
-    A class for drawing box corners on an image using provided detections.
-    """
+    """A class for drawing box corners on an image using provided detections."""
 
     def __init__(
         self,
@@ -1127,9 +1122,7 @@ class BoxCornerAnnotator(BaseAnnotator):
 
 
 class CircleAnnotator(BaseAnnotator):
-    """
-    A class for drawing circle on an image using provided detections.
-    """
+    """A class for drawing circle on an image using provided detections."""
 
     def __init__(
         self,
@@ -1145,7 +1138,6 @@ class CircleAnnotator(BaseAnnotator):
             color_lookup: Strategy for mapping colors to annotations.
                 Options are `INDEX`, `CLASS`, `TRACK`.
         """
-
         self.color: Color | ColorPalette = _normalize_color_input(color)
         self.thickness: int = thickness
         self.color_lookup: ColorLookup = color_lookup
@@ -1219,8 +1211,7 @@ class CircleAnnotator(BaseAnnotator):
 
 
 class DotAnnotator(BaseAnnotator):
-    """
-    A class for drawing dots on an image at specific coordinates based on provided
+    """A class for drawing dots on an image at specific coordinates based on provided
     detections.
     """
 
@@ -1330,9 +1321,7 @@ class DotAnnotator(BaseAnnotator):
 
 
 class LabelAnnotator(_BaseLabelAnnotator):
-    """
-    A class for annotating labels on an image using provided detections.
-    """
+    """A class for annotating labels on an image using provided detections."""
 
     def __init__(
         self,
@@ -1682,9 +1671,8 @@ class LabelAnnotator(_BaseLabelAnnotator):
 
 
 class RichLabelAnnotator(_BaseLabelAnnotator):
-    """
-    A class for annotating labels on an image using provided detections,
-    with support for Unicode characters by using a custom font.
+    """A class for annotating labels on an image using provided detections, with support
+    for Unicode characters by using a custom font.
     """
 
     def __init__(
@@ -1954,9 +1942,7 @@ class RichLabelAnnotator(_BaseLabelAnnotator):
 
 
 class IconAnnotator(BaseAnnotator):
-    """
-    A class for drawing an icon on an image, using provided detections.
-    """
+    """A class for drawing an icon on an image, using provided detections."""
 
     def __init__(
         self,
@@ -2056,9 +2042,7 @@ class IconAnnotator(BaseAnnotator):
 
 
 class BlurAnnotator(BaseAnnotator):
-    """
-    A class for blurring regions in an image using provided detections.
-    """
+    """A class for blurring regions in an image using provided detections."""
 
     def __init__(self, kernel_size: int | None = None):
         """
@@ -2139,9 +2123,8 @@ class TraceAnnotator(BaseAnnotator):
 
     !!! warning
 
-        This annotator uses the `sv.Detections.tracker_id`. Read
-        [here](/latest/trackers/) to learn how to plug
-        tracking into your inference pipeline.
+    This annotator uses the `sv.Detections.tracker_id`. Read [here](/latest/trackers/)
+    to learn how to plug tracking into your inference pipeline.
     """
 
     def __init__(
@@ -2369,8 +2352,9 @@ class TraceAnnotator(BaseAnnotator):
 class HeatMapAnnotator(BaseAnnotator):
     """
     A class for drawing heatmaps on an image based on provided detections.
-    Heat accumulates over time and is drawn as a semi-transparent overlay
-    of blurred circles.
+
+    Heat accumulates over time and is drawn as a semi-transparent overlay of blurred
+    circles.
     """
 
     def __init__(
@@ -2529,9 +2513,7 @@ class HeatMapAnnotator(BaseAnnotator):
 
 
 class PixelateAnnotator(BaseAnnotator):
-    """
-    A class for pixelating regions in an image using provided detections.
-    """
+    """A class for pixelating regions in an image using provided detections."""
 
     def __init__(self, pixel_size: int | None = None):
         """
@@ -2627,8 +2609,7 @@ class PixelateAnnotator(BaseAnnotator):
 
 
 class TriangleAnnotator(BaseAnnotator):
-    """
-    A class for drawing triangle markers on an image at specific coordinates based on
+    """A class for drawing triangle markers on an image at specific coordinates based on
     provided detections.
     """
 
@@ -2749,9 +2730,8 @@ class TriangleAnnotator(BaseAnnotator):
 
 
 class RoundBoxAnnotator(BaseAnnotator):
-    """
-    A class for drawing bounding boxes with round edges on an image
-    using provided detections.
+    """A class for drawing bounding boxes with round edges on an image using provided
+    detections.
     """
 
     def __init__(
@@ -2885,9 +2865,7 @@ class RoundBoxAnnotator(BaseAnnotator):
 
 
 class PercentageBarAnnotator(BaseAnnotator):
-    """
-    A class for drawing percentage bars on an image using provided detections.
-    """
+    """A class for drawing percentage bars on an image using provided detections."""
 
     def __init__(
         self,
@@ -3094,9 +3072,7 @@ class PercentageBarAnnotator(BaseAnnotator):
 
 
 class CropAnnotator(BaseAnnotator):
-    """
-    A class for drawing scaled up crops of detections on the scene.
-    """
+    """A class for drawing scaled up crops of detections on the scene."""
 
     def __init__(
         self,
@@ -3265,17 +3241,17 @@ class CropAnnotator(BaseAnnotator):
 
 class BackgroundOverlayAnnotator(BaseAnnotator):
     """
-    A class for drawing a colored overlay on the background of an image outside
-    the region of detections.
+    A class for drawing a colored overlay on the background of an image outside the
+    region of detections.
 
-    If masks are provided, the background is colored outside the masks.
-    If masks are not provided, the background is colored outside the bounding boxes.
+    If masks are provided, the background is colored outside the masks. If masks are not
+    provided, the background is colored outside the bounding boxes.
 
     You can use the `force_box` parameter to force the annotator to use bounding boxes.
 
     !!! warning
 
-        This annotator uses `sv.Detections.mask`.
+    This annotator uses `sv.Detections.mask`.
     """
 
     def __init__(
@@ -3357,12 +3333,11 @@ class BackgroundOverlayAnnotator(BaseAnnotator):
 
 class ComparisonAnnotator:
     """
-    Highlights the differences between two sets of detections.
-    Useful for comparing results from two different models, or the difference
-    between a ground truth and a prediction.
+    Highlights the differences between two sets of detections. Useful for comparing
+    results from two different models, or the difference between a ground truth and a
+    prediction.
 
-    If present, uses the oriented bounding box data.
-    Otherwise, if present, uses a mask.
+    If present, uses the oriented bounding box data. Otherwise, if present, uses a mask.
     Otherwise, uses the bounding box data.
     """
 
@@ -3394,7 +3369,6 @@ class ComparisonAnnotator:
             label_overlap: Label for areas present in both sets of detections.
             label_scale: Controls how large the labels are.
         """
-
         self.color_1 = color_1
         self.color_2 = color_2
         self.color_overlap = color_overlap

--- a/src/supervision/annotators/utils.py
+++ b/src/supervision/annotators/utils.py
@@ -168,8 +168,8 @@ def resolve_color(
 
 def wrap_text(text: object, max_line_length: int | None = None) -> list[str]:
     """
-    Wrap `text` to the specified maximum line length, respecting existing
-    newlines. Falls back to str() if `text` is not already a string.
+    Wrap `text` to the specified maximum line length, respecting existing newlines.
+    Falls back to str() if `text` is not already a string.
 
     Args:
         text: The text (or object) to wrap.
@@ -178,7 +178,6 @@ def wrap_text(text: object, max_line_length: int | None = None) -> list[str]:
     Returns:
         Wrapped lines.
     """
-
     if not text:
         return [""]
 
@@ -373,7 +372,8 @@ class Trace:
         self.tracker_id: npt.NDArray[np.int_] = np.array([], dtype=int)
 
     def put(self, detections: Detections) -> None:
-        """Append a frame of detections to the trace history.
+        """
+        Append a frame of detections to the trace history.
 
         A frame that detected nothing contributes no points but still advances
         the frame counter, keeping `max_size` a window over elapsed frames
@@ -430,11 +430,12 @@ class Trace:
         return xy
 
     def reset(self) -> None:
-        """Restore the trace buffers to their initial empty state.
+        """
+        Restore the trace buffers to their initial empty state.
 
-        Clears the accumulated `frame_id`, `xy`, and `tracker_id` history and
-        rewinds `current_frame_id` to `0`, so the trace can be reused across
-        independent streams without carrying over points from a previous run.
+        Clears the accumulated `frame_id`, `xy`, and `tracker_id` history and rewinds
+        `current_frame_id` to `0`, so the trace can be reused across independent streams
+        without carrying over points from a previous run.
         """
         self.current_frame_id = 0
         self.frame_id = np.array([], dtype=int)

--- a/src/supervision/annotators/utils.py
+++ b/src/supervision/annotators/utils.py
@@ -290,11 +290,10 @@ def snap_boxes(
     xyxy: npt.NDArray[np.float32],
     resolution_wh: tuple[int, int],
 ) -> npt.NDArray[np.float32]:
-    """
-    Shifts `label` bounding boxes into the frame so that they are fully contained
-    within the given resolution, prioritizing the top/left edge.
-    Unlike `clip_boxes`, this function does not crop boxes.
-    It moves them entirely if they exceed the frame boundaries.
+    """Shifts `label` bounding boxes into the frame so that they are fully contained
+    within the given resolution, prioritizing the top/left edge. Unlike `clip_boxes`,
+    this function does not crop boxes. It moves them entirely if they exceed the frame
+    boundaries.
 
     Args:
         xyxy: A numpy array of shape `(N, 4)` where each

--- a/src/supervision/annotators/utils.py
+++ b/src/supervision/annotators/utils.py
@@ -17,8 +17,7 @@ PENDING_TRACK_ID = -1
 
 
 class ColorLookup(Enum):
-    """
-    Enumeration class to define strategies for mapping colors to annotations.
+    """Enumeration class to define strategies for mapping colors to annotations.
 
     This enum supports three different lookup strategies:
         - `INDEX`: Colors are determined by the index of the detection within the scene.
@@ -167,8 +166,7 @@ def resolve_color(
 
 
 def wrap_text(text: object, max_line_length: int | None = None) -> list[str]:
-    """
-    Wrap `text` to the specified maximum line length, respecting existing newlines.
+    """Wrap `text` to the specified maximum line length, respecting existing newlines.
     Falls back to str() if `text` is not already a string.
 
     Args:
@@ -212,8 +210,7 @@ def wrap_text(text: object, max_line_length: int | None = None) -> list[str]:
 
 
 def _validate_labels(labels: list[str] | None, detections: Detections) -> None:
-    """
-    Validates that the number of provided labels matches the number of detections.
+    """Validates that the number of provided labels matches the number of detections.
 
     Args:
         labels: A list of labels, one for each detection. Can
@@ -244,8 +241,7 @@ def validate_labels(labels: list[str] | None, detections: Detections) -> None:
 def get_labels_text(
     detections: Detections, custom_labels: list[str] | None
 ) -> list[str]:
-    """
-    Retrieves the text labels for the detections.
+    """Retrieves the text labels for the detections.
 
     If `custom_labels` are provided, they are used. Otherwise, the labels are
     extracted from the `detections` object, prioritizing the 'class_name' field,
@@ -372,8 +368,7 @@ class Trace:
         self.tracker_id: npt.NDArray[np.int_] = np.array([], dtype=int)
 
     def put(self, detections: Detections) -> None:
-        """
-        Append a frame of detections to the trace history.
+        """Append a frame of detections to the trace history.
 
         A frame that detected nothing contributes no points but still advances
         the frame counter, keeping `max_size` a window over elapsed frames
@@ -430,8 +425,7 @@ class Trace:
         return xy
 
     def reset(self) -> None:
-        """
-        Restore the trace buffers to their initial empty state.
+        """Restore the trace buffers to their initial empty state.
 
         Clears the accumulated `frame_id`, `xy`, and `tracker_id` history and rewinds
         `current_frame_id` to `0`, so the trace can be reused across independent streams
@@ -444,8 +438,7 @@ class Trace:
 
 
 def hex_to_rgba(hex_color: str) -> tuple[int, int, int, int]:
-    """
-    Converts a hex color string (e.g. "#FF00FF" or "#FF00FF80") to an RGBA tuple.
+    """Converts a hex color string (e.g. "#FF00FF" or "#FF00FF80") to an RGBA tuple.
 
     Args:
         hex_color: A hex color string.
@@ -482,8 +475,7 @@ def hex_to_rgba(hex_color: str) -> tuple[int, int, int, int]:
 
 
 def rgba_to_hex(rgba: tuple[int, int, int, int]) -> str:
-    """
-    Converts an RGBA tuple (0-255 each) to a hex color string.
+    """Converts an RGBA tuple (0-255 each) to a hex color string.
 
     Args:
         rgba: RGBA values in range 0-255.
@@ -508,8 +500,7 @@ def rgba_to_hex(rgba: tuple[int, int, int, int]) -> str:
 
 
 def is_valid_hex(hex_color: str) -> bool:
-    """
-    Checks if a given string is a valid hex color.
+    """Checks if a given string is a valid hex color.
 
     Args:
         hex_color: A hex color string with an optional leading "#". Supports
@@ -532,8 +523,7 @@ def is_valid_hex(hex_color: str) -> bool:
 
 
 def calculate_dynamic_kernel_size(x1: int, y1: int, x2: int, y2: int) -> int:
-    """
-    Computes a blur kernel size proportional to the shorter side of a bounding box.
+    """Computes a blur kernel size proportional to the shorter side of a bounding box.
 
     Args:
         x1: Left edge of the bounding box.
@@ -555,8 +545,7 @@ def calculate_dynamic_kernel_size(x1: int, y1: int, x2: int, y2: int) -> int:
 
 
 def calculate_dynamic_pixel_size(x1: int, y1: int, x2: int, y2: int) -> int:
-    """
-    Computes a pixelation size proportional to the shorter side of a bounding box.
+    """Computes a pixelation size proportional to the shorter side of a bounding box.
 
     Args:
         x1: Left edge of the bounding box.

--- a/src/supervision/assets/downloader.py
+++ b/src/supervision/assets/downloader.py
@@ -10,8 +10,7 @@ logger = _get_logger(__name__)
 
 
 def is_md5_hash_matching(filename: str | Path, original_md5_hash: str) -> bool:
-    """
-    Check if the MD5 hash of a file matches the original hash.
+    """Check if the MD5 hash of a file matches the original hash.
 
     Note: MD5 is used here for file integrity checking (detecting corruption),
     not for cryptographic security purposes.
@@ -71,8 +70,7 @@ def download_assets(
     asset_name: Assets | str,
     directory: str | Path | None = None,
 ) -> str:
-    """
-    Download a specified asset if it doesn't already exist or is corrupted.
+    """Download a specified asset if it doesn't already exist or is corrupted.
 
     Args:
         asset_name: The name or type of the asset to be downloaded.

--- a/src/supervision/assets/downloader.py
+++ b/src/supervision/assets/downloader.py
@@ -34,9 +34,7 @@ def is_md5_hash_matching(filename: str | Path, original_md5_hash: str) -> bool:
 
 
 def _download_asset(filename: str, destination: Path) -> None:
-    """
-    Download asset bytes to the target destination via a temporary file.
-    """
+    """Download asset bytes to the target destination via a temporary file."""
     _download_to_file(MEDIA_ASSETS[filename][0], destination, timeout=30.0, stream=True)
 
 
@@ -47,9 +45,7 @@ def _download_verified_asset(
     check_target: str | Path,
     retry_on_mismatch: bool = True,
 ) -> None:
-    """
-    Download an asset and reject payloads whose MD5 does not match the catalog.
-    """
+    """Download an asset and reject payloads whose MD5 does not match the catalog."""
     _download_asset(filename, destination)
 
     if is_md5_hash_matching(check_target, original_md5_hash):
@@ -98,7 +94,6 @@ def download_assets(
 
         ```
     """
-
     filename = asset_name.filename if isinstance(asset_name, Assets) else asset_name
     if directory is None:
         destination = Path.cwd() / filename

--- a/src/supervision/assets/list.py
+++ b/src/supervision/assets/list.py
@@ -24,8 +24,9 @@ class Assets(Enum):
 
 class VideoAssets(Assets):
     """
-    Each member of this class represents a video asset. The value associated with each
-    member has a filename and hash of the video. File names and links can be seen below.
+    Each member of this class represents a video asset.
+
+    The value associated with each member has a filename and hash of the video. File names and links can be seen below.
 
     | Asset                  | Video Filename             | Video URL                                                                             |
     |------------------------|----------------------------|---------------------------------------------------------------------------------------|
@@ -58,14 +59,14 @@ class VideoAssets(Assets):
 
 class ImageAssets(Assets):
     """
-    Each member of this enum represents a image asset. The value associated with each
-    member is the filename of the image.
+    Each member of this enum represents a image asset.
+
+    The value associated with each member is the filename of the image.
 
     | Asset              | Image Filename         | Video URL                                                                             |
     |--------------------|------------------------|---------------------------------------------------------------------------------------|
     | `PEOPLE_WALKING`   | `people-walking.jpg`   | [Link](https://media.roboflow.com/supervision/image-examples/people-walking.jpg)      |
     | `SOCCER`           | `soccer.jpg`           | [Link](https://media.roboflow.com/supervision/image-examples/soccer.jpg)              |
-
     """  # noqa: E501 // docs
 
     PEOPLE_WALKING = ("people-walking.jpg", "e6bda00b47f2908eeae7df86ef995dcd")

--- a/src/supervision/assets/list.py
+++ b/src/supervision/assets/list.py
@@ -23,8 +23,7 @@ class Assets(Enum):
 
 
 class VideoAssets(Assets):
-    """
-    Each member of this class represents a video asset.
+    """Each member of this class represents a video asset.
 
     The value associated with each member has a filename and hash of the video. File names and links can be seen below.
 
@@ -58,8 +57,7 @@ class VideoAssets(Assets):
 
 
 class ImageAssets(Assets):
-    """
-    Each member of this enum represents a image asset.
+    """Each member of this enum represents a image asset.
 
     The value associated with each member is the filename of the image.
 

--- a/src/supervision/classification/core.py
+++ b/src/supervision/classification/core.py
@@ -11,18 +11,14 @@ if TYPE_CHECKING:
 
 
 def _validate_class_ids(class_id: Any, n: int) -> None:
-    """
-    Ensure that class_id is a 1d np.ndarray with (n, ) shape.
-    """
+    """Ensure that class_id is a 1d np.ndarray with (n, ) shape."""
     is_valid = isinstance(class_id, np.ndarray) and class_id.shape == (n,)
     if not is_valid:
         raise ValueError("class_id must be 1d np.ndarray with (n, ) shape")
 
 
 def _validate_confidence(confidence: Any, n: int) -> None:
-    """
-    Ensure that confidence is a 1d np.ndarray with (n, ) shape.
-    """
+    """Ensure that confidence is a 1d np.ndarray with (n, ) shape."""
     if confidence is not None:
         is_valid = isinstance(confidence, np.ndarray) and confidence.shape == (n,)
         if not is_valid:
@@ -35,18 +31,14 @@ class Classifications:
     confidence: npt.NDArray[np.floating] | None = None
 
     def __post_init__(self) -> None:
-        """
-        Validate the classification inputs.
-        """
+        """Validate the classification inputs."""
         n = len(self.class_id)
 
         _validate_class_ids(self.class_id, n)
         _validate_confidence(self.confidence, n)
 
     def __eq__(self, other: object) -> bool:
-        """
-        Compare classifications by value across numpy-backed fields.
-        """
+        """Compare classifications by value across numpy-backed fields."""
         if not isinstance(other, Classifications):
             return NotImplemented
         if not np.array_equal(self.class_id, other.class_id):
@@ -56,9 +48,7 @@ class Classifications:
         return bool(np.array_equal(self.confidence, other.confidence))
 
     def __len__(self) -> int:
-        """
-        Returns the number of classifications.
-        """
+        """Returns the number of classifications."""
         return len(self.class_id)
 
     @classmethod

--- a/src/supervision/classification/core.py
+++ b/src/supervision/classification/core.py
@@ -172,9 +172,8 @@ class Classifications:
     def get_top_k(
         self, k: int
     ) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.floating]]:
-        """
-        Retrieve the top k class IDs and confidences,
-            ordered in descending order by confidence.
+        """Retrieve the top k class IDs and confidences, ordered in descending order by
+        confidence.
 
         Args:
             k: The number of top class IDs and confidences to retrieve.

--- a/src/supervision/dataset/core.py
+++ b/src/supervision/dataset/core.py
@@ -70,8 +70,7 @@ class BaseDataset(ABC):
 
 
 class DetectionDataset(BaseDataset):
-    """
-    Contains information about a detection dataset.
+    """Contains information about a detection dataset.
 
     Handles lazy image loading and annotation retrieval, dataset splitting, conversions into multiple
     formats.
@@ -171,8 +170,7 @@ class DetectionDataset(BaseDataset):
         return image_path, image, annotation
 
     def __iter__(self) -> Iterator[tuple[str, npt.NDArray[np.uint8], Detections]]:
-        """
-        Iterate over the images and annotations in the dataset.
+        """Iterate over the images and annotations in the dataset.
 
         Yields:
             Tuples containing the image path, image data, and its annotation.
@@ -387,8 +385,7 @@ class DetectionDataset(BaseDataset):
         approximation_percentage: float = 0.0,
         show_progress: bool = False,
     ) -> None:
-        """
-        Exports the dataset to PASCAL VOC format.
+        """Exports the dataset to PASCAL VOC format.
 
         This method saves the images and their corresponding annotations in PASCAL VOC format. Both output
         layouts are preflighted before any files are written so a collision in
@@ -586,8 +583,7 @@ class DetectionDataset(BaseDataset):
         is_obb: bool = False,
         show_progress: bool = False,
     ) -> None:
-        """
-        Exports the dataset to YOLO format.
+        """Exports the dataset to YOLO format.
 
         This method saves the images and their corresponding annotations in YOLO format.
 
@@ -1040,8 +1036,7 @@ class DetectionDataset(BaseDataset):
 
 @dataclass
 class ClassificationDataset(BaseDataset):
-    """
-    Contains information about a classification dataset, handles lazy image loading,
+    """Contains information about a classification dataset, handles lazy image loading,
     dataset splitting.
 
     Attributes:
@@ -1104,8 +1099,7 @@ class ClassificationDataset(BaseDataset):
     def __iter__(
         self,
     ) -> Iterator[tuple[str, npt.NDArray[np.uint8], Classifications]]:
-        """
-        Iterate over the images and annotations in the dataset.
+        """Iterate over the images and annotations in the dataset.
 
         Yields:
             Tuples containing the image path, image data, and its annotation.
@@ -1212,8 +1206,7 @@ class ClassificationDataset(BaseDataset):
     def as_folder_structure(
         self, root_directory_path: str, show_progress: bool = False
     ) -> None:
-        """
-        Saves the dataset as a multi-class folder structure.
+        """Saves the dataset as a multi-class folder structure.
 
         Images assigned to the same class must have unique basenames
         (case-insensitive). Conflicts are rejected before any files are written.

--- a/src/supervision/dataset/core.py
+++ b/src/supervision/dataset/core.py
@@ -72,8 +72,8 @@ class BaseDataset(ABC):
 class DetectionDataset(BaseDataset):
     """Contains information about a detection dataset.
 
-    Handles lazy image loading and annotation retrieval, dataset splitting, conversions into multiple
-    formats.
+    Handles lazy image loading and annotation retrieval, dataset splitting, conversions
+    into multiple formats.
 
     Attributes:
         classes: List containing dataset class names.
@@ -207,9 +207,8 @@ class DetectionDataset(BaseDataset):
         random_state: int | None = None,
         shuffle: bool = True,
     ) -> tuple[DetectionDataset, DetectionDataset]:
-        """
-        Splits the dataset into two parts (training and testing)
-            using the provided split_ratio. The input dataset is not mutated.
+        """Splits the dataset into two parts (training and testing) using the provided
+        split_ratio. The input dataset is not mutated.
 
         Args:
             split_ratio: The ratio of the training
@@ -275,9 +274,8 @@ class DetectionDataset(BaseDataset):
 
     @classmethod
     def merge(cls, dataset_list: list[DetectionDataset]) -> DetectionDataset:
-        """
-        Merge a list of `DetectionDataset` objects into a single
-            `DetectionDataset` object.
+        """Merge a list of `DetectionDataset` objects into a single `DetectionDataset`
+        object.
 
         This method takes a list of `DetectionDataset` objects and combines
         their respective fields (`classes`, `images`,
@@ -387,9 +385,9 @@ class DetectionDataset(BaseDataset):
     ) -> None:
         """Exports the dataset to PASCAL VOC format.
 
-        This method saves the images and their corresponding annotations in PASCAL VOC format. Both output
-        layouts are preflighted before any files are written so a collision in
-        either target fails without partial output.
+        This method saves the images and their corresponding annotations in PASCAL VOC
+        format. Both output layouts are preflighted before any files are written so a
+        collision in either target fails without partial output.
 
         Args:
             images_directory_path: The path to the directory
@@ -455,8 +453,7 @@ class DetectionDataset(BaseDataset):
         force_masks: bool = False,
         show_progress: bool = False,
     ) -> DetectionDataset:
-        """
-        Creates a Dataset instance from PASCAL VOC formatted data.
+        """Creates a Dataset instance from PASCAL VOC formatted data.
 
         Args:
             images_directory_path: Path to the directory containing the images.
@@ -515,8 +512,7 @@ class DetectionDataset(BaseDataset):
         is_obb: bool = False,
         show_progress: bool = False,
     ) -> DetectionDataset:
-        """
-        Creates a Dataset instance from YOLO formatted data.
+        """Creates a Dataset instance from YOLO formatted data.
 
         Args:
             images_directory_path: The path to the
@@ -677,8 +673,7 @@ class DetectionDataset(BaseDataset):
         annotations_directory_path: str,
         force_masks: bool = False,
     ) -> DetectionDataset:
-        """
-        Creates a Dataset instance from LabelMe formatted data.
+        """Creates a Dataset instance from LabelMe formatted data.
 
         LabelMe stores one JSON file per image, each containing a list of
         ``shapes``. ``rectangle`` shapes are loaded as bounding boxes and
@@ -734,14 +729,13 @@ class DetectionDataset(BaseDataset):
         images_directory_path: str | None = None,
         annotations_directory_path: str | None = None,
     ) -> None:
-        """
-        Exports the dataset to LabelMe format. This method saves the images and
-        their corresponding annotations as per-image LabelMe ``.json`` files.
-        Masked detections are written as ``polygon`` shapes whose vertices
-        approximate the mask contour, so masks are not bit-exact on round-trip.
-        Because the bounding box is recomputed from the quantized polygon contour
-        on re-import, bounding boxes for masked detections may also shift by
-        approximately one pixel after a save-load cycle.
+        """Exports the dataset to LabelMe format. This method saves the images and their
+        corresponding annotations as per-image LabelMe ``.json`` files. Masked
+        detections are written as ``polygon`` shapes whose vertices approximate the mask
+        contour, so masks are not bit-exact on round-trip. Because the bounding box is
+        recomputed from the quantized polygon contour on re-import, bounding boxes for
+        masked detections may also shift by approximately one pixel after a save-load
+        cycle.
 
         Args:
             images_directory_path: The path to the directory
@@ -780,8 +774,7 @@ class DetectionDataset(BaseDataset):
         annotations_path: str,
         show_progress: bool = False,
     ) -> DetectionDataset:
-        """
-        Creates a Dataset instance from CreateML formatted data.
+        """Creates a Dataset instance from CreateML formatted data.
 
         CreateML stores object-detection annotations in a single JSON file as a
         list of per-image entries, with each box expressed as a pixel-space
@@ -834,9 +827,8 @@ class DetectionDataset(BaseDataset):
         annotations_path: str | None = None,
         show_progress: bool = False,
     ) -> None:
-        """
-        Exports the dataset to CreateML format. This method saves the
-        images and their corresponding annotations in CreateML format.
+        """Exports the dataset to CreateML format. This method saves the images and
+        their corresponding annotations in CreateML format.
 
         Args:
             images_directory_path: The path to the directory where the images
@@ -881,8 +873,7 @@ class DetectionDataset(BaseDataset):
         *,
         use_iscrowd: bool = True,
     ) -> DetectionDataset:
-        """
-        Creates a Dataset instance from COCO formatted data.
+        """Creates a Dataset instance from COCO formatted data.
 
         Args:
             images_directory_path: The path to the
@@ -940,9 +931,8 @@ class DetectionDataset(BaseDataset):
         starting_annotation_id: int = 1,
         show_progress: bool = False,
     ) -> tuple[int, int]:
-        """
-        Exports the dataset to COCO format. This method saves the
-        images and their corresponding annotations in COCO format.
+        """Exports the dataset to COCO format. This method saves the images and their
+        corresponding annotations in COCO format.
 
         !!! tip
 
@@ -1136,9 +1126,8 @@ class ClassificationDataset(BaseDataset):
         random_state: int | None = None,
         shuffle: bool = True,
     ) -> tuple[ClassificationDataset, ClassificationDataset]:
-        """
-        Splits the dataset into two parts (training and testing)
-            using the provided split_ratio.
+        """Splits the dataset into two parts (training and testing) using the provided
+        split_ratio.
 
         Args:
             split_ratio: The ratio of the training
@@ -1256,8 +1245,7 @@ class ClassificationDataset(BaseDataset):
     def from_folder_structure(
         cls, root_directory_path: str, show_progress: bool = False
     ) -> ClassificationDataset:
-        """
-        Load data from a multiclass folder structure into a ClassificationDataset.
+        """Load data from a multiclass folder structure into a ClassificationDataset.
 
         Args:
             root_directory_path: The path to the dataset directory. Hidden

--- a/src/supervision/dataset/core.py
+++ b/src/supervision/dataset/core.py
@@ -71,8 +71,9 @@ class BaseDataset(ABC):
 
 class DetectionDataset(BaseDataset):
     """
-    Contains information about a detection dataset. Handles lazy image loading
-    and annotation retrieval, dataset splitting, conversions into multiple
+    Contains information about a detection dataset.
+
+    Handles lazy image loading and annotation retrieval, dataset splitting, conversions into multiple
     formats.
 
     Attributes:
@@ -387,8 +388,9 @@ class DetectionDataset(BaseDataset):
         show_progress: bool = False,
     ) -> None:
         """
-        Exports the dataset to PASCAL VOC format. This method saves the images
-        and their corresponding annotations in PASCAL VOC format. Both output
+        Exports the dataset to PASCAL VOC format.
+
+        This method saves the images and their corresponding annotations in PASCAL VOC format. Both output
         layouts are preflighted before any files are written so a collision in
         either target fails without partial output.
 
@@ -585,8 +587,9 @@ class DetectionDataset(BaseDataset):
         show_progress: bool = False,
     ) -> None:
         """
-        Exports the dataset to YOLO format. This method saves the
-        images and their corresponding annotations in YOLO format.
+        Exports the dataset to YOLO format.
+
+        This method saves the images and their corresponding annotations in YOLO format.
 
         Args:
             images_directory_path: The path to the
@@ -1038,8 +1041,8 @@ class DetectionDataset(BaseDataset):
 @dataclass
 class ClassificationDataset(BaseDataset):
     """
-    Contains information about a classification dataset, handles lazy image
-    loading, dataset splitting.
+    Contains information about a classification dataset, handles lazy image loading,
+    dataset splitting.
 
     Attributes:
         classes: List containing dataset class names.

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -385,8 +385,7 @@ def detections_to_coco_annotations(
 
 
 def get_coco_class_index_mapping(annotations_path: str) -> dict[int, int]:
-    """
-    Generates a mapping from sequential class indices to original COCO class ids.
+    """Generates a mapping from sequential class indices to original COCO class ids.
 
     This function is essential when working with models that expect class ids to be
     zero-indexed and sequential (0 to 79), as opposed to the original COCO

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -51,7 +51,8 @@ def build_coco_class_index_mapping(
 
 
 def classes_to_coco_categories(classes: list[str]) -> list[CocoDict]:
-    """Convert a list of class names to COCO ``categories`` entries.
+    """
+    Convert a list of class names to COCO ``categories`` entries.
 
     Category ids are emitted 1-indexed to comply with the COCO specification
     and tools such as CVAT, which require ``category_id`` values to start at
@@ -160,7 +161,8 @@ def coco_annotations_to_detections(
     with_masks: bool,
     use_iscrowd: bool = True,
 ) -> Detections:
-    """Convert COCO annotation dicts for a single image into a `Detections` object.
+    """
+    Convert COCO annotation dicts for a single image into a `Detections` object.
 
     .. warning::
         The returned ``Detections.class_id`` contains **raw COCO** ``category_id``
@@ -582,11 +584,12 @@ def _with_seg_mask(annotation: dict[str, Any]) -> bool:
 
 
 def _image_resolution_hw(dataset: DetectionDataset, image_path: str) -> tuple[int, int]:
-    """Return ``(height, width)`` for ``image_path`` without decoding pixels.
+    """
+    Return ``(height, width)`` for ``image_path`` without decoding pixels.
 
-    Uses the in-memory array when the dataset holds one; otherwise reads the
-    size from the file header via lazy ``PIL.Image.open``, which parses only
-    image metadata — the same optimization the YOLO loader uses (#1636).
+    Uses the in-memory array when the dataset holds one; otherwise reads the size from
+    the file header via lazy ``PIL.Image.open``, which parses only image metadata — the
+    same optimization the YOLO loader uses (#1636).
     """
     if dataset._images_in_memory:
         image_height, image_width = dataset._images_in_memory[image_path].shape[:2]

--- a/src/supervision/dataset/formats/coco.py
+++ b/src/supervision/dataset/formats/coco.py
@@ -51,8 +51,7 @@ def build_coco_class_index_mapping(
 
 
 def classes_to_coco_categories(classes: list[str]) -> list[CocoDict]:
-    """
-    Convert a list of class names to COCO ``categories`` entries.
+    """Convert a list of class names to COCO ``categories`` entries.
 
     Category ids are emitted 1-indexed to comply with the COCO specification
     and tools such as CVAT, which require ``category_id`` values to start at
@@ -161,8 +160,7 @@ def coco_annotations_to_detections(
     with_masks: bool,
     use_iscrowd: bool = True,
 ) -> Detections:
-    """
-    Convert COCO annotation dicts for a single image into a `Detections` object.
+    """Convert COCO annotation dicts for a single image into a `Detections` object.
 
     .. warning::
         The returned ``Detections.class_id`` contains **raw COCO** ``category_id``
@@ -464,8 +462,7 @@ def load_coco_annotations(
     use_iscrowd: bool = True,
     show_progress: bool = False,
 ) -> tuple[list[str], list[str], dict[str, Detections]]:
-    """
-    Load COCO annotations and convert them to `Detections`.
+    """Load COCO annotations and convert them to `Detections`.
 
     If `force_masks` is `False`, masks are still loaded for images whose annotations
     include a `segmentation` field. This keeps mask handling consistent with other
@@ -584,8 +581,7 @@ def _with_seg_mask(annotation: dict[str, Any]) -> bool:
 
 
 def _image_resolution_hw(dataset: DetectionDataset, image_path: str) -> tuple[int, int]:
-    """
-    Return ``(height, width)`` for ``image_path`` without decoding pixels.
+    """Return ``(height, width)`` for ``image_path`` without decoding pixels.
 
     Uses the in-memory array when the dataset holds one; otherwise reads the size from
     the file header via lazy ``PIL.Image.open``, which parses only image metadata — the

--- a/src/supervision/dataset/formats/createml.py
+++ b/src/supervision/dataset/formats/createml.py
@@ -17,12 +17,13 @@ CreateMLDict = dict[str, Any]
 
 
 def _resolve_image_path(images_directory_path: str, image_name: str) -> str:
-    """Resolve and validate an image path against the images directory.
+    """
+    Resolve and validate an image path against the images directory.
 
-    Rejects annotations whose ``image`` field escapes ``images_directory_path``
-    (via ``..`` traversal, an absolute path, or a symlink pointing outside),
-    mirroring the protection used by the COCO loader. Returns the canonical
-    resolved path so aliases collapse to a single dataset entry.
+    Rejects annotations whose ``image`` field escapes ``images_directory_path`` (via
+    ``..`` traversal, an absolute path, or a symlink pointing outside), mirroring the
+    protection used by the COCO loader. Returns the canonical resolved path so aliases
+    collapse to a single dataset entry.
     """
     images_directory_resolved = Path(images_directory_path).resolve()
     image_path = Path(images_directory_path) / Path(image_name)
@@ -134,7 +135,8 @@ def load_createml_annotations(
     annotations_path: str,
     show_progress: bool = False,
 ) -> tuple[list[str], list[str], dict[str, Detections]]:
-    """Load CreateML object-detection annotations and convert them to ``Detections``.
+    """
+    Load CreateML object-detection annotations and convert them to ``Detections``.
 
     CreateML uses a single JSON file containing a list of per-image entries, each
     holding axis-aligned bounding boxes. Class names are inferred from the labels

--- a/src/supervision/dataset/formats/createml.py
+++ b/src/supervision/dataset/formats/createml.py
@@ -17,8 +17,7 @@ CreateMLDict = dict[str, Any]
 
 
 def _resolve_image_path(images_directory_path: str, image_name: str) -> str:
-    """
-    Resolve and validate an image path against the images directory.
+    """Resolve and validate an image path against the images directory.
 
     Rejects annotations whose ``image`` field escapes ``images_directory_path`` (via
     ``..`` traversal, an absolute path, or a symlink pointing outside), mirroring the
@@ -135,8 +134,7 @@ def load_createml_annotations(
     annotations_path: str,
     show_progress: bool = False,
 ) -> tuple[list[str], list[str], dict[str, Detections]]:
-    """
-    Load CreateML object-detection annotations and convert them to ``Detections``.
+    """Load CreateML object-detection annotations and convert them to ``Detections``.
 
     CreateML uses a single JSON file containing a list of per-image entries, each
     holding axis-aligned bounding boxes. Class names are inferred from the labels

--- a/src/supervision/dataset/formats/labelme.py
+++ b/src/supervision/dataset/formats/labelme.py
@@ -64,7 +64,8 @@ def labelme_shapes_to_detections(
     resolution_wh: tuple[int, int],
     with_masks: bool,
 ) -> Detections:
-    """Convert a single image's LabelMe shapes into ``Detections``.
+    """
+    Convert a single image's LabelMe shapes into ``Detections``.
 
     Only ``rectangle`` and ``polygon`` shapes are imported; other shape types
     (``circle``, ``line``, ``point``, ``linestrip``) are skipped with a warning.
@@ -301,7 +302,8 @@ def _build_shape(label: str, points: list[list[float]], shape_type: str) -> Labe
 def detections_to_labelme_shapes(
     detections: Detections, classes: list[str]
 ) -> list[LabelMeDict]:
-    """Convert ``Detections`` into a list of LabelMe shape dicts.
+    """
+    Convert ``Detections`` into a list of LabelMe shape dicts.
 
     Masked detections are exported as ``polygon`` shapes (one per connected
     component); box-only detections — and masked detections whose mask yields no

--- a/src/supervision/dataset/formats/labelme.py
+++ b/src/supervision/dataset/formats/labelme.py
@@ -64,8 +64,7 @@ def labelme_shapes_to_detections(
     resolution_wh: tuple[int, int],
     with_masks: bool,
 ) -> Detections:
-    """
-    Convert a single image's LabelMe shapes into ``Detections``.
+    """Convert a single image's LabelMe shapes into ``Detections``.
 
     Only ``rectangle`` and ``polygon`` shapes are imported; other shape types
     (``circle``, ``line``, ``point``, ``linestrip``) are skipped with a warning.
@@ -302,8 +301,7 @@ def _build_shape(label: str, points: list[list[float]], shape_type: str) -> Labe
 def detections_to_labelme_shapes(
     detections: Detections, classes: list[str]
 ) -> list[LabelMeDict]:
-    """
-    Convert ``Detections`` into a list of LabelMe shape dicts.
+    """Convert ``Detections`` into a list of LabelMe shape dicts.
 
     Masked detections are exported as ``polygon`` shapes (one per connected
     component); box-only detections — and masked detections whose mask yields no

--- a/src/supervision/dataset/formats/pascal_voc.py
+++ b/src/supervision/dataset/formats/pascal_voc.py
@@ -99,8 +99,7 @@ def detections_to_pascal_voc(
     max_image_area_percentage: float = 1.0,
     approximation_percentage: float = 0.75,
 ) -> str:
-    """
-    Converts Detections object to Pascal VOC XML format.
+    """Converts Detections object to Pascal VOC XML format.
 
     Args:
         detections: A Detections object containing bounding boxes,
@@ -195,8 +194,7 @@ def load_pascal_voc_annotations(
     force_masks: bool = False,
     show_progress: bool = False,
 ) -> tuple[list[str], list[str], dict[str, Detections]]:
-    """
-    Load Pascal VOC XML annotations in sorted image-path order.
+    """Load Pascal VOC XML annotations in sorted image-path order.
 
     Args:
         images_directory_path: The path to the directory containing the images.

--- a/src/supervision/dataset/formats/pascal_voc.py
+++ b/src/supervision/dataset/formats/pascal_voc.py
@@ -211,7 +211,6 @@ def load_pascal_voc_annotations(
             and a dictionary with image paths as keys and corresponding
             Detections instances as values.
     """
-
     image_paths = sorted(
         str(path)
         for path in list_files_with_extensions(

--- a/src/supervision/dataset/formats/yolo.py
+++ b/src/supervision/dataset/formats/yolo.py
@@ -75,7 +75,8 @@ def _with_seg_mask(lines: list[str]) -> bool:
 
 
 def _extract_class_names(file_path: str) -> list[str]:
-    """Return class names from a YOLO data.yaml file ordered by class index.
+    """
+    Return class names from a YOLO data.yaml file ordered by class index.
 
     Supports list and dict forms of the ``names`` field. Dict keys that are
     all int-like (plain ints or digit strings) are sorted numerically so
@@ -203,8 +204,8 @@ def load_yolo_annotations(
     show_progress: bool = False,
 ) -> tuple[list[str], list[str], dict[str, Detections]]:
     """
-    Loads YOLO annotations and returns class names, images,
-        and their corresponding detections.
+    Loads YOLO annotations and returns class names, images, and their corresponding
+    detections.
 
     Args:
         images_directory_path: The path to the directory containing the images.

--- a/src/supervision/dataset/formats/yolo.py
+++ b/src/supervision/dataset/formats/yolo.py
@@ -75,8 +75,7 @@ def _with_seg_mask(lines: list[str]) -> bool:
 
 
 def _extract_class_names(file_path: str) -> list[str]:
-    """
-    Return class names from a YOLO data.yaml file ordered by class index.
+    """Return class names from a YOLO data.yaml file ordered by class index.
 
     Supports list and dict forms of the ``names`` field. Dict keys that are
     all int-like (plain ints or digit strings) are sorted numerically so
@@ -203,8 +202,7 @@ def load_yolo_annotations(
     is_obb: bool = False,
     show_progress: bool = False,
 ) -> tuple[list[str], list[str], dict[str, Detections]]:
-    """
-    Loads YOLO annotations and returns class names, images, and their corresponding
+    """Loads YOLO annotations and returns class names, images, and their corresponding
     detections.
 
     Args:

--- a/src/supervision/dataset/utils.py
+++ b/src/supervision/dataset/utils.py
@@ -34,7 +34,8 @@ from supervision.detection.utils.polygons import (
 def mask_to_rle(
     mask: npt.NDArray[np.bool_], compressed: bool = False
 ) -> list[int] | str:
-    """Deprecated since 0.28.0.
+    """
+    Deprecated since 0.28.0.
 
     Use `supervision.detection.utils.converters.mask_to_rle`.
     """
@@ -46,7 +47,8 @@ def rle_to_mask(
     rle: npt.NDArray[np.integer] | list[int] | str | bytes,
     resolution_wh: tuple[int, int],
 ) -> npt.NDArray[np.bool_]:
-    """Deprecated since 0.28.0.
+    """
+    Deprecated since 0.28.0.
 
     Use `supervision.detection.utils.converters.rle_to_mask`.
     """
@@ -65,10 +67,11 @@ def approximate_mask_with_polygons(
     max_image_area_percentage: float = 1.0,
     approximation_percentage: float = 0.0,
 ) -> list[npt.NDArray[np.number]]:
-    """Filter mask polygons by area and optionally simplify them.
+    """
+    Filter mask polygons by area and optionally simplify them.
 
-    The default `approximation_percentage=0.0` preserves the original contour
-    unless callers explicitly ask for simplification.
+    The default `approximation_percentage=0.0` preserves the original contour unless
+    callers explicitly ask for simplification.
     """
     height, width = mask.shape
     image_area = height * width
@@ -145,7 +148,8 @@ def check_no_basename_collisions(
     key: Callable[[str], str],
     output_kind: str,
 ) -> None:
-    """Raise if two image paths would be written to the same output file.
+    """
+    Raise if two image paths would be written to the same output file.
 
     Dataset image paths may share a basename when they originate from different
     directories (a legal, common state after :meth:`DetectionDataset.merge`).

--- a/src/supervision/dataset/utils.py
+++ b/src/supervision/dataset/utils.py
@@ -241,8 +241,7 @@ def train_test_split(
     random_state: int | None = None,
     shuffle: bool = True,
 ) -> tuple[list[T], list[T]]:
-    """
-    Splits the data into two parts using the provided train_ratio.
+    """Splits the data into two parts using the provided train_ratio.
 
     Args:
         data: The data to split.

--- a/src/supervision/dataset/utils.py
+++ b/src/supervision/dataset/utils.py
@@ -34,8 +34,7 @@ from supervision.detection.utils.polygons import (
 def mask_to_rle(
     mask: npt.NDArray[np.bool_], compressed: bool = False
 ) -> list[int] | str:
-    """
-    Deprecated since 0.28.0.
+    """Deprecated since 0.28.0.
 
     Use `supervision.detection.utils.converters.mask_to_rle`.
     """
@@ -47,8 +46,7 @@ def rle_to_mask(
     rle: npt.NDArray[np.integer] | list[int] | str | bytes,
     resolution_wh: tuple[int, int],
 ) -> npt.NDArray[np.bool_]:
-    """
-    Deprecated since 0.28.0.
+    """Deprecated since 0.28.0.
 
     Use `supervision.detection.utils.converters.rle_to_mask`.
     """
@@ -67,8 +65,7 @@ def approximate_mask_with_polygons(
     max_image_area_percentage: float = 1.0,
     approximation_percentage: float = 0.0,
 ) -> list[npt.NDArray[np.number]]:
-    """
-    Filter mask polygons by area and optionally simplify them.
+    """Filter mask polygons by area and optionally simplify them.
 
     The default `approximation_percentage=0.0` preserves the original contour unless
     callers explicitly ask for simplification.
@@ -148,8 +145,7 @@ def check_no_basename_collisions(
     key: Callable[[str], str],
     output_kind: str,
 ) -> None:
-    """
-    Raise if two image paths would be written to the same output file.
+    """Raise if two image paths would be written to the same output file.
 
     Dataset image paths may share a basename when they originate from different
     directories (a legal, common state after :meth:`DetectionDataset.merge`).

--- a/src/supervision/detection/_geometry_dispatch.py
+++ b/src/supervision/detection/_geometry_dispatch.py
@@ -21,8 +21,7 @@ if TYPE_CHECKING:
 
 
 def detection_area(detections: Detections) -> npt.NDArray[np.generic]:
-    """
-    Calculate detection areas using the richest geometry present.
+    """Calculate detection areas using the richest geometry present.
 
     Selection order:
 
@@ -65,8 +64,7 @@ def detection_iou(
     detections_b: Detections,
     overlap_metric: OverlapMetric | str = OverlapMetric.IOU,
 ) -> npt.NDArray[np.floating]:
-    """
-    Calculate pairwise IoU using the richest geometry both operands share.
+    """Calculate pairwise IoU using the richest geometry both operands share.
 
     Selection order:
 

--- a/src/supervision/detection/compact_mask.py
+++ b/src/supervision/detection/compact_mask.py
@@ -1,17 +1,18 @@
-"""Crop-RLE compact mask storage for memory-efficient instance segmentation.
+"""
+Crop-RLE compact mask storage for memory-efficient instance segmentation.
 
-Dense ``(N, H, W)`` boolean masks use O(N·H·W) memory, which becomes
-prohibitive for aerial imagery (e.g. 1000 objects x 4K image ~ 8.3 GB).
-:class:`CompactMask` stores each mask as a run-length encoding of its
-bounding-box crop, reducing typical usage to tens of MB.
+Dense ``(N, H, W)`` boolean masks use O(N·H·W) memory, which becomes prohibitive for
+aerial imagery (e.g. 1000 objects x 4K image ~ 8.3 GB). :class:`CompactMask` stores each
+mask as a run-length encoding of its bounding-box crop, reducing typical usage to tens
+of MB.
 
-The bounding boxes (``xyxy``) already present in ``Detections`` serve as the
-crop boundaries, so no extra metadata is required from the caller.
+The bounding boxes (``xyxy``) already present in ``Detections`` serve as the crop
+boundaries, so no extra metadata is required from the caller.
 
-CompactMask reduces memory footprint but does not improve computational
-speed. The ingestion path (base48 decode, column split, RLE trim) is
-Python-level and is typically slower than the dense NumPy path. The primary
-benefit is memory savings for large images with many sparse masks.
+CompactMask reduces memory footprint but does not improve computational speed. The
+ingestion path (base48 decode, column split, RLE trim) is Python-level and is typically
+slower than the dense NumPy path. The primary benefit is memory savings for large images
+with many sparse masks.
 """
 
 from __future__ import annotations
@@ -308,7 +309,8 @@ def _rle_join_cols(
 
 
 def _rle_trim_col_runs(col_runs: Sequence[int], y1: int, y2: int) -> list[int]:
-    """Restrict one full-height column RLE to inclusive rows ``[y1, y2]``.
+    """
+    Restrict one full-height column RLE to inclusive rows ``[y1, y2]``.
 
     Args:
         col_runs: Run lengths for one full-height column, starting with a
@@ -364,7 +366,8 @@ def _rle_trim_col_runs(col_runs: Sequence[int], y1: int, y2: int) -> list[int]:
 
 
 def _coco_rle_counts_to_array(counts: Any) -> npt.NDArray[np.int32]:
-    """Decode COCO RLE counts into absolute F-order run lengths.
+    """
+    Decode COCO RLE counts into absolute F-order run lengths.
 
     Args:
         counts: COCO compressed counts (``str`` or ``bytes``), or uncompressed
@@ -521,7 +524,8 @@ def _resize_crop(
     new_h: int,
     new_w: int,
 ) -> npt.NDArray[np.int32]:
-    """Resize one RLE crop to ``(new_h, new_w)``, choosing the fastest path.
+    """
+    Resize one RLE crop to ``(new_h, new_w)``, choosing the fastest path.
 
     Dispatch order:
 

--- a/src/supervision/detection/compact_mask.py
+++ b/src/supervision/detection/compact_mask.py
@@ -1,5 +1,4 @@
-"""
-Crop-RLE compact mask storage for memory-efficient instance segmentation.
+"""Crop-RLE compact mask storage for memory-efficient instance segmentation.
 
 Dense ``(N, H, W)`` boolean masks use O(N·H·W) memory, which becomes prohibitive for
 aerial imagery (e.g. 1000 objects x 4K image ~ 8.3 GB). :class:`CompactMask` stores each
@@ -309,8 +308,7 @@ def _rle_join_cols(
 
 
 def _rle_trim_col_runs(col_runs: Sequence[int], y1: int, y2: int) -> list[int]:
-    """
-    Restrict one full-height column RLE to inclusive rows ``[y1, y2]``.
+    """Restrict one full-height column RLE to inclusive rows ``[y1, y2]``.
 
     Args:
         col_runs: Run lengths for one full-height column, starting with a
@@ -366,8 +364,7 @@ def _rle_trim_col_runs(col_runs: Sequence[int], y1: int, y2: int) -> list[int]:
 
 
 def _coco_rle_counts_to_array(counts: Any) -> npt.NDArray[np.int32]:
-    """
-    Decode COCO RLE counts into absolute F-order run lengths.
+    """Decode COCO RLE counts into absolute F-order run lengths.
 
     Args:
         counts: COCO compressed counts (``str`` or ``bytes``), or uncompressed
@@ -524,8 +521,7 @@ def _resize_crop(
     new_h: int,
     new_w: int,
 ) -> npt.NDArray[np.int32]:
-    """
-    Resize one RLE crop to ``(new_h, new_w)``, choosing the fastest path.
+    """Resize one RLE crop to ``(new_h, new_w)``, choosing the fastest path.
 
     Dispatch order:
 

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -209,9 +209,7 @@ class Detections:
         )
 
     def __len__(self) -> int:
-        """
-        Returns the number of detections in the Detections object.
-        """
+        """Returns the number of detections in the Detections object."""
         return len(self.xyxy)
 
     def __iter__(
@@ -3004,7 +3002,8 @@ class Detections:
     def _build_nms_predictions(
         self, class_agnostic: bool, operation_name: str
     ) -> npt.NDArray[np.floating]:
-        """Stack xyxy + confidence (+ class_id) for NMS/NMM/Soft-NMS dispatch.
+        """
+        Stack xyxy + confidence (+ class_id) for NMS/NMM/Soft-NMS dispatch.
 
         Callers must already have verified `self.confidence is not None`.
         """
@@ -3039,8 +3038,9 @@ class Detections:
         overlap_metric: OverlapMetric = OverlapMetric.IOU,
     ) -> Detections:
         """
-        Performs non-max suppression on detection set. Dispatch order: (1) if mask
-        data present, IoU mask is used; (2) else if oriented-box coordinates
+        Performs non-max suppression on detection set.
+
+        Dispatch order: (1) if mask data present, IoU mask is used; (2) else if oriented-box coordinates
         (``data[ORIENTED_BOX_COORDINATES]``) present, oriented-box IoU is used; (3)
         otherwise, axis-aligned box IoU is used.
 
@@ -3102,8 +3102,9 @@ class Detections:
         score_threshold: float | None = None,
     ) -> Detections:
         """
-        Performs Gaussian Soft Non-Maximum Suppression on detection set. Dispatch
-        order: (1) if mask data present, IoU mask is used; (2) otherwise,
+        Performs Gaussian Soft Non-Maximum Suppression on detection set.
+
+        Dispatch order: (1) if mask data present, IoU mask is used; (2) otherwise,
         axis-aligned box IoU is used. Oriented-box detections are not given
         dedicated OBB-IoU treatment and fall back to their axis-aligned `xyxy`.
 
@@ -3252,7 +3253,8 @@ class Detections:
 def _merge_obb_corners(
     corners_list: list[npt.NDArray[np.number]],
 ) -> npt.NDArray[np.floating]:
-    """Merge multiple OBB corner arrays using winner-angle projection.
+    """
+    Merge multiple OBB corner arrays using winner-angle projection.
 
     The first entry in *corners_list* is the winner. Its orientation angle
     (derived from its first edge) defines the local frame in which the
@@ -3312,7 +3314,8 @@ def _merge_obb_corners(
 
 
 def _merge_detection_group(detections: list[Detections]) -> Detections:
-    """Merge a group of single-object Detections into one merged detection.
+    """
+    Merge a group of single-object Detections into one merged detection.
 
     Used internally by :meth:`Detections.with_nmm` to combine each merge group
     into a single output detection. The highest-confidence detection is the

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -88,11 +88,12 @@ from supervision.validators import (
 
 @dataclass
 class Detections:
-    """
-    The `sv.Detections` class in the Supervision library standardizes results from
+    """The `sv.Detections` class in the Supervision library standardizes results from
     various object detection and segmentation models into a consistent format. This
     class simplifies data manipulation and filtering, providing a uniform API for
-    integration with Supervision [trackers](/trackers/), [annotators](/latest/detection/annotators/), and [tools](/detection/tools/line_zone/).
+    integration with Supervision [trackers](/trackers/),
+    [annotators](/latest/detection/annotators/), and
+    [tools](/detection/tools/line_zone/).
 
     === "RF-DETR"
 
@@ -224,10 +225,8 @@ class Detections:
             _DetectionDataType,
         ]
     ]:
-        """
-        Iterates over the Detections object and yield a tuple of
-        `(xyxy, mask, confidence, class_id, tracker_id, data)` for each detection.
-        """
+        """Iterates over the Detections object and yield a tuple of `(xyxy, mask,
+        confidence, class_id, tracker_id, data)` for each detection."""
         for i in range(len(self.xyxy)):
             yield (
                 self.xyxy[i],
@@ -1140,10 +1139,8 @@ class Detections:
     def from_lmm(
         cls, lmm: LMM | str, result: str | dict[str, Any], **kwargs: Any
     ) -> Detections:
-        """
-        !!! deprecated "Deprecated"
-            `Detections.from_lmm` is **deprecated** and will be removed in `supervision-0.31.0`.
-            Please use `Detections.from_vlm` instead.
+        """!!! deprecated "Deprecated" `Detections.from_lmm` is **deprecated** and will
+        be removed in `supervision-0.31.0`. Please use `Detections.from_vlm` instead.
 
         Creates a Detections object from the given result string based on the specified
         Large Multimodal Model (LMM).
@@ -1624,10 +1621,8 @@ class Detections:
     def from_vlm(
         cls, vlm: VLM | str, result: str | dict[str, Any], **kwargs: Any
     ) -> Detections:
-        """
-
-        Creates a Detections object from the given result string based on the specified
-        Vision Language Model (VLM).
+        """Creates a Detections object from the given result string based on the
+        specified Vision Language Model (VLM).
 
         | Name                | Enum (sv.VLM)        | Tasks                   | Required parameters         | Optional parameters |
         |---------------------|----------------------|-------------------------|-----------------------------|---------------------|
@@ -2032,7 +2027,6 @@ class Detections:
                   dtype='<U24')}
 
             ```
-
         """  # noqa: E501
 
         vlm = _validate_vlm_parameters(vlm, result, kwargs)
@@ -2273,9 +2267,8 @@ class Detections:
 
     @classmethod
     def empty(cls) -> Detections:
-        """
-        Create an empty Detections object with no bounding boxes,
-            confidences, or class IDs.
+        """Create an empty Detections object with no bounding boxes, confidences, or
+        class IDs.
 
         Returns:
             An empty Detections object.
@@ -2296,8 +2289,7 @@ class Detections:
         )
 
     def is_empty(self) -> bool:
-        """
-        Check whether the `Detections` object has zero bounding boxes.
+        """Check whether the `Detections` object has zero bounding boxes.
 
         Returns:
             `True` if there are no detections, `False` otherwise.
@@ -2321,8 +2313,7 @@ class Detections:
 
     @classmethod
     def merge(cls, detections_list: list[Detections]) -> Detections:
-        """
-        Merge a list of Detections objects into a single Detections object.
+        """Merge a list of Detections objects into a single Detections object.
 
         This method takes a list of Detections objects and combines their
         respective fields (`xyxy`, `mask`, `confidence`, `class_id`, and `tracker_id`)
@@ -2739,8 +2730,7 @@ class Detections:
         | npt.NDArray[np.generic]
         | str,
     ) -> Detections | list[Any] | npt.NDArray[np.generic] | None:
-        """
-        Get a subset of the Detections object or access an item from its data field.
+        """Get a subset of the Detections object or access an item from its data field.
 
         When provided with an integer, slice, list of integers, or a numpy array, this
         method returns a new Detections object that represents a subset of the original
@@ -2774,8 +2764,7 @@ class Detections:
         return self.select(index)
 
     def __setitem__(self, key: str, value: npt.NDArray[np.generic] | list[Any]) -> None:
-        """
-        Set a value in the data dictionary of the Detections object.
+        """Set a value in the data dictionary of the Detections object.
 
         Args:
             key: The key in the data dictionary to set.
@@ -2816,8 +2805,7 @@ class Detections:
 
     @property
     def area(self) -> npt.NDArray[np.generic]:
-        """
-        Calculate the area of each detection in the set of object detections.
+        """Calculate the area of each detection in the set of object detections.
 
         Selection order:
 
@@ -2901,8 +2889,7 @@ class Detections:
 
     @property
     def box_aspect_ratio(self) -> npt.NDArray[np.generic]:
-        """
-        Compute the aspect ratio (width divided by height) for each bounding box.
+        """Compute the aspect ratio (width divided by height) for each bounding box.
 
         Returns:
             Array of shape `(N,)` containing aspect ratios, where `N` is the
@@ -3037,9 +3024,9 @@ class Detections:
     ) -> Detections:
         """Performs non-max suppression on detection set.
 
-        Dispatch order: (1) if mask data present, IoU mask is used; (2) else if oriented-box coordinates
-        (``data[ORIENTED_BOX_COORDINATES]``) present, oriented-box IoU is used; (3)
-        otherwise, axis-aligned box IoU is used.
+        Dispatch order: (1) if mask data present, IoU mask is used; (2) else if
+        oriented-box coordinates (``data[ORIENTED_BOX_COORDINATES]``) present,
+        oriented-box IoU is used; (3) otherwise, axis-aligned box IoU is used.
 
         Args:
             threshold: The intersection-over-union threshold
@@ -3426,9 +3413,8 @@ def _merge_detection_group(detections: list[Detections]) -> Detections:
 def merge_inner_detection_object_pair(
     detections_1: Detections, detections_2: Detections
 ) -> Detections:
-    """
-    Merges two Detections objects into a single Detections object.
-    Assumes each Detections contains exactly one object.
+    """Merges two Detections objects into a single Detections object. Assumes each
+    Detections contains exactly one object.
 
     A `winning` detection is determined based on the confidence score of the two
     input detections. This winning detection is then used to specify which

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -2875,8 +2875,7 @@ class Detections:
 
     @property
     def box_area(self) -> npt.NDArray[np.generic]:
-        """
-        Calculate the area of each bounding box in the set of object detections.
+        """Calculate the area of each bounding box in the set of object detections.
 
         Returns:
             An array of floats containing the area of each bounding
@@ -3002,8 +3001,7 @@ class Detections:
     def _build_nms_predictions(
         self, class_agnostic: bool, operation_name: str
     ) -> npt.NDArray[np.floating]:
-        """
-        Stack xyxy + confidence (+ class_id) for NMS/NMM/Soft-NMS dispatch.
+        """Stack xyxy + confidence (+ class_id) for NMS/NMM/Soft-NMS dispatch.
 
         Callers must already have verified `self.confidence is not None`.
         """
@@ -3037,8 +3035,7 @@ class Detections:
         class_agnostic: bool = False,
         overlap_metric: OverlapMetric = OverlapMetric.IOU,
     ) -> Detections:
-        """
-        Performs non-max suppression on detection set.
+        """Performs non-max suppression on detection set.
 
         Dispatch order: (1) if mask data present, IoU mask is used; (2) else if oriented-box coordinates
         (``data[ORIENTED_BOX_COORDINATES]``) present, oriented-box IoU is used; (3)
@@ -3101,8 +3098,7 @@ class Detections:
         class_agnostic: bool = False,
         score_threshold: float | None = None,
     ) -> Detections:
-        """
-        Performs Gaussian Soft Non-Maximum Suppression on detection set.
+        """Performs Gaussian Soft Non-Maximum Suppression on detection set.
 
         Dispatch order: (1) if mask data present, IoU mask is used; (2) otherwise,
         axis-aligned box IoU is used. Oriented-box detections are not given
@@ -3253,8 +3249,7 @@ class Detections:
 def _merge_obb_corners(
     corners_list: list[npt.NDArray[np.number]],
 ) -> npt.NDArray[np.floating]:
-    """
-    Merge multiple OBB corner arrays using winner-angle projection.
+    """Merge multiple OBB corner arrays using winner-angle projection.
 
     The first entry in *corners_list* is the winner. Its orientation angle
     (derived from its first edge) defines the local frame in which the
@@ -3314,8 +3309,7 @@ def _merge_obb_corners(
 
 
 def _merge_detection_group(detections: list[Detections]) -> Detections:
-    """
-    Merge a group of single-object Detections into one merged detection.
+    """Merge a group of single-object Detections into one merged detection.
 
     Used internally by :meth:`Detections.with_nmm` to combine each merge group
     into a single output detection. The highest-confidence detection is the
@@ -3530,10 +3524,9 @@ def merge_inner_detections_objects(
     threshold: float = 0.5,
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> Detections:
-    """
-    Given N detections each of length 1 (exactly one object inside), combine them into a
-    single detection object of length 1. The contained inner object will be the merged
-    result of all the input detections.
+    """Given N detections each of length 1 (exactly one object inside), combine them
+    into a single detection object of length 1. The contained inner object will be the
+    merged result of all the input detections.
 
     For example, this lets you merge N boxes into one big box, N masks into one mask,
     etc.
@@ -3551,10 +3544,9 @@ def merge_inner_detections_objects(
 def merge_inner_detections_objects_without_iou(
     detections: list[Detections],
 ) -> Detections:
-    """
-    Given N detections each of length 1 (exactly one object inside), combine them into a
-    single detection object of length 1. The contained inner object will be the merged
-    result of all the input detections.
+    """Given N detections each of length 1 (exactly one object inside), combine them
+    into a single detection object of length 1. The contained inner object will be the
+    merged result of all the input detections.
 
     For example, this lets you merge N boxes into one big box, N masks into one mask,
     etc.
@@ -3565,8 +3557,7 @@ def merge_inner_detections_objects_without_iou(
 def _validate_fields_both_defined_or_none(
     detections_1: Detections, detections_2: Detections
 ) -> None:
-    """
-    Verify that for each optional field in the Detections, both instances either have
+    """Verify that for each optional field in the Detections, both instances either have
     the field set to None or both have it set to non-None values.
 
     `data` field is ignored.

--- a/src/supervision/detection/line_zone.py
+++ b/src/supervision/detection/line_zone.py
@@ -22,8 +22,7 @@ TEXT_MARGIN = 10
 
 
 class LineZone:
-    """
-    This class is responsible for counting the number of objects that cross a
+    """This class is responsible for counting the number of objects that cross a
     predefined line.
 
     <video controls>
@@ -664,20 +663,21 @@ class LineZoneAnnotator:
         text_box_color: Color,
         line_angle_degrees: float,
     ) -> npt.NDArray[np.uint8]:
-        """Create the small text box displaying line zone count, E.g. "out: 7".
+        """Create the small text box displaying line zone count, E.g.
 
-        Args:
-            text: The text to display.
-            text_scale: The scale of the text.
-            text_thickness: The thickness of the text.
-            text_padding: The padding around the text.
-            text_color: The color of the text.
-            text_box_show: Whether to display the text box.
-            text_box_color: The color of the text box.
-            line_angle_degrees: The angle of the line in degrees.
+        "out: 7".
+                Args:
+                    text: The text to display.
+                    text_scale: The scale of the text.
+                    text_thickness: The thickness of the text.
+                    text_padding: The padding around the text.
+                    text_color: The color of the text.
+                    text_box_show: Whether to display the text box.
+                    text_box_color: The color of the text box.
+                    line_angle_degrees: The angle of the line in degrees.
 
-        Returns:
-            The label of shape (H, W, 4), in BGRA format.
+                Returns:
+                    The label of shape (H, W, 4), in BGRA format.
         """
         text_width, text_height = cv2.getTextSize(
             text, cv2.FONT_HERSHEY_SIMPLEX, text_scale, text_thickness

--- a/src/supervision/detection/line_zone.py
+++ b/src/supervision/detection/line_zone.py
@@ -267,8 +267,8 @@ class LineZone:
         self, detections: Detections
     ) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.bool_], npt.NDArray[np.bool_]]:
         """
-        Find if detections' anchors are within the limit of the line
-        zone and which anchors are on its left and right side.
+        Find if detections' anchors are within the limit of the line zone and which
+        anchors are on its left and right side.
 
         Assumes:
             * At least 1 detection is provided
@@ -324,8 +324,8 @@ class LineZone:
 
     def _update_class_id_to_name(self, detections: Detections) -> None:
         """
-        Update the attribute keeping track of which class
-        IDs correspond to which class names.
+        Update the attribute keeping track of which class IDs correspond to which class
+        names.
 
         Assumes that class_names are only provided when class_ids are.
         """
@@ -349,8 +349,8 @@ class LineZoneAnnotator:
     """
     Draw a `LineZone` and its in/out counts on a video frame.
 
-    Use this annotator after calling `LineZone.trigger` so the rendered counts
-    reflect the latest tracked detections.
+    Use this annotator after calling `LineZone.trigger` so the rendered counts reflect
+    the latest tracked detections.
     """
 
     def __init__(
@@ -371,8 +371,7 @@ class LineZoneAnnotator:
         text_centered: bool = True,
     ) -> None:
         """
-        A class for drawing the `LineZone` and its detected object count
-        on an image.
+        A class for drawing the `LineZone` and its detected object count on an image.
 
         Args:
             thickness: Line thickness.
@@ -391,7 +390,6 @@ class LineZoneAnnotator:
                 Recommended to set to `True`.
             text_centered: Pass `False` to disable text centering. Useful
                 when the label overlaps something important.
-
         """
         self.thickness: int = thickness
         self.color: Color = color
@@ -420,7 +418,6 @@ class LineZoneAnnotator:
 
         Returns:
             The image with the line drawn on it.
-
         """
         line_start = line_counter.vector.start.as_xy_int_tuple()
         line_end = line_counter.vector.end.as_xy_int_tuple()
@@ -575,8 +572,9 @@ class LineZoneAnnotator:
         is_in_count: bool,
     ) -> npt.NDArray[np.uint8]:
         """
-        Draw the count label on the frame. For example: "out: 7".
-        The label contains horizontal text and is not rotated.
+        Draw the count label on the frame.
+
+        For example: "out: 7". The label contains horizontal text and is not rotated.
 
         Args:
             frame: The entire scene, on which the label will be placed.
@@ -618,8 +616,9 @@ class LineZoneAnnotator:
         is_in_count: bool,
     ) -> npt.NDArray[np.uint8]:
         """
-        Draw the count label on the frame. For example: "out: 7".
-        The label is oriented to match the line angle.
+        Draw the count label on the frame.
+
+        For example: "out: 7". The label is oriented to match the line angle.
 
         Args:
             frame: The entire scene, on which the label will be placed.
@@ -631,7 +630,6 @@ class LineZoneAnnotator:
         Returns:
             The scene with the label drawn on it.
         """
-
         line_angle_degrees = self._get_line_angle(line_zone)
         label_image = self._make_label_image(
             text,
@@ -675,20 +673,21 @@ class LineZoneAnnotator:
         line_angle_degrees: float,
     ) -> npt.NDArray[np.uint8]:
         """
-        Create the small text box displaying line zone count. E.g. "out: 7".
+        Create the small text box displaying line zone count.
 
-        Args:
-            text: The text to display.
-            text_scale: The scale of the text.
-            text_thickness: The thickness of the text.
-            text_padding: The padding around the text.
-            text_color: The color of the text.
-            text_box_show: Whether to display the text box.
-            text_box_color: The color of the text box.
-            line_angle_degrees: The angle of the line in degrees.
+        E.g. "out: 7".
+                Args:
+                    text: The text to display.
+                    text_scale: The scale of the text.
+                    text_thickness: The thickness of the text.
+                    text_padding: The padding around the text.
+                    text_color: The color of the text.
+                    text_box_show: Whether to display the text box.
+                    text_box_color: The color of the text box.
+                    line_angle_degrees: The angle of the line in degrees.
 
-        Returns:
-            The label of shape (H, W, 4), in BGRA format.
+                Returns:
+                    The label of shape (H, W, 4), in BGRA format.
         """
         text_width, text_height = cv2.getTextSize(
             text, cv2.FONT_HERSHEY_SIMPLEX, text_scale, text_thickness
@@ -747,8 +746,8 @@ class LineZoneAnnotatorMulticlass:
     """
     Draw per-class crossing counts for one or more `LineZone` instances.
 
-    The annotator renders a table with one row per line zone and one column per
-    class observed by the zones.
+    The annotator renders a table with one row per line zone and one column per class
+    observed by the zones.
     """
 
     def __init__(
@@ -823,7 +822,6 @@ class LineZoneAnnotatorMulticlass:
 
         Returns:
             The image with the table drawn on it.
-
         """
         if line_zone_labels is None:
             line_zone_labels = [f"Line {i + 1}:" for i in range(len(line_zones))]

--- a/src/supervision/detection/line_zone.py
+++ b/src/supervision/detection/line_zone.py
@@ -664,21 +664,20 @@ class LineZoneAnnotator:
         text_box_color: Color,
         line_angle_degrees: float,
     ) -> npt.NDArray[np.uint8]:
-        """Create the small text box displaying line zone count.
+        """Create the small text box displaying line zone count, E.g. "out: 7".
 
-        E.g. "out: 7".
-                Args:
-                    text: The text to display.
-                    text_scale: The scale of the text.
-                    text_thickness: The thickness of the text.
-                    text_padding: The padding around the text.
-                    text_color: The color of the text.
-                    text_box_show: Whether to display the text box.
-                    text_box_color: The color of the text box.
-                    line_angle_degrees: The angle of the line in degrees.
+        Args:
+            text: The text to display.
+            text_scale: The scale of the text.
+            text_thickness: The thickness of the text.
+            text_padding: The padding around the text.
+            text_color: The color of the text.
+            text_box_show: Whether to display the text box.
+            text_box_color: The color of the text box.
+            line_angle_degrees: The angle of the line in degrees.
 
-                Returns:
-                    The label of shape (H, W, 4), in BGRA format.
+        Returns:
+            The label of shape (H, W, 4), in BGRA format.
         """
         text_width, text_height = cv2.getTextSize(
             text, cv2.FONT_HERSHEY_SIMPLEX, text_scale, text_thickness

--- a/src/supervision/detection/line_zone.py
+++ b/src/supervision/detection/line_zone.py
@@ -148,8 +148,8 @@ class LineZone:
     def trigger(
         self, detections: Detections
     ) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.bool_]]:
-        """
-        Update the `in_count` and `out_count` based on the objects that cross the line.
+        """Update the `in_count` and `out_count` based on the objects that cross the
+        line.
 
         Args:
             detections: A Detections object for which to update the counts.
@@ -266,8 +266,7 @@ class LineZone:
     def _compute_anchor_sides(
         self, detections: Detections
     ) -> tuple[npt.NDArray[np.bool_], npt.NDArray[np.bool_], npt.NDArray[np.bool_]]:
-        """
-        Find if detections' anchors are within the limit of the line zone and which
+        """Find if detections' anchors are within the limit of the line zone and which
         anchors are on its left and right side.
 
         Assumes:
@@ -323,9 +322,8 @@ class LineZone:
         return in_limits, has_any_left_trigger, has_any_right_trigger
 
     def _update_class_id_to_name(self, detections: Detections) -> None:
-        """
-        Update the attribute keeping track of which class IDs correspond to which class
-        names.
+        """Update the attribute keeping track of which class IDs correspond to which
+        class names.
 
         Assumes that class_names are only provided when class_ids are.
         """
@@ -346,8 +344,7 @@ class LineZone:
 
 
 class LineZoneAnnotator:
-    """
-    Draw a `LineZone` and its in/out counts on a video frame.
+    """Draw a `LineZone` and its in/out counts on a video frame.
 
     Use this annotator after calling `LineZone.trigger` so the rendered counts reflect
     the latest tracked detections.
@@ -370,8 +367,7 @@ class LineZoneAnnotator:
         text_orient_to_line: bool = False,
         text_centered: bool = True,
     ) -> None:
-        """
-        A class for drawing the `LineZone` and its detected object count on an image.
+        """A class for drawing the `LineZone` and its detected object count on an image.
 
         Args:
             thickness: Line thickness.
@@ -409,8 +405,7 @@ class LineZoneAnnotator:
     def annotate(
         self, frame: npt.NDArray[np.uint8], line_counter: LineZone
     ) -> npt.NDArray[np.uint8]:
-        """
-        Draws the line on the frame using the line zone provided.
+        """Draws the line on the frame using the line zone provided.
 
         Args:
             frame: The image on which the line will be drawn.
@@ -476,8 +471,7 @@ class LineZoneAnnotator:
         return frame
 
     def _get_line_angle(self, line_zone: LineZone) -> float:
-        """
-        Calculate the line counter angle (in degrees).
+        """Calculate the line counter angle (in degrees).
 
         Args:
             line_zone: The line zone object.
@@ -508,8 +502,8 @@ class LineZoneAnnotator:
         is_in_count: bool,
         label_dimension: int,
     ) -> tuple[int, int]:
-        """
-        Calculate insertion anchor in frame to position the center of the count image.
+        """Calculate insertion anchor in frame to position the center of the count
+        image.
 
         Args:
             line_zone: The line counter object used for counting.
@@ -571,8 +565,7 @@ class LineZoneAnnotator:
         text: str,
         is_in_count: bool,
     ) -> npt.NDArray[np.uint8]:
-        """
-        Draw the count label on the frame.
+        """Draw the count label on the frame.
 
         For example: "out: 7". The label contains horizontal text and is not rotated.
 
@@ -615,8 +608,7 @@ class LineZoneAnnotator:
         text: str,
         is_in_count: bool,
     ) -> npt.NDArray[np.uint8]:
-        """
-        Draw the count label on the frame.
+        """Draw the count label on the frame.
 
         For example: "out: 7". The label is oriented to match the line angle.
 
@@ -672,8 +664,7 @@ class LineZoneAnnotator:
         text_box_color: Color,
         line_angle_degrees: float,
     ) -> npt.NDArray[np.uint8]:
-        """
-        Create the small text box displaying line zone count.
+        """Create the small text box displaying line zone count.
 
         E.g. "out: 7".
                 Args:
@@ -743,8 +734,7 @@ class LineZoneAnnotator:
 
 
 class LineZoneAnnotatorMulticlass:
-    """
-    Draw per-class crossing counts for one or more `LineZone` instances.
+    """Draw per-class crossing counts for one or more `LineZone` instances.
 
     The annotator renders a table with one row per line zone and one column per class
     observed by the zones.
@@ -768,8 +758,7 @@ class LineZoneAnnotatorMulticlass:
         text_thickness: int = 1,
         force_draw_class_ids: bool = False,
     ) -> None:
-        """
-        Draw a table showing how many items of each class crossed each line.
+        """Draw a table showing how many items of each class crossed each line.
 
         Args:
             table_position: The position of the table.
@@ -811,8 +800,8 @@ class LineZoneAnnotatorMulticlass:
         line_zones: list[LineZone],
         line_zone_labels: list[str] | None = None,
     ) -> npt.NDArray[np.uint8]:
-        """
-        Draws a table with the number of objects of each class that crossed each line.
+        """Draws a table with the number of objects of each class that crossed each
+        line.
 
         Args:
             frame: The image on which the table will be drawn.

--- a/src/supervision/detection/tools/csv_sink.py
+++ b/src/supervision/detection/tools/csv_sink.py
@@ -100,9 +100,7 @@ class CSVSink:
         self.close()
 
     def open(self) -> None:
-        """
-        Open the CSV file for writing.
-        """
+        """Open the CSV file for writing."""
         parent_directory = os.path.dirname(self.file_name)
         if parent_directory and not os.path.exists(parent_directory):
             os.makedirs(parent_directory)
@@ -117,10 +115,10 @@ class CSVSink:
         """
         Close the CSV file.
 
-        When every appended batch was empty no header has been written yet, so
-        the schema remembered from the first such batch is emitted here. This
-        keeps a run that never detected anything readable as an empty table
-        rather than as a zero-byte file.
+        When every appended batch was empty no header has been written yet, so the
+        schema remembered from the first such batch is emitted here. This keeps a run
+        that never detected anything readable as an empty table rather than as a zero-
+        byte file.
         """
         if self.file is None or self.file.closed:
             return

--- a/src/supervision/detection/tools/csv_sink.py
+++ b/src/supervision/detection/tools/csv_sink.py
@@ -74,8 +74,7 @@ class CSVSink:
     """
 
     def __init__(self, file_name: str = "output.csv") -> None:
-        """
-        Initialize the CSVSink instance.
+        """Initialize the CSVSink instance.
 
         Args:
             file_name: The name of the CSV file.
@@ -112,8 +111,7 @@ class CSVSink:
         self.deferred_field_names = []
 
     def close(self) -> None:
-        """
-        Close the CSV file.
+        """Close the CSV file.
 
         When every appended batch was empty no header has been written yet, so the
         schema remembered from the first such batch is emitted here. This keeps a run
@@ -136,8 +134,7 @@ class CSVSink:
 
     @staticmethod
     def _slice_value(value: Any, i: int, n: int) -> Any:
-        """
-        Return the i-th element when the value stores per-detection data.
+        """Return the i-th element when the value stores per-detection data.
 
         Dispatch rules:
             - np.ndarray with ndim == 0: return as-is for broadcasting
@@ -164,8 +161,7 @@ class CSVSink:
     def parse_detection_data(
         detections: Detections, custom_data: dict[str, Any] | None = None
     ) -> list[dict[str, Any]]:
-        """
-        Convert detections and optional custom data into per-detection rows.
+        """Convert detections and optional custom data into per-detection rows.
 
         Builds one dictionary per detection containing bounding box coordinates,
         detection attributes, and any values from ``detections.data`` or
@@ -215,8 +211,7 @@ class CSVSink:
     def append(
         self, detections: Detections, custom_data: dict[str, Any] | None = None
     ) -> None:
-        """
-        Append detection data to the CSV file.
+        """Append detection data to the CSV file.
 
         The CSV header is fixed by the first batch that actually contains
         detections; batches with no detections write nothing and leave the

--- a/src/supervision/detection/tools/csv_sink.py
+++ b/src/supervision/detection/tools/csv_sink.py
@@ -29,9 +29,8 @@ class WriterProtocol(Protocol):
 
 
 class CSVSink:
-    """
-    A utility class for saving detection data to a CSV file. This class is designed to
-    efficiently serialize detection objects into a CSV format, allowing for the
+    """A utility class for saving detection data to a CSV file. This class is designed
+    to efficiently serialize detection objects into a CSV format, allowing for the
     inclusion of bounding box coordinates and additional attributes like `confidence`,
     `class_id`, and `tracker_id`.
 

--- a/src/supervision/detection/tools/inference_slicer.py
+++ b/src/supervision/detection/tools/inference_slicer.py
@@ -103,8 +103,7 @@ def move_detections(
 
 
 class InferenceSlicer:
-    """
-    Perform tiled inference on large images by slicing them into overlapping patches.
+    """Perform tiled inference on large images by slicing them into overlapping patches.
 
     This class divides an input image into overlapping slices of configurable size
     and overlap, runs inference on each slice through a user-provided callback, and

--- a/src/supervision/detection/tools/inference_slicer.py
+++ b/src/supervision/detection/tools/inference_slicer.py
@@ -27,11 +27,12 @@ from supervision.utils.iterables import create_batches
 
 @runtime_checkable
 class WindowedRasterDataset(Protocol):
-    """Structural type for a rasterio-style dataset read window-by-window.
+    """
+    Structural type for a rasterio-style dataset read window-by-window.
 
-    Matched structurally by `_is_windowed_raster` rather than by import so
-    `rasterio` stays an optional dependency — any object exposing these members
-    works. `rasterio.io.DatasetReader` satisfies this protocol.
+    Matched structurally by `_is_windowed_raster` rather than by import so `rasterio`
+    stays an optional dependency — any object exposing these members works.
+    `rasterio.io.DatasetReader` satisfies this protocol.
     """
 
     width: int
@@ -42,10 +43,11 @@ class WindowedRasterDataset(Protocol):
 
 
 def _is_windowed_raster(image: object) -> TypeGuard[WindowedRasterDataset]:
-    """Duck-type check for a rasterio-style dataset that supports windowed reads.
+    """
+    Duck-type check for a rasterio-style dataset that supports windowed reads.
 
-    Avoids importing rasterio so it remains an optional dependency. numpy arrays
-    and PIL images do not expose this combination of attributes.
+    Avoids importing rasterio so it remains an optional dependency. numpy arrays and PIL
+    images do not expose this combination of attributes.
     """
     return (
         callable(getattr(image, "read", None))
@@ -60,7 +62,8 @@ def move_detections(
     offset: npt.NDArray[Any],
     resolution_wh: tuple[int, int] | None = None,
 ) -> Detections:
-    """Translate detections by a pixel offset, repositioning boxes and masks.
+    """
+    Translate detections by a pixel offset, repositioning boxes and masks.
 
     Args:
         detections: Detections object to be moved. The input is left unchanged;
@@ -556,7 +559,8 @@ class InferenceSlicer:
         image: ImageType | WindowedRasterDataset,
         offsets: list[npt.NDArray[Any]],
     ) -> list[Detections]:
-        """Run batch inference callback on multiple slices.
+        """
+        Run batch inference callback on multiple slices.
 
         Args:
             image: The full image or rasterio dataset.

--- a/src/supervision/detection/tools/inference_slicer.py
+++ b/src/supervision/detection/tools/inference_slicer.py
@@ -27,8 +27,7 @@ from supervision.utils.iterables import create_batches
 
 @runtime_checkable
 class WindowedRasterDataset(Protocol):
-    """
-    Structural type for a rasterio-style dataset read window-by-window.
+    """Structural type for a rasterio-style dataset read window-by-window.
 
     Matched structurally by `_is_windowed_raster` rather than by import so `rasterio`
     stays an optional dependency — any object exposing these members works.
@@ -43,8 +42,7 @@ class WindowedRasterDataset(Protocol):
 
 
 def _is_windowed_raster(image: object) -> TypeGuard[WindowedRasterDataset]:
-    """
-    Duck-type check for a rasterio-style dataset that supports windowed reads.
+    """Duck-type check for a rasterio-style dataset that supports windowed reads.
 
     Avoids importing rasterio so it remains an optional dependency. numpy arrays and PIL
     images do not expose this combination of attributes.
@@ -62,8 +60,7 @@ def move_detections(
     offset: npt.NDArray[Any],
     resolution_wh: tuple[int, int] | None = None,
 ) -> Detections:
-    """
-    Translate detections by a pixel offset, repositioning boxes and masks.
+    """Translate detections by a pixel offset, repositioning boxes and masks.
 
     Args:
         detections: Detections object to be moved. The input is left unchanged;
@@ -311,8 +308,7 @@ class InferenceSlicer:
         self._raster_read_lock = threading.Lock()
 
     def __call__(self, image: ImageType | WindowedRasterDataset) -> Detections:
-        """
-        Perform tiled inference on the full image and return merged detections.
+        """Perform tiled inference on the full image and return merged detections.
 
         The first slice always runs synchronously so the output type can be
         inspected before committing to a threading strategy. Detections are
@@ -477,8 +473,8 @@ class InferenceSlicer:
     def _run_callback(
         self, image: ImageType | WindowedRasterDataset, offset: npt.NDArray[Any]
     ) -> Detections:
-        """
-        Run detection callback on a sliced portion of the image and adjust coordinates.
+        """Run detection callback on a sliced portion of the image and adjust
+        coordinates.
 
         Args:
             image: The full image.
@@ -559,8 +555,7 @@ class InferenceSlicer:
         image: ImageType | WindowedRasterDataset,
         offsets: list[npt.NDArray[Any]],
     ) -> list[Detections]:
-        """
-        Run batch inference callback on multiple slices.
+        """Run batch inference callback on multiple slices.
 
         Args:
             image: The full image or rasterio dataset.
@@ -700,8 +695,8 @@ class InferenceSlicer:
         slice_wh: tuple[int, int],
         overlap_wh: tuple[int, int],
     ) -> npt.NDArray[Any]:
-        """
-        Generate bounding boxes defining the coordinates of image slices with overlap.
+        """Generate bounding boxes defining the coordinates of image slices with
+        overlap.
 
         Args:
             resolution_wh: Image resolution `(width, height)`.

--- a/src/supervision/detection/tools/json_sink.py
+++ b/src/supervision/detection/tools/json_sink.py
@@ -11,9 +11,8 @@ from supervision.detection.core import Detections
 
 
 class JSONSink:
-    """
-    A utility class for saving detection data to a JSON file. This class is designed to
-    efficiently serialize detection objects into a JSON format, allowing for the
+    """A utility class for saving detection data to a JSON file. This class is designed
+    to efficiently serialize detection objects into a JSON format, allowing for the
     inclusion of bounding box coordinates and additional attributes like `confidence`,
     `class_id`, and `tracker_id`.
 

--- a/src/supervision/detection/tools/json_sink.py
+++ b/src/supervision/detection/tools/json_sink.py
@@ -49,8 +49,7 @@ class JSONSink:
     """
 
     def __init__(self, file_name: str = "output.json") -> None:
-        """
-        Initialize the JSONSink instance.
+        """Initialize the JSONSink instance.
 
         Args:
             file_name: The name of the JSON file.
@@ -82,8 +81,7 @@ class JSONSink:
 
     @staticmethod
     def _json_default(value: Any) -> Any:
-        """
-        Return a JSON-serializable equivalent of a NumPy scalar or array.
+        """Return a JSON-serializable equivalent of a NumPy scalar or array.
 
         Called as the ``default`` hook by :func:`json.dump`. Converts
         :class:`numpy.generic` scalars via ``.item()`` and
@@ -118,8 +116,7 @@ class JSONSink:
 
     @staticmethod
     def _slice_value(value: Any, i: int, n: int) -> Any:
-        """
-        Return the i-th element when the value stores per-detection data.
+        """Return the i-th element when the value stores per-detection data.
 
         Dispatch rules:
             - np.ndarray with ndim == 0: return as-is for broadcasting
@@ -146,8 +143,7 @@ class JSONSink:
     def parse_detection_data(
         detections: Detections, custom_data: dict[str, Any] | None = None
     ) -> list[dict[str, Any]]:
-        """
-        Convert detections and optional custom data into per-detection rows.
+        """Convert detections and optional custom data into per-detection rows.
 
         Builds one dictionary per detection containing bounding box coordinates,
         detection attributes, and any values from ``detections.data`` or
@@ -197,8 +193,7 @@ class JSONSink:
     def append(
         self, detections: Detections, custom_data: dict[str, Any] | None = None
     ) -> None:
-        """
-        Append detection data to the JSON file.
+        """Append detection data to the JSON file.
 
         Args:
             detections: The detection data.

--- a/src/supervision/detection/tools/json_sink.py
+++ b/src/supervision/detection/tools/json_sink.py
@@ -72,9 +72,7 @@ class JSONSink:
         self.write_and_close()
 
     def open(self) -> None:
-        """
-        Open the JSON file for writing.
-        """
+        """Open the JSON file for writing."""
         parent_directory = os.path.dirname(self.file_name)
         if parent_directory and not os.path.exists(parent_directory):
             os.makedirs(parent_directory)
@@ -84,7 +82,8 @@ class JSONSink:
 
     @staticmethod
     def _json_default(value: Any) -> Any:
-        """Return a JSON-serializable equivalent of a NumPy scalar or array.
+        """
+        Return a JSON-serializable equivalent of a NumPy scalar or array.
 
         Called as the ``default`` hook by :func:`json.dump`. Converts
         :class:`numpy.generic` scalars via ``.item()`` and
@@ -108,9 +107,7 @@ class JSONSink:
         )
 
     def write_and_close(self) -> None:
-        """
-        Write and close the JSON file.
-        """
+        """Write and close the JSON file."""
         if self.file:
             try:
                 json.dump(

--- a/src/supervision/detection/tools/polygon_zone.py
+++ b/src/supervision/detection/tools/polygon_zone.py
@@ -93,8 +93,7 @@ class PolygonZone:
         )
 
     def trigger(self, detections: Detections) -> npt.NDArray[np.bool_]:
-        """
-        Determines if the detections are within the polygon zone.
+        """Determines if the detections are within the polygon zone.
 
         Anchor points are calculated from original (unclipped) detection boxes to
         avoid per-zone clipping shifting anchor positions. This prevents a single
@@ -193,8 +192,7 @@ class PolygonZoneAnnotator:
     def annotate(
         self, scene: npt.NDArray[Any], label: str | None = None
     ) -> npt.NDArray[Any]:
-        """
-        Annotates the polygon zone within a frame with a count of detected objects.
+        """Annotates the polygon zone within a frame with a count of detected objects.
 
         Args:
             scene: The image on which the polygon zone will be annotated

--- a/src/supervision/detection/tools/polygon_zone.py
+++ b/src/supervision/detection/tools/polygon_zone.py
@@ -14,8 +14,7 @@ from supervision.geometry.utils import get_polygon_center
 
 
 class PolygonZone:
-    """
-    A class for defining a polygon-shaped zone within a frame for detecting objects.
+    """A class for defining a polygon-shaped zone within a frame for detecting objects.
 
     !!! warning
 
@@ -132,8 +131,7 @@ class PolygonZone:
 
 
 class PolygonZoneAnnotator:
-    """
-    A class for annotating a polygon-shaped zone within a frame with a count of
+    """A class for annotating a polygon-shaped zone within a frame with a count of
     detected objects.
 
     Attributes:

--- a/src/supervision/detection/tools/smoother.py
+++ b/src/supervision/detection/tools/smoother.py
@@ -138,8 +138,7 @@ class DetectionsSmoother:
         self.tracks.clear()
 
     def update_with_detections(self, detections: Detections) -> Detections:
-        """
-        Updates the smoother with a new set of detections from a frame.
+        """Updates the smoother with a new set of detections from a frame.
 
         Args:
             detections: The detections to add to the smoother.
@@ -173,8 +172,7 @@ class DetectionsSmoother:
         return self.get_smoothed_detections(track_ids=current_track_ids)
 
     def get_track(self, track_id: int) -> Detections | None:
-        """
-        Return the smoothed `Detections` for a single track.
+        """Return the smoothed `Detections` for a single track.
 
         Averages `xyxy` over all valid (non-`None`) frames in the track window.
         `confidence` is averaged only over frames that carry it; frames with
@@ -226,8 +224,7 @@ class DetectionsSmoother:
         return ret
 
     def get_smoothed_detections(self, track_ids: set[int] | None = None) -> Detections:
-        """
-        Return the smoothed detections for the requested active tracks.
+        """Return the smoothed detections for the requested active tracks.
 
         Args:
             track_ids: Optional set of track IDs to include in the output. When

--- a/src/supervision/detection/tools/smoother.py
+++ b/src/supervision/detection/tools/smoother.py
@@ -144,7 +144,6 @@ class DetectionsSmoother:
         Args:
             detections: The detections to add to the smoother.
         """
-
         if detections.tracker_id is None:
             warnings.warn(
                 "Smoothing skipped. DetectionsSmoother requires tracker_id. Refer to "
@@ -174,7 +173,8 @@ class DetectionsSmoother:
         return self.get_smoothed_detections(track_ids=current_track_ids)
 
     def get_track(self, track_id: int) -> Detections | None:
-        """Return the smoothed `Detections` for a single track.
+        """
+        Return the smoothed `Detections` for a single track.
 
         Averages `xyxy` over all valid (non-`None`) frames in the track window.
         `confidence` is averaged only over frames that carry it; frames with
@@ -226,7 +226,8 @@ class DetectionsSmoother:
         return ret
 
     def get_smoothed_detections(self, track_ids: set[int] | None = None) -> Detections:
-        """Return the smoothed detections for the requested active tracks.
+        """
+        Return the smoothed detections for the requested active tracks.
 
         Args:
             track_ids: Optional set of track IDs to include in the output. When

--- a/src/supervision/detection/tools/smoother.py
+++ b/src/supervision/detection/tools/smoother.py
@@ -26,8 +26,7 @@ def _align_oriented_corners(corners: np.ndarray, reference: np.ndarray) -> np.nd
 
 
 class DetectionsSmoother:
-    """
-    A utility class for smoothing detections over multiple frames in video tracking.
+    """A utility class for smoothing detections over multiple frames in video tracking.
     It maintains a history of detections for each track and provides smoothed
     predictions based on these histories.
 
@@ -111,10 +110,9 @@ class DetectionsSmoother:
         )
 
     def reset(self) -> None:
-        """
-        Clears the per-track detection history so the smoother can be reused
-        across independent streams without carrying over frames from a
-        previous stream. The configured window `length` is preserved.
+        """Clears the per-track detection history so the smoother can be reused across
+        independent streams without carrying over frames from a previous stream. The
+        configured window `length` is preserved.
 
         Examples:
             ```pycon

--- a/src/supervision/detection/tools/transformers.py
+++ b/src/supervision/detection/tools/transformers.py
@@ -14,8 +14,7 @@ from supervision.detection.utils.converters import mask_to_xyxy
 def process_transformers_detection_result(
     detection_result: dict[str, Any], id2label: dict[int, str] | None
 ) -> dict[str, Any]:
-    """
-    Process the result of Transformers object detection functions such as
+    """Process the result of Transformers object detection functions such as
     `post_process` (v4) and `post_process_detection` (v5).
 
     Args:
@@ -43,8 +42,7 @@ def process_transformers_detection_result(
 def process_transformers_v4_segmentation_result(
     segmentation_result: dict[str, Any], id2label: dict[int, str] | None
 ) -> dict[str, Any]:
-    """
-    Process the result of Transformers segmentation functions such as
+    """Process the result of Transformers segmentation functions such as
     `post_process_panoptic`, `post_process_segmentation`, and `post_process_instance`
     (v4).
 
@@ -82,8 +80,7 @@ def process_transformers_v4_segmentation_result(
 def process_transformers_v5_segmentation_result(
     segmentation_result: Any, id2label: dict[int, str] | None
 ) -> dict[str, Any]:
-    """
-    Process the result of Transformers segmentation functions such as
+    """Process the result of Transformers segmentation functions such as
     `post_process_semantic_segmentation`, `post_process_instance_segmentation`, and
     `post_process_panoptic_segmentation` (v5).
 
@@ -112,8 +109,7 @@ def process_transformers_v5_segmentation_result(
 def process_transformers_v5_semantic_or_instance_segmentation_result(
     segmentation_result: dict[str, Any], id2label: dict[int, str] | None
 ) -> dict[str, Any]:
-    """
-    Process the result of Transformers segmentation functions such as
+    """Process the result of Transformers segmentation functions such as
     `post_process_semantic_segmentation` and `post_process_instance_segmentation` (v5).
 
     Args:

--- a/src/supervision/detection/tools/transformers.py
+++ b/src/supervision/detection/tools/transformers.py
@@ -151,8 +151,7 @@ def process_transformers_v5_semantic_or_instance_segmentation_result(
 def process_transformers_v4_panoptic_segmentation_result(
     segmentation_result: dict[str, Any], id2label: dict[int, str] | None
 ) -> dict[str, Any]:
-    """
-    Process the result of the Transformers function `post_process_panoptic` (v4).
+    """Process the result of the Transformers function `post_process_panoptic` (v4).
 
     Args:
         segmentation_result: Dictionary containing segmentation results with keys
@@ -185,8 +184,7 @@ def process_transformers_v4_panoptic_segmentation_result(
 def process_transformers_v5_panoptic_segmentation_result(
     segmentation_array: npt.NDArray[Any], id2label: dict[int, str] | None
 ) -> dict[str, Any]:
-    """
-    Process a v5 Transformers semantic segmentation tensor.
+    """Process a v5 Transformers semantic segmentation tensor.
 
     Args:
         segmentation_array: Segmentation array where unique values are class IDs.
@@ -210,8 +208,7 @@ def process_transformers_v5_panoptic_segmentation_result(
 
 
 def png_string_to_segmentation_array(png_string: bytes) -> npt.NDArray[Any]:
-    """
-    Convert a PNG byte string to a panoptic segmentation array.
+    """Convert a PNG byte string to a panoptic segmentation array.
 
     Args:
         png_string: A byte string representing the PNG image.
@@ -241,8 +238,7 @@ def append_class_names_to_data(
     id2label: dict[int, str] | None,
     data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """
-    Helper function to create or append to a data dictionary with class names if
+    """Helper function to create or append to a data dictionary with class names if
     available.
 
     Args:

--- a/src/supervision/detection/utils/boxes.py
+++ b/src/supervision/detection/utils/boxes.py
@@ -15,8 +15,7 @@ def clip_boxes(
     xyxy: npt.NDArray[np.number],
     resolution_wh: tuple[int, int],
 ) -> npt.NDArray[np.number]:
-    """
-    Clips bounding boxes coordinates to fit within the frame resolution.
+    """Clips bounding boxes coordinates to fit within the frame resolution.
 
     Args:
         xyxy: A numpy array of shape `(N, 4)` where each
@@ -58,8 +57,7 @@ def pad_boxes(
     px: int,
     py: int | None = None,
 ) -> npt.NDArray[np.number]:
-    """
-    Pads bounding boxes coordinates with a constant padding.
+    """Pads bounding boxes coordinates with a constant padding.
 
     Args:
         xyxy: A numpy array of shape `(N, 4)` where each
@@ -112,8 +110,7 @@ def denormalize_boxes(
     normalization_factor: float = 1.0,
     normalized_xyxy: npt.NDArray[np.number] | None = None,
 ) -> npt.NDArray[np.number]:
-    """
-    Convert normalized bounding box coordinates to absolute pixel coordinates.
+    """Convert normalized bounding box coordinates to absolute pixel coordinates.
 
     Multiplies each bounding box coordinate by image size and divides by
     `normalization_factor`, mapping values from normalized `[0, normalization_factor]`
@@ -427,8 +424,7 @@ def _oriented_box_anchors(
 def scale_boxes(
     xyxy: npt.NDArray[np.number], factor: float
 ) -> npt.NDArray[np.floating]:
-    """
-    Scale the dimensions of bounding boxes.
+    """Scale the dimensions of bounding boxes.
 
     Args:
         xyxy: An integer or floating-point array of shape `(n, 4)` containing
@@ -507,8 +503,7 @@ def spread_out_boxes(
     xyxy: npt.NDArray[np.number],
     max_iterations: int = 100,
 ) -> npt.NDArray[np.number]:
-    """
-    Spread out boxes that overlap with each other.
+    """Spread out boxes that overlap with each other.
 
     Args:
         xyxy: Numpy array of shape (N, 4) where N is the number of boxes.

--- a/src/supervision/detection/utils/converters.py
+++ b/src/supervision/detection/utils/converters.py
@@ -412,7 +412,8 @@ def mask_to_polygons(mask: npt.NDArray[np.bool_]) -> list[npt.NDArray[np.int32]]
 
 
 def _base48_decode(s: str) -> list[int]:
-    """Decode a COCO base-48 string to raw (delta-encoded) integers.
+    """
+    Decode a COCO base-48 string to raw (delta-encoded) integers.
 
     Implements the variable-length base-48 codec from the COCO API
     (pycocotools). Each integer is encoded across one or more 6-bit
@@ -462,7 +463,8 @@ def _base48_decode(s: str) -> list[int]:
 
 
 def _base48_encode(values: list[int]) -> str:
-    """Encode raw (delta-encoded) integers to a COCO base-48 string.
+    """
+    Encode raw (delta-encoded) integers to a COCO base-48 string.
 
     The inverse of :func:`_base48_decode`. Applies the same variable-length
     base-48 codec used by pycocotools.
@@ -556,7 +558,8 @@ def _delta_encode(counts: list[int]) -> list[int]:
 
 
 def is_compressed_rle(rle: object) -> bool:
-    """Return ``True`` if ``rle`` is a COCO compressed RLE (``str`` or ``bytes``).
+    """
+    Return ``True`` if ``rle`` is a COCO compressed RLE (``str`` or ``bytes``).
 
     Use this to branch between the compressed-string pipeline
     (:func:`_base48_decode` → :func:`_delta_decode`) and the uncompressed

--- a/src/supervision/detection/utils/converters.py
+++ b/src/supervision/detection/utils/converters.py
@@ -12,9 +12,7 @@ CoordinateConvention = Literal["inclusive", "exclusive"]
 
 
 def xyxy_to_polygons(box: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
-    """
-    Convert an array of boxes to an array of polygons.
-    Retains the input datatype.
+    """Convert an array of boxes to an array of polygons. Retains the input datatype.
 
     Args:
         box: An array of boxes (N, 4), where each box is represented as a
@@ -76,9 +74,8 @@ def polygon_to_mask(
 
 
 def xywh_to_xyxy(xywh: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
-    """
-    Converts bounding box coordinates from `(x, y, width, height)`
-    format to `(x_min, y_min, x_max, y_max)` format.
+    """Converts bounding box coordinates from `(x, y, width, height)` format to `(x_min,
+    y_min, x_max, y_max)` format.
 
     Args:
         xywh: A numpy array of shape `(N, 4)` where each row
@@ -109,9 +106,8 @@ def xywh_to_xyxy(xywh: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
 
 
 def xyxy_to_xywh(xyxy: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
-    """
-    Converts bounding box coordinates from `(x_min, y_min, x_max, y_max)`
-    format to `(x, y, width, height)` format.
+    """Converts bounding box coordinates from `(x_min, y_min, x_max, y_max)` format to
+    `(x, y, width, height)` format.
 
     Args:
         xyxy: A numpy array of shape `(N, 4)` where each row
@@ -143,8 +139,7 @@ def xyxy_to_xywh(xyxy: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
 
 
 def xcycwh_to_xyxy(xcycwh: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
-    """
-    Converts bounding box coordinates from `(center_x, center_y, width, height)`
+    """Converts bounding box coordinates from `(center_x, center_y, width, height)`
     format to `(x_min, y_min, x_max, y_max)` format.
 
     Args:
@@ -190,10 +185,9 @@ def xcycwh_to_xyxy(xcycwh: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
 
 
 def xyxy_to_xcycarh(xyxy: npt.NDArray[np.number]) -> npt.NDArray[np.floating]:
-    """
-    Converts bounding box coordinates from `(x_min, y_min, x_max, y_max)`
-    into measurement space to format `(center x, center y, aspect ratio, height)`,
-    where the aspect ratio is `width / height`.
+    """Converts bounding box coordinates from `(x_min, y_min, x_max, y_max)` into
+    measurement space to format `(center x, center y, aspect ratio, height)`, where the
+    aspect ratio is `width / height`.
 
     Args:
         xyxy: Bounding box in format `(x1, y1, x2, y2)`.
@@ -215,7 +209,6 @@ def xyxy_to_xcycarh(xyxy: npt.NDArray[np.number]) -> npt.NDArray[np.floating]:
                [32.5       , 47.5       ,  0.77..., 45.        ]])
 
         ```
-
     """
     if xyxy.size == 0:
         return np.empty((0, 4), dtype=float)
@@ -240,8 +233,7 @@ def mask_to_xyxy(
     masks: npt.NDArray[np.bool_],
     coordinate_convention: CoordinateConvention = "inclusive",
 ) -> npt.NDArray[np.int_]:
-    """
-    Converts a 3D `np.array` of 2D bool masks into a 2D `np.array` of bounding boxes.
+    """Converts a 3D `np.array` of 2D bool masks into a 2D `np.array` of bounding boxes.
 
     Args:
         masks: A 3D `np.array` of shape `(N, H, W)` containing 2D bool masks.
@@ -304,8 +296,8 @@ def xyxy_to_mask(
     resolution_wh: tuple[int, int],
     coordinate_convention: CoordinateConvention = "inclusive",
 ) -> npt.NDArray[np.bool_]:
-    """
-    Converts a 2D `np.ndarray` of bounding boxes into a 3D `np.ndarray` of bool masks.
+    """Converts a 2D `np.ndarray` of bounding boxes into a 3D `np.ndarray` of bool
+    masks.
 
     Args:
         boxes: A 2D `np.ndarray` of shape `(N, 4)` containing bounding boxes
@@ -375,8 +367,7 @@ def xyxy_to_mask(
 
 
 def mask_to_polygons(mask: npt.NDArray[np.bool_]) -> list[npt.NDArray[np.int32]]:
-    """
-    Converts a binary mask to a list of polygons.
+    """Converts a binary mask to a list of polygons.
 
     Args:
         mask: A binary mask represented as a 2D NumPy array of shape `(H, W)`,
@@ -663,8 +654,7 @@ def rle_to_mask(
     rle: npt.NDArray[np.integer[Any]] | list[int] | str | bytes,
     resolution_wh: tuple[int, int],
 ) -> npt.NDArray[np.bool_]:
-    """
-    Converts a COCO run-length encoding (RLE) to a binary mask.
+    """Converts a COCO run-length encoding (RLE) to a binary mask.
 
     Implements the COCO RLE format used by ``pycocotools``: pixels are counted
     in **column-major (Fortran) order** — top-to-bottom within each column,
@@ -736,8 +726,7 @@ def rle_to_mask(
 def mask_to_rle(
     mask: npt.NDArray[np.bool_], compressed: bool = False
 ) -> list[int] | str:
-    """
-    Converts a binary mask into a COCO run-length encoding (RLE).
+    """Converts a binary mask into a COCO run-length encoding (RLE).
 
     Produces RLE in the COCO format used by ``pycocotools``: pixels are counted
     in **column-major (Fortran) order** — top-to-bottom within each column,
@@ -811,8 +800,7 @@ def mask_to_rle(
 
 
 def polygon_to_xyxy(polygon: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
-    """
-    Converts a polygon represented by a NumPy array into a bounding box.
+    """Converts a polygon represented by a NumPy array into a bounding box.
 
     Args:
         polygon: A polygon represented by a NumPy array of shape `(N, 2)`,

--- a/src/supervision/detection/utils/converters.py
+++ b/src/supervision/detection/utils/converters.py
@@ -412,8 +412,7 @@ def mask_to_polygons(mask: npt.NDArray[np.bool_]) -> list[npt.NDArray[np.int32]]
 
 
 def _base48_decode(s: str) -> list[int]:
-    """
-    Decode a COCO base-48 string to raw (delta-encoded) integers.
+    """Decode a COCO base-48 string to raw (delta-encoded) integers.
 
     Implements the variable-length base-48 codec from the COCO API
     (pycocotools). Each integer is encoded across one or more 6-bit
@@ -463,8 +462,7 @@ def _base48_decode(s: str) -> list[int]:
 
 
 def _base48_encode(values: list[int]) -> str:
-    """
-    Encode raw (delta-encoded) integers to a COCO base-48 string.
+    """Encode raw (delta-encoded) integers to a COCO base-48 string.
 
     The inverse of :func:`_base48_decode`. Applies the same variable-length
     base-48 codec used by pycocotools.
@@ -558,8 +556,7 @@ def _delta_encode(counts: list[int]) -> list[int]:
 
 
 def is_compressed_rle(rle: object) -> bool:
-    """
-    Return ``True`` if ``rle`` is a COCO compressed RLE (``str`` or ``bytes``).
+    """Return ``True`` if ``rle`` is a COCO compressed RLE (``str`` or ``bytes``).
 
     Use this to branch between the compressed-string pipeline
     (:func:`_base48_decode` → :func:`_delta_decode`) and the uncompressed

--- a/src/supervision/detection/utils/internal.py
+++ b/src/supervision/detection/utils/internal.py
@@ -38,7 +38,8 @@ def _valid_rle_payload(prediction: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def extract_ultralytics_masks(yolov8_results: Any) -> npt.NDArray[np.bool_] | None:
-    """Extract boolean masks from Ultralytics results, cropping letterbox padding.
+    """
+    Extract boolean masks from Ultralytics results, cropping letterbox padding.
 
     Handles the case where the inference resolution differs from the original image
     shape by computing the letterbox padding offsets, cropping them out, and resizing
@@ -98,7 +99,8 @@ def _resolve_rle_mask(
     image_width: int,
     compact_masks: bool,
 ) -> tuple[npt.NDArray[np.bool_] | None, dict[str, Any] | None]:
-    """Decode one RLE prediction into (dense_mask, compact_pending).
+    """
+    Decode one RLE prediction into (dense_mask, compact_pending).
 
     Returns ``(dense_mask, None)`` when ``compact_masks=False`` or when the
     RLE size does not match the image size (fall back to dense decode).
@@ -170,7 +172,8 @@ def _decode_compact_masks(
     image_width: int,
     n_predictions: int,
 ) -> CompactMask | None:
-    """Decode deferred COCO-RLE entries and merge with polygon compact masks.
+    """
+    Decode deferred COCO-RLE entries and merge with polygon compact masks.
 
     Attempts a single batched ``CompactMask.from_coco_rle`` call for all pending
     items to eliminate per-prediction call overhead on the happy path.  On any

--- a/src/supervision/detection/utils/internal.py
+++ b/src/supervision/detection/utils/internal.py
@@ -38,8 +38,7 @@ def _valid_rle_payload(prediction: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def extract_ultralytics_masks(yolov8_results: Any) -> npt.NDArray[np.bool_] | None:
-    """
-    Extract boolean masks from Ultralytics results, cropping letterbox padding.
+    """Extract boolean masks from Ultralytics results, cropping letterbox padding.
 
     Handles the case where the inference resolution differs from the original image
     shape by computing the letterbox padding offsets, cropping them out, and resizing
@@ -99,8 +98,7 @@ def _resolve_rle_mask(
     image_width: int,
     compact_masks: bool,
 ) -> tuple[npt.NDArray[np.bool_] | None, dict[str, Any] | None]:
-    """
-    Decode one RLE prediction into (dense_mask, compact_pending).
+    """Decode one RLE prediction into (dense_mask, compact_pending).
 
     Returns ``(dense_mask, None)`` when ``compact_masks=False`` or when the
     RLE size does not match the image size (fall back to dense decode).
@@ -172,8 +170,7 @@ def _decode_compact_masks(
     image_width: int,
     n_predictions: int,
 ) -> CompactMask | None:
-    """
-    Decode deferred COCO-RLE entries and merge with polygon compact masks.
+    """Decode deferred COCO-RLE entries and merge with polygon compact masks.
 
     Attempts a single batched ``CompactMask.from_coco_rle`` call for all pending
     items to eliminate per-prediction call overhead on the happy path.  On any
@@ -503,8 +500,7 @@ def is_data_equal(
     data_a: _DetectionDataType,
     data_b: _DetectionDataType,
 ) -> bool:
-    """
-    Compares the data payloads of two Detections instances.
+    """Compares the data payloads of two Detections instances.
 
     Args:
         data_a, data_b: The data payloads of the instances.
@@ -518,8 +514,7 @@ def is_data_equal(
 
 
 def is_metadata_equal(metadata_a: _MetadataType, metadata_b: _MetadataType) -> bool:
-    """
-    Compares the metadata payloads of two Detections instances.
+    """Compares the metadata payloads of two Detections instances.
 
     Args:
         metadata_a, metadata_b: The metadata payloads of the instances.
@@ -541,8 +536,7 @@ def is_metadata_equal(metadata_a: _MetadataType, metadata_b: _MetadataType) -> b
 def merge_data(
     data_list: list[_DetectionDataType],
 ) -> _DetectionDataType:
-    """
-    Merges the data payloads of a list of Detections instances.
+    """Merges the data payloads of a list of Detections instances.
 
     Warning: Assumes that empty detections were filtered-out before passing data to
     this function.
@@ -600,8 +594,7 @@ def merge_data(
 
 
 def merge_metadata(metadata_list: list[_MetadataType]) -> _MetadataType:
-    """
-    Merge metadata from a list of metadata dictionaries.
+    """Merge metadata from a list of metadata dictionaries.
 
     This function combines the metadata dictionaries. If a key appears in more than one
     dictionary, the values must be identical for the merge to succeed.
@@ -657,8 +650,7 @@ def get_data_item(
     data: _DetectionDataType,
     index: int | slice | list[int] | npt.NDArray[np.integer | np.bool_],
 ) -> _DetectionDataType:
-    """
-    Retrieve a subset of the data dictionary based on the given index.
+    """Retrieve a subset of the data dictionary based on the given index.
 
     Args:
         data: The data dictionary of the Detections object.

--- a/src/supervision/detection/utils/iou_and_nms.py
+++ b/src/supervision/detection/utils/iou_and_nms.py
@@ -15,8 +15,7 @@ from supervision.utils.internal import warn_deprecated
 
 
 class OverlapFilter(Enum):
-    """
-    Enum specifying the strategy for filtering overlapping detections.
+    """Enum specifying the strategy for filtering overlapping detections.
 
     Attributes:
         NONE: Do not filter detections based on overlap.
@@ -53,8 +52,7 @@ class OverlapFilter(Enum):
 
 
 class OverlapMetric(Enum):
-    """
-    Enum specifying the metric for measuring overlap between detections.
+    """Enum specifying the metric for measuring overlap between detections.
 
     Attributes:
         IOU: Intersection over Union. A region-overlap metric that compares
@@ -400,8 +398,7 @@ def box_iou_batch_with_jaccard(
 
 
 def _polygon_areas(polygons: npt.NDArray[np.number]) -> npt.NDArray[np.float64]:
-    """
-    Compute the area of each oriented-box polygon using the shoelace formula.
+    """Compute the area of each oriented-box polygon using the shoelace formula.
 
     Each polygon is translated to its own first corner before the shoelace
     products, keeping representable integer coordinates with large origins (e.g.
@@ -429,8 +426,7 @@ def _polygon_areas(polygons: npt.NDArray[np.number]) -> npt.NDArray[np.float64]:
 
 
 def _aabb_envelopes(polygons: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
-    """
-    Compute the axis-aligned bounding envelope of each oriented box.
+    """Compute the axis-aligned bounding envelope of each oriented box.
 
     Args:
         polygons: ``(N, 4, 2)`` array of polygon corners.
@@ -449,8 +445,7 @@ def _overlapping_envelope_pairs(
     envelopes_true: npt.NDArray[np.number],
     envelopes_detection: npt.NDArray[np.number],
 ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
-    """
-    Return index pairs ``(i, j)`` whose axis-aligned envelopes overlap.
+    """Return index pairs ``(i, j)`` whose axis-aligned envelopes overlap.
 
     Uses a fused boolean evaluation to halve peak transient memory compared to
     named-intermediate form (4 separate NxM float64 arrays vs 1 boolean array).
@@ -774,9 +769,9 @@ def _mask_iou_batch_split(
     masks_detection: npt.NDArray[Any],
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> npt.NDArray[np.floating]:
-    """
-    Internal function. Compute Intersection over Union (IoU) of two sets of masks -
-    `masks_true` and `masks_detection`.
+    """Internal function.
+
+    Compute Intersection over Union (IoU) of two sets of masks - `masks_true` and `masks_detection`.
 
     Args:
         masks_true: 3D `np.ndarray` representing ground-truth masks.
@@ -1112,8 +1107,7 @@ def mask_soft_non_max_suppression(
 def _prepare_predictions_for_nms(
     predictions: npt.NDArray[np.floating],
 ) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-    """
-    Add an agnostic class column when missing, sort by descending score.
+    """Add an agnostic class column when missing, sort by descending score.
 
     Returns the score-descending sort index, the reordered predictions, and the category
     vector for the loop callers to consume.
@@ -1132,8 +1126,7 @@ def _nms_loop_from_iou_matrix(
     categories: npt.NDArray[np.floating],
     iou_threshold: float,
 ) -> npt.NDArray[np.bool_]:
-    """
-    Greedy NMS suppression loop given a precomputed pairwise IoU matrix.
+    """Greedy NMS suppression loop given a precomputed pairwise IoU matrix.
 
     Assumes `ious` is square with row/column order matching `categories`. Detections
     sharing a category whose IoU exceeds `iou_threshold` are dropped in favour of the
@@ -1287,8 +1280,7 @@ def _group_overlapping_masks(
     iou_threshold: float = 0.5,
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> list[list[int]]:
-    """
-    Apply greedy version of non-maximum merging to avoid detecting too many.
+    """Apply greedy version of non-maximum merging to avoid detecting too many.
 
     Args:
         predictions: An array of shape `(n, 5)` containing
@@ -1508,9 +1500,8 @@ def _non_max_merge_per_category(
     predictions: npt.NDArray[np.floating],
     group_within: Callable[[npt.NDArray[np.int_]], list[list[int]]],
 ) -> list[list[int]]:
-    """
-    Dispatch NMM grouping per class, then translate local indices back to the global row
-    positions of ``predictions``.
+    """Dispatch NMM grouping per class, then translate local indices back to the global
+    row positions of ``predictions``.
 
     ``group_within(global_indices)`` must return merge groups expressed in terms of
     *positions inside `global_indices`*, not absolute row positions. When
@@ -1543,9 +1534,8 @@ def _group_overlapping_boxes(
     iou_threshold: float = 0.5,
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> list[list[int]]:
-    """
-    Apply greedy version of non-maximum merging to avoid detecting too many overlapping
-    bounding boxes for a given object.
+    """Apply greedy version of non-maximum merging to avoid detecting too many
+    overlapping bounding boxes for a given object.
 
     Args:
         predictions: An array of shape `(n, 5)` containing
@@ -1733,8 +1723,7 @@ def _group_overlapping_oriented_boxes(
     iou_threshold: float = 0.5,
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> list[list[int]]:
-    """
-    Greedy non-maximum merging on oriented boxes.
+    """Greedy non-maximum merging on oriented boxes.
 
     Mirrors
     :func:`_group_overlapping_boxes` but uses :func:`oriented_box_iou_batch`.

--- a/src/supervision/detection/utils/iou_and_nms.py
+++ b/src/supervision/detection/utils/iou_and_nms.py
@@ -768,7 +768,8 @@ def _mask_iou_batch_split(
 ) -> npt.NDArray[np.floating]:
     """Internal function.
 
-    Compute Intersection over Union (IoU) of two sets of masks - `masks_true` and `masks_detection`.
+    Compute Intersection over Union (IoU) of two sets of masks - `masks_true` and
+    `masks_detection`.
 
     Args:
         masks_true: 3D `np.ndarray` representing ground-truth masks.

--- a/src/supervision/detection/utils/iou_and_nms.py
+++ b/src/supervision/detection/utils/iou_and_nms.py
@@ -400,7 +400,8 @@ def box_iou_batch_with_jaccard(
 
 
 def _polygon_areas(polygons: npt.NDArray[np.number]) -> npt.NDArray[np.float64]:
-    """Compute the area of each oriented-box polygon using the shoelace formula.
+    """
+    Compute the area of each oriented-box polygon using the shoelace formula.
 
     Each polygon is translated to its own first corner before the shoelace
     products, keeping representable integer coordinates with large origins (e.g.
@@ -428,7 +429,8 @@ def _polygon_areas(polygons: npt.NDArray[np.number]) -> npt.NDArray[np.float64]:
 
 
 def _aabb_envelopes(polygons: npt.NDArray[np.number]) -> npt.NDArray[np.number]:
-    """Compute the axis-aligned bounding envelope of each oriented box.
+    """
+    Compute the axis-aligned bounding envelope of each oriented box.
 
     Args:
         polygons: ``(N, 4, 2)`` array of polygon corners.
@@ -447,7 +449,8 @@ def _overlapping_envelope_pairs(
     envelopes_true: npt.NDArray[np.number],
     envelopes_detection: npt.NDArray[np.number],
 ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
-    """Return index pairs ``(i, j)`` whose axis-aligned envelopes overlap.
+    """
+    Return index pairs ``(i, j)`` whose axis-aligned envelopes overlap.
 
     Uses a fused boolean evaluation to halve peak transient memory compared to
     named-intermediate form (4 separate NxM float64 arrays vs 1 boolean array).
@@ -772,9 +775,8 @@ def _mask_iou_batch_split(
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> npt.NDArray[np.floating]:
     """
-    Internal function.
-    Compute Intersection over Union (IoU) of two sets of masks -
-        `masks_true` and `masks_detection`.
+    Internal function. Compute Intersection over Union (IoU) of two sets of masks -
+    `masks_true` and `masks_detection`.
 
     Args:
         masks_true: 3D `np.ndarray` representing ground-truth masks.
@@ -1110,10 +1112,11 @@ def mask_soft_non_max_suppression(
 def _prepare_predictions_for_nms(
     predictions: npt.NDArray[np.floating],
 ) -> tuple[npt.NDArray[np.int_], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-    """Add an agnostic class column when missing, sort by descending score.
+    """
+    Add an agnostic class column when missing, sort by descending score.
 
-    Returns the score-descending sort index, the reordered predictions, and the
-    category vector for the loop callers to consume.
+    Returns the score-descending sort index, the reordered predictions, and the category
+    vector for the loop callers to consume.
     """
     rows, columns = predictions.shape
     if columns == 5:
@@ -1129,11 +1132,12 @@ def _nms_loop_from_iou_matrix(
     categories: npt.NDArray[np.floating],
     iou_threshold: float,
 ) -> npt.NDArray[np.bool_]:
-    """Greedy NMS suppression loop given a precomputed pairwise IoU matrix.
+    """
+    Greedy NMS suppression loop given a precomputed pairwise IoU matrix.
 
-    Assumes `ious` is square with row/column order matching `categories`.
-    Detections sharing a category whose IoU exceeds `iou_threshold` are dropped
-    in favour of the higher-confidence entry.
+    Assumes `ious` is square with row/column order matching `categories`. Detections
+    sharing a category whose IoU exceeds `iou_threshold` are dropped in favour of the
+    higher-confidence entry.
     """
     rows = len(ious)
     ious = ious - np.eye(rows)
@@ -1284,7 +1288,7 @@ def _group_overlapping_masks(
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> list[list[int]]:
     """
-    Apply greedy version of non-maximum merging to avoid detecting too many
+    Apply greedy version of non-maximum merging to avoid detecting too many.
 
     Args:
         predictions: An array of shape `(n, 5)` containing
@@ -1504,13 +1508,14 @@ def _non_max_merge_per_category(
     predictions: npt.NDArray[np.floating],
     group_within: Callable[[npt.NDArray[np.int_]], list[list[int]]],
 ) -> list[list[int]]:
-    """Dispatch NMM grouping per class, then translate local indices back to
-    the global row positions of ``predictions``.
+    """
+    Dispatch NMM grouping per class, then translate local indices back to the global row
+    positions of ``predictions``.
 
-    ``group_within(global_indices)`` must return merge groups expressed in
-    terms of *positions inside `global_indices`*, not absolute row positions.
-    When ``predictions`` has no class column, a single pass over all rows is
-    performed instead of per-category iteration.
+    ``group_within(global_indices)`` must return merge groups expressed in terms of
+    *positions inside `global_indices`*, not absolute row positions. When
+    ``predictions`` has no class column, a single pass over all rows is performed
+    instead of per-category iteration.
     """
     if predictions.shape[1] == 5:
         global_indices = np.arange(len(predictions), dtype=int)
@@ -1539,8 +1544,8 @@ def _group_overlapping_boxes(
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> list[list[int]]:
     """
-    Apply greedy version of non-maximum merging to avoid detecting too many
-    overlapping bounding boxes for a given object.
+    Apply greedy version of non-maximum merging to avoid detecting too many overlapping
+    bounding boxes for a given object.
 
     Args:
         predictions: An array of shape `(n, 5)` containing
@@ -1729,7 +1734,9 @@ def _group_overlapping_oriented_boxes(
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> list[list[int]]:
     """
-    Greedy non-maximum merging on oriented boxes. Mirrors
+    Greedy non-maximum merging on oriented boxes.
+
+    Mirrors
     :func:`_group_overlapping_boxes` but uses :func:`oriented_box_iou_batch`.
     """
     merge_groups: list[list[int]] = []

--- a/src/supervision/detection/utils/iou_and_nms.py
+++ b/src/supervision/detection/utils/iou_and_nms.py
@@ -105,8 +105,7 @@ def box_iou(
     box_detection: list[float] | npt.NDArray[np.number],
     overlap_metric: OverlapMetric | str = OverlapMetric.IOU,
 ) -> float:
-    """
-    Compute overlap metric between two bounding boxes.
+    """Compute overlap metric between two bounding boxes.
 
     Supports standard IOU (intersection-over-union) and IOS
     (intersection-over-smaller-area) metrics. Returns the overlap value in range
@@ -188,8 +187,7 @@ def box_iou_batch(
     boxes_detection: npt.NDArray[np.number],
     overlap_metric: OverlapMetric | str = OverlapMetric.IOU,
 ) -> npt.NDArray[np.float32]:
-    """
-    Compute pairwise overlap scores between batches of bounding boxes.
+    """Compute pairwise overlap scores between batches of bounding boxes.
 
     Supports standard IOU (intersection-over-union) and IOS
     (intersection-over-smaller-area) metrics for all `boxes_true` and
@@ -478,9 +476,8 @@ def oriented_box_iou_batch(
     boxes_detection: npt.NDArray[np.number],
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> npt.NDArray[np.floating]:
-    """
-    Compute pairwise overlap scores between two sets of oriented bounding boxes
-    using the configured `overlap_metric`.
+    """Compute pairwise overlap scores between two sets of oriented bounding boxes using
+    the configured `overlap_metric`.
 
     Overlap areas are computed exactly via convex-polygon intersection, gated by
     a cheap axis-aligned envelope pre-filter — no rasterization is involved, so
@@ -837,9 +834,8 @@ def mask_iou_batch(
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
     memory_limit: int = 1024 * 5,
 ) -> npt.NDArray[np.floating]:
-    """
-    Compute Intersection over Union (IoU) of two sets of masks -
-        `masks_true` and `masks_detection`.
+    """Compute Intersection over Union (IoU) of two sets of masks - `masks_true` and
+    `masks_detection`.
 
     Accepts both dense ``(N, H, W)`` boolean arrays and
     :class:`~supervision.detection.compact_mask.CompactMask` objects.
@@ -947,8 +943,7 @@ def mask_non_max_suppression(
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
     mask_dimension: int = 640,
 ) -> npt.NDArray[np.bool_]:
-    """
-    Perform Non-Maximum Suppression (NMS) on segmentation predictions.
+    """Perform Non-Maximum Suppression (NMS) on segmentation predictions.
 
     IoU is computed exactly on the full-resolution masks for both dense and
     :class:`~supervision.detection.compact_mask.CompactMask` inputs.  The
@@ -1026,8 +1021,7 @@ def mask_soft_non_max_suppression(
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
     mask_dimension: int = 640,
 ) -> npt.NDArray[np.floating]:
-    """
-    Perform Soft Non-Maximum Suppression (Soft-NMS) on segmentation predictions.
+    """Perform Soft Non-Maximum Suppression (Soft-NMS) on segmentation predictions.
 
     Unlike `mask_non_max_suppression`, which discards overlapping masks outright,
     Soft-NMS keeps every detection and instead rescales its confidence by
@@ -1178,8 +1172,7 @@ def box_non_max_suppression(
     iou_threshold: float = 0.5,
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> npt.NDArray[np.bool_]:
-    """
-    Perform Non-Maximum Suppression (NMS) on object detection predictions.
+    """Perform Non-Maximum Suppression (NMS) on object detection predictions.
 
     Args:
         predictions: An array of object detection predictions in
@@ -1224,8 +1217,7 @@ def box_soft_non_max_suppression(
     sigma: float = 0.5,
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> npt.NDArray[np.floating]:
-    """
-    Perform Soft Non-Maximum Suppression (Soft-NMS) on object detection predictions.
+    """Perform Soft Non-Maximum Suppression (Soft-NMS) on object detection predictions.
 
     Unlike `box_non_max_suppression`, which discards overlapping boxes outright,
     Soft-NMS keeps every detection and instead rescales its confidence by
@@ -1338,8 +1330,7 @@ def mask_non_max_merge(
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
     mask_dimension: int = 640,
 ) -> list[list[int]]:
-    """
-    Perform Non-Maximum Merging (NMM) on segmentation predictions.
+    """Perform Non-Maximum Merging (NMM) on segmentation predictions.
 
     Args:
         predictions: A 2D array of object detection predictions in
@@ -1576,9 +1567,8 @@ def box_non_max_merge(
     iou_threshold: float = 0.5,
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> list[list[int]]:
-    """
-    Apply greedy version of non-maximum merging per category to avoid detecting
-    too many overlapping bounding boxes for a given object.
+    """Apply greedy version of non-maximum merging per category to avoid detecting too
+    many overlapping bounding boxes for a given object.
 
     Args:
         predictions: An array of shape `(n, 5)` or `(n, 6)`
@@ -1627,8 +1617,7 @@ def oriented_box_non_max_suppression(
     iou_threshold: float = 0.5,
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> npt.NDArray[np.bool_]:
-    """
-    Perform Non-Maximum Suppression on oriented bounding box predictions.
+    """Perform Non-Maximum Suppression on oriented bounding box predictions.
 
     Overlap is computed via :func:`oriented_box_iou_batch` on the four
     corners of each box, so detections whose axis-aligned bounding boxes
@@ -1755,9 +1744,8 @@ def oriented_box_non_max_merge(
     iou_threshold: float = 0.5,
     overlap_metric: OverlapMetric = OverlapMetric.IOU,
 ) -> list[list[int]]:
-    """
-    Perform Non-Maximum Merging on oriented bounding box predictions,
-    grouped per category.
+    """Perform Non-Maximum Merging on oriented bounding box predictions, grouped per
+    category.
 
     Mirrors :func:`box_non_max_merge` but uses oriented-box IoU, so groups
     of rotated detections sharing the same body — rather than the same

--- a/src/supervision/detection/utils/masks.py
+++ b/src/supervision/detection/utils/masks.py
@@ -555,7 +555,8 @@ def _compact_masks_to_roi(
     masks: CompactMask,
     image_shape: tuple[int, int],
 ) -> tuple[int, int, int, int] | None:
-    """Return exclusive bounding-box union for compact masks.
+    """
+    Return exclusive bounding-box union for compact masks.
 
     Uses crop metadata (offsets + shapes) — no RLE decode required.
 
@@ -587,7 +588,8 @@ def _masks_to_roi(
     image_shape: tuple[int, int],
     xyxy: npt.NDArray[np.number] | None = None,
 ) -> tuple[int, int, int, int] | None:
-    """Return exclusive true-pixel bounds for dense or compact masks.
+    """
+    Return exclusive true-pixel bounds for dense or compact masks.
 
     Args:
         masks: Dense boolean mask array of shape ``(N, H, W)`` or ``(H, W)``,

--- a/src/supervision/detection/utils/masks.py
+++ b/src/supervision/detection/utils/masks.py
@@ -294,8 +294,7 @@ def contains_multiple_segments(
 def resize_masks(
     masks: npt.NDArray[np.bool_], max_dimension: int = 640
 ) -> npt.NDArray[np.bool_]:
-    """
-    Resize all masks in the array to have a maximum dimension of max_dimension,
+    """Resize all masks in the array to have a maximum dimension of max_dimension,
     maintaining aspect ratio.
 
     Args:
@@ -555,8 +554,7 @@ def _compact_masks_to_roi(
     masks: CompactMask,
     image_shape: tuple[int, int],
 ) -> tuple[int, int, int, int] | None:
-    """
-    Return exclusive bounding-box union for compact masks.
+    """Return exclusive bounding-box union for compact masks.
 
     Uses crop metadata (offsets + shapes) — no RLE decode required.
 
@@ -588,8 +586,7 @@ def _masks_to_roi(
     image_shape: tuple[int, int],
     xyxy: npt.NDArray[np.number] | None = None,
 ) -> tuple[int, int, int, int] | None:
-    """
-    Return exclusive true-pixel bounds for dense or compact masks.
+    """Return exclusive true-pixel bounds for dense or compact masks.
 
     Args:
         masks: Dense boolean mask array of shape ``(N, H, W)`` or ``(H, W)``,

--- a/src/supervision/detection/utils/masks.py
+++ b/src/supervision/detection/utils/masks.py
@@ -42,8 +42,7 @@ def move_masks(
     offset: npt.NDArray[np.integer],
     resolution_wh: tuple[int, int],
 ) -> npt.NDArray[np.bool_]:
-    """
-    Offset the masks in an array by the specified (x, y) amount.
+    """Offset the masks in an array by the specified (x, y) amount.
 
     Args:
         masks: A 3D array of binary masks corresponding to the
@@ -118,8 +117,7 @@ def move_masks(
 def calculate_masks_centroids(
     masks: npt.NDArray[np.bool_] | CompactMask,
 ) -> npt.NDArray[np.int_]:
-    """
-    Calculate the centroids of binary masks in a tensor.
+    """Calculate the centroids of binary masks in a tensor.
 
     Args:
         masks: A 3D NumPy array of shape (num_masks, height, width).
@@ -188,8 +186,7 @@ def calculate_masks_centroids(
 
 
 def contains_holes(mask: npt.NDArray[np.bool_]) -> bool:
-    """
-    Checks if the binary mask contains holes (background pixels fully enclosed by
+    """Checks if the binary mask contains holes (background pixels fully enclosed by
     foreground pixels).
 
     Args:
@@ -232,8 +229,7 @@ def contains_holes(mask: npt.NDArray[np.bool_]) -> bool:
 def contains_multiple_segments(
     mask: npt.NDArray[np.bool_], connectivity: int = 4
 ) -> bool:
-    """
-    Checks if the binary mask contains multiple unconnected foreground segments.
+    """Checks if the binary mask contains multiple unconnected foreground segments.
 
     Args:
         mask: 2D binary mask where `True` indicates foreground
@@ -373,8 +369,7 @@ def filter_segments_by_distance(
     connectivity: int = 8,
     mode: Literal["edge", "centroid"] = "edge",
 ) -> npt.NDArray[np.bool_]:
-    """
-    Keep the largest connected component and any other components within a distance
+    """Keep the largest connected component and any other components within a distance
     threshold.
 
     Distance can be absolute in pixels or relative to the image diagonal.

--- a/src/supervision/detection/utils/polygons.py
+++ b/src/supervision/detection/utils/polygons.py
@@ -7,11 +7,12 @@ from supervision import _cv2 as cv2
 def _to_local_cv2_polygon(
     polygon: npt.NDArray[np.number],
 ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.number]]:
-    """Translate a polygon to a local float32 coordinate system for OpenCV.
+    """
+    Translate a polygon to a local float32 coordinate system for OpenCV.
 
-    Integer subtraction uses object arithmetic so unsigned and signed inputs do
-    not wrap before conversion. Translating first preserves representable local
-    geometry when absolute coordinates exceed float32 precision.
+    Integer subtraction uses object arithmetic so unsigned and signed inputs do not wrap
+    before conversion. Translating first preserves representable local geometry when
+    absolute coordinates exceed float32 precision.
     """
     origin = polygon.min(axis=0)
     if np.issubdtype(polygon.dtype, np.integer):

--- a/src/supervision/detection/utils/polygons.py
+++ b/src/supervision/detection/utils/polygons.py
@@ -31,8 +31,7 @@ def filter_polygons_by_area(
     min_area: float | None = None,
     max_area: float | None = None,
 ) -> list[npt.NDArray[np.number]]:
-    """
-    Filters a list of polygons based on their area.
+    """Filters a list of polygons based on their area.
 
     Args:
         polygons: A list of polygons, where each polygon is
@@ -79,8 +78,7 @@ def filter_polygons_by_area(
 def approximate_polygon(
     polygon: npt.NDArray[np.number], percentage: float, epsilon_step: float = 0.05
 ) -> npt.NDArray[np.number]:
-    """
-    Approximates a given polygon by reducing a certain percentage of points.
+    """Approximates a given polygon by reducing a certain percentage of points.
 
     This function uses the Ramer-Douglas-Peucker algorithm to simplify the input
     polygon by reducing the number of points while preserving the general shape.

--- a/src/supervision/detection/utils/polygons.py
+++ b/src/supervision/detection/utils/polygons.py
@@ -7,8 +7,7 @@ from supervision import _cv2 as cv2
 def _to_local_cv2_polygon(
     polygon: npt.NDArray[np.number],
 ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.number]]:
-    """
-    Translate a polygon to a local float32 coordinate system for OpenCV.
+    """Translate a polygon to a local float32 coordinate system for OpenCV.
 
     Integer subtraction uses object arithmetic so unsigned and signed inputs do not wrap
     before conversion. Translating first preserves representable local geometry when

--- a/src/supervision/detection/utils/vlms.py
+++ b/src/supervision/detection/utils/vlms.py
@@ -1,6 +1,5 @@
 def edit_distance(string_1: str, string_2: str, case_sensitive: bool = True) -> int:
-    """
-    Calculates the minimum number of single-character edits required to transform one
+    """Calculates the minimum number of single-character edits required to transform one
     string into another. Allowed operations are insertion, deletion, and substitution.
 
     Args:
@@ -64,9 +63,8 @@ def fuzzy_match_index(
     threshold: int,
     case_sensitive: bool = True,
 ) -> int | None:
-    """
-    Searches for the first string in `candidates` whose edit distance to `query` is less
-    than or equal to `threshold`.
+    """Searches for the first string in `candidates` whose edit distance to `query` is
+    less than or equal to `threshold`.
 
     Args:
         candidates: List of strings to search.

--- a/src/supervision/detection/utils/vlms.py
+++ b/src/supervision/detection/utils/vlms.py
@@ -1,8 +1,7 @@
 def edit_distance(string_1: str, string_2: str, case_sensitive: bool = True) -> int:
     """
-    Calculates the minimum number of single-character edits required
-    to transform one string into another. Allowed operations are insertion,
-    deletion, and substitution.
+    Calculates the minimum number of single-character edits required to transform one
+    string into another. Allowed operations are insertion, deletion, and substitution.
 
     Args:
         string_1: The source string to be transformed.
@@ -66,8 +65,8 @@ def fuzzy_match_index(
     case_sensitive: bool = True,
 ) -> int | None:
     """
-    Searches for the first string in `candidates` whose edit distance
-    to `query` is less than or equal to `threshold`.
+    Searches for the first string in `candidates` whose edit distance to `query` is less
+    than or equal to `threshold`.
 
     Args:
         candidates: List of strings to search.

--- a/src/supervision/detection/vlm.py
+++ b/src/supervision/detection/vlm.py
@@ -20,8 +20,7 @@ from supervision.validators import _validate_resolution
 
 
 class LMM(Enum):
-    """
-    Enum specifying supported Large Multimodal Models (LMMs).
+    """Enum specifying supported Large Multimodal Models (LMMs).
 
     !!! deprecated "Deprecated"
 
@@ -72,8 +71,7 @@ class LMM(Enum):
 
 
 class VLM(Enum):
-    """
-    Enum specifying supported Vision-Language Models (VLMs).
+    """Enum specifying supported Vision-Language Models (VLMs).
 
     Attributes:
         PALIGEMMA: Google's PaliGemma vision-language model.
@@ -169,8 +167,7 @@ SUPPORTED_TASKS_FLORENCE_2 = [
 def _validate_vlm_parameters(
     vlm: VLM | str, result: Any, kwargs: dict[str, Any]
 ) -> VLM:
-    """
-    Validates the parameters and result type for a given Vision-Language Model (VLM).
+    """Validates the parameters and result type for a given Vision-Language Model (VLM).
 
     Args:
         vlm: The VLM enum or string specifying the model.
@@ -221,8 +218,7 @@ def validate_vlm_parameters(vlm: VLM | str, result: Any, kwargs: dict[str, Any])
 def from_paligemma(
     result: str, resolution_wh: tuple[int, int], classes: list[str] | None = None
 ) -> tuple[npt.NDArray[Any], npt.NDArray[Any] | None, npt.NDArray[Any]]:
-    """
-    Parse bounding boxes from paligemma-formatted text, scale them to the specified
+    """Parse bounding boxes from paligemma-formatted text, scale them to the specified
     resolution, and optionally filter by classes.
 
     Args:
@@ -263,9 +259,8 @@ def from_paligemma(
 
 
 def recover_truncated_qwen_2_5_vl_response(text: str) -> Any | None:
-    """
-    Attempt to recover and parse a truncated or malformed JSON snippet from Qwen-2.5-VL
-    output.
+    """Attempt to recover and parse a truncated or malformed JSON snippet from
+    Qwen-2.5-VL output.
 
     This utility extracts a JSON-like portion from a string that may be truncated or
     malformed, cleans trailing commas, and attempts to parse it into a Python object.
@@ -313,8 +308,7 @@ def from_qwen_2_5_vl(
     resolution_wh: tuple[int, int],
     classes: list[str] | None = None,
 ) -> tuple[npt.NDArray[Any], npt.NDArray[Any] | None, npt.NDArray[Any]]:
-    """
-    Parse and rescale bounding boxes and class labels from Qwen-2.5-VL JSON output.
+    """Parse and rescale bounding boxes and class labels from Qwen-2.5-VL JSON output.
 
     The JSON is expected to be enclosed in triple backticks with the format:
       ```json
@@ -403,8 +397,7 @@ def from_qwen_3_vl(
     resolution_wh: tuple[int, int],
     classes: list[str] | None = None,
 ) -> tuple[npt.NDArray[Any], npt.NDArray[Any] | None, npt.NDArray[Any]]:
-    """
-    Parse and scale bounding boxes from Qwen-3-VL style JSON output.
+    """Parse and scale bounding boxes from Qwen-3-VL style JSON output.
 
     Args:
         result: String containing the Qwen-3-VL JSON output.
@@ -428,9 +421,8 @@ def from_qwen_3_vl(
 def from_deepseek_vl_2(
     result: str, resolution_wh: tuple[int, int], classes: list[str] | None = None
 ) -> tuple[npt.NDArray[Any], npt.NDArray[Any] | None, npt.NDArray[Any]]:
-    """
-    Parse bounding boxes from deepseek-vl2-formatted text, scale them to the specified
-    resolution, and optionally filter by classes.
+    """Parse bounding boxes from deepseek-vl2-formatted text, scale them to the
+    specified resolution, and optionally filter by classes.
 
     The DeepSeek-VL2 output typically contains pairs of <|ref|> ... <|/ref|> labels
     and <|det|> ... <|/det|> bounding box definitions. Each <|det|> section may
@@ -606,8 +598,7 @@ def from_florence_2(
 
 
 def _recover_gemini_json_objects(text: str) -> list[Any]:
-    """
-    Salvage individual JSON objects from a malformed Gemini JSON array.
+    """Salvage individual JSON objects from a malformed Gemini JSON array.
 
     Scans for balanced `{...}` spans and parses each independently, keeping the
     ones that decode into a `dict` and skipping the rest. This recovers the valid
@@ -909,8 +900,8 @@ def from_google_gemini_3_5(
     npt.NDArray[Any] | None,
     npt.NDArray[Any] | None,
 ]:
-    """
-    Parse and scale bounding boxes and masks from Google Gemini 3.5 style JSON output.
+    """Parse and scale bounding boxes and masks from Google Gemini 3.5 style JSON
+    output.
 
     Gemini 3.5 emits the same detection JSON as Gemini 2.5 (`box_2d` in
     `[y_min, x_min, y_max, x_max]` normalized to 0-1000, plus `label` and optional
@@ -933,8 +924,7 @@ def from_moondream(
     result: dict[str, Any],
     resolution_wh: tuple[int, int],
 ) -> npt.NDArray[Any]:
-    """
-    Parse and scale bounding boxes from moondream JSON output.
+    """Parse and scale bounding boxes from moondream JSON output.
 
     The JSON is expected to have a key "objects" with a list of dictionaries:
       {

--- a/src/supervision/detection/vlm.py
+++ b/src/supervision/detection/vlm.py
@@ -237,7 +237,6 @@ def from_paligemma(
             optional array of shape `(n,)` with class indices, and `class_name`
             is an array of shape `(n,)` with class labels.
     """
-
     w, h = _validate_resolution(resolution_wh)
 
     pattern = re.compile(
@@ -339,7 +338,6 @@ def from_qwen_2_5_vl(
             is an optional array of shape `(N,)` with class indices, and
             `class_name` is an array of shape `(N,)` with class names.
     """
-
     in_w, in_h = _validate_resolution(input_wh)
     out_w, out_h = _validate_resolution(resolution_wh)
 
@@ -681,7 +679,6 @@ def from_google_gemini_2_0(
             is an array of shape `(n,)` with class labels.
 
     """
-
     w, h = _validate_resolution(resolution_wh)
 
     lines = result.splitlines()
@@ -963,7 +960,6 @@ def from_moondream(
         An array of shape `(n, 4)` containing the bounding boxes coordinates
             in format `[x1, y1, x2, y2]`.
     """
-
     w, h = resolution_wh
     if w <= 0 or h <= 0:
         raise ValueError(

--- a/src/supervision/draw/base.py
+++ b/src/supervision/draw/base.py
@@ -8,7 +8,7 @@ ImageType = TypeVar("ImageType", npt.NDArray[np.uint8], Image.Image)
 """
 An image of type `np.ndarray` or `PIL.Image.Image`.
 
-Unlike a `Union`, ensures the type remains consistent. If a function
-takes an `ImageType` argument and returns an `ImageType`, when you
-pass an `np.ndarray`, you will get an `np.ndarray` back.
+Unlike a `Union`, ensures the type remains consistent. If a function takes an
+`ImageType` argument and returns an `ImageType`, when you pass an `np.ndarray`, you will
+get an `np.ndarray` back.
 """

--- a/src/supervision/draw/base.py
+++ b/src/supervision/draw/base.py
@@ -5,8 +5,7 @@ import numpy.typing as npt
 from PIL import Image
 
 ImageType = TypeVar("ImageType", npt.NDArray[np.uint8], Image.Image)
-"""
-An image of type `np.ndarray` or `PIL.Image.Image`.
+"""An image of type `np.ndarray` or `PIL.Image.Image`.
 
 Unlike a `Union`, ensures the type remains consistent. If a function takes an
 `ImageType` argument and returns an `ImageType`, when you pass an `np.ndarray`, you will

--- a/src/supervision/draw/color.py
+++ b/src/supervision/draw/color.py
@@ -62,8 +62,7 @@ def _validate_color_hex(color_hex: str) -> None:
 
 @dataclass
 class Color:
-    """
-    Represents a color in RGBA format.
+    """Represents a color in RGBA format.
 
     This class provides methods to work with colors, including creating colors from hex
     codes, converting colors to hex strings, RGB tuples, BGR tuples, RGBA tuples,
@@ -115,8 +114,7 @@ class Color:
 
     @classmethod
     def from_hex(cls, color_hex: str) -> Color:
-        """
-        Create a Color instance from a hex string.
+        """Create a Color instance from a hex string.
 
         Args:
             color_hex: The hex string representing the color. This string can
@@ -158,8 +156,7 @@ class Color:
 
     @classmethod
     def from_rgb_tuple(cls, color_tuple: tuple[int, int, int]) -> Color:
-        """
-        Create a Color instance from an RGB tuple.
+        """Create a Color instance from an RGB tuple.
 
         Args:
             color_tuple: A tuple representing the color in RGB format, where each
@@ -186,8 +183,7 @@ class Color:
 
     @classmethod
     def from_bgr_tuple(cls, color_tuple: tuple[int, int, int]) -> Color:
-        """
-        Create a Color instance from a BGR tuple.
+        """Create a Color instance from a BGR tuple.
 
         Args:
             color_tuple: A tuple representing the color in BGR format, where each
@@ -214,8 +210,7 @@ class Color:
 
     @classmethod
     def from_rgba_tuple(cls, color_tuple: tuple[int, int, int, int]) -> Color:
-        """
-        Create a Color instance from an RGBA tuple.
+        """Create a Color instance from an RGBA tuple.
 
         Args:
             color_tuple: A tuple representing the color in RGBA format, where each
@@ -244,8 +239,7 @@ class Color:
 
     @classmethod
     def from_bgra_tuple(cls, color_tuple: tuple[int, int, int, int]) -> Color:
-        """
-        Create a Color instance from a BGRA tuple.
+        """Create a Color instance from a BGRA tuple.
 
         Args:
             color_tuple: A tuple representing the color in BGRA format, where each
@@ -273,8 +267,7 @@ class Color:
         return cls(r=r, g=g, b=b, a=a)
 
     def as_hex(self) -> str:
-        """
-        Converts the Color instance to a hex string.
+        """Converts the Color instance to a hex string.
 
         Returns:
             The hexadecimal color string. Returns `#RRGGBBAA` if alpha is not 255,
@@ -296,8 +289,7 @@ class Color:
         return f"#{self.r:02x}{self.g:02x}{self.b:02x}"
 
     def as_rgb(self) -> tuple[int, int, int]:
-        """
-        Returns the color as an RGB tuple.
+        """Returns the color as an RGB tuple.
 
         Returns:
             RGB tuple.
@@ -313,8 +305,7 @@ class Color:
         return self.r, self.g, self.b
 
     def as_bgr(self) -> tuple[int, int, int]:
-        """
-        Returns the color as a BGR tuple.
+        """Returns the color as a BGR tuple.
 
         Returns:
             BGR tuple.
@@ -330,8 +321,7 @@ class Color:
         return self.b, self.g, self.r
 
     def as_rgba(self) -> tuple[int, int, int, int]:
-        """
-        Returns the color as an RGBA tuple.
+        """Returns the color as an RGBA tuple.
 
         Returns:
             RGBA tuple.
@@ -347,8 +337,7 @@ class Color:
         return self.r, self.g, self.b, self.a
 
     def as_bgra(self) -> tuple[int, int, int, int]:
-        """
-        Returns the color as a BGRA tuple.
+        """Returns the color as a BGRA tuple.
 
         Returns:
             BGRA tuple.
@@ -419,8 +408,7 @@ class ColorPalette:
 
     @classproperty
     def DEFAULT(cls) -> ColorPalette:
-        """
-        Returns a default color palette.
+        """Returns a default color palette.
 
         Returns:
             A ColorPalette instance with default colors.
@@ -440,8 +428,7 @@ class ColorPalette:
 
     @classproperty
     def ROBOFLOW(cls) -> ColorPalette:
-        """
-        Returns a Roboflow color palette.
+        """Returns a Roboflow color palette.
 
         Returns:
             A ColorPalette instance with Roboflow colors.
@@ -488,8 +475,7 @@ class ColorPalette:
 
     @classmethod
     def from_matplotlib(cls, palette_name: str, color_count: int) -> ColorPalette:
-        """
-        Create a ColorPalette instance from a Matplotlib color palette.
+        """Create a ColorPalette instance from a Matplotlib color palette.
 
         Args:
             palette_name: Name of the Matplotlib palette.
@@ -561,8 +547,7 @@ class ColorPalette:
         return self.colors[idx]
 
     def __len__(self) -> int:
-        """
-        Returns the number of colors in the palette.
+        """Returns the number of colors in the palette.
 
         Returns:
             The number of colors.
@@ -571,8 +556,7 @@ class ColorPalette:
 
 
 def unify_to_bgr(color: tuple[int, int, int] | Color) -> tuple[int, int, int]:
-    """
-    Converts a color input in multiple formats to a standardized BGR format.
+    """Converts a color input in multiple formats to a standardized BGR format.
 
     Args:
         color: The color input to be converted,

--- a/src/supervision/draw/color.py
+++ b/src/supervision/draw/color.py
@@ -452,8 +452,7 @@ class ColorPalette:
 
     @classmethod
     def from_hex(cls, color_hex_list: list[str]) -> ColorPalette:
-        """
-        Create a ColorPalette instance from a list of hex strings.
+        """Create a ColorPalette instance from a list of hex strings.
 
         Args:
             color_hex_list: List of color hex strings.
@@ -521,8 +520,7 @@ class ColorPalette:
         )
 
     def by_idx(self, idx: int) -> Color:
-        """
-        Return the color at a given index in the palette.
+        """Return the color at a given index in the palette.
 
         Args:
             idx: Index of the color in the palette.

--- a/src/supervision/draw/utils.py
+++ b/src/supervision/draw/utils.py
@@ -486,8 +486,8 @@ def draw_image(
 def calculate_optimal_text_scale(resolution_wh: tuple[int, int]) -> float:
     """Calculate optimal font scale based on image resolution.
 
-    Adjusts font scale proportionally to the smallest dimension of the given image resolution for
-    consistent readability.
+    Adjusts font scale proportionally to the smallest dimension of the given image
+    resolution for consistent readability.
 
     Args:
         resolution_wh: A tuple of `(width, height)` of the image in pixels.
@@ -511,8 +511,8 @@ def calculate_optimal_text_scale(resolution_wh: tuple[int, int]) -> float:
 def calculate_optimal_line_thickness(resolution_wh: tuple[int, int]) -> int:
     """Calculate optimal line thickness based on image resolution.
 
-    Adjusts the line thickness for readability depending on the smallest dimension of the provided
-    image resolution.
+    Adjusts the line thickness for readability depending on the smallest dimension of
+    the provided image resolution.
 
     Args:
         resolution_wh: A tuple of `(width, height)` of the image in pixels.

--- a/src/supervision/draw/utils.py
+++ b/src/supervision/draw/utils.py
@@ -16,8 +16,7 @@ def draw_line(
     color: Color = Color.ROBOFLOW,
     thickness: int = 2,
 ) -> npt.NDArray[np.uint8]:
-    """
-    Draws a line on a given scene.
+    """Draws a line on a given scene.
 
     Args:
         scene: The scene on which the line will be drawn
@@ -60,8 +59,7 @@ def draw_rectangle(
     color: Color = Color.ROBOFLOW,
     thickness: int = 2,
 ) -> npt.NDArray[np.uint8]:
-    """
-    Draws a rectangle on an image.
+    """Draws a rectangle on an image.
 
     Args:
         scene: The scene on which the rectangle will be drawn
@@ -102,8 +100,7 @@ def draw_filled_rectangle(
     color: Color = Color.ROBOFLOW,
     opacity: float = 1,
 ) -> npt.NDArray[np.uint8]:
-    """
-    Draws a filled rectangle on an image.
+    """Draws a filled rectangle on an image.
 
     Args:
         scene: The scene on which the rectangle will be drawn
@@ -158,8 +155,7 @@ def draw_rounded_rectangle(
     color: Color,
     border_radius: int,
 ) -> npt.NDArray[np.uint8]:
-    """
-    Draws a rounded rectangle on an image.
+    """Draws a rounded rectangle on an image.
 
     Args:
         scene: The image on which the rounded rectangle will be drawn.
@@ -323,8 +319,7 @@ def draw_text(
     text_font: int = cv2.FONT_HERSHEY_SIMPLEX,
     background_color: Color | None = None,
 ) -> npt.NDArray[np.uint8]:
-    """
-    Draw text with background on a scene.
+    """Draw text with background on a scene.
 
     Args:
         scene: A numpy ndarray representing the image, typically of shape
@@ -401,8 +396,7 @@ def draw_image(
     opacity: float,
     rect: Rect,
 ) -> npt.NDArray[np.uint8]:
-    """
-    Draws an image onto a given scene with specified opacity and dimensions.
+    """Draws an image onto a given scene with specified opacity and dimensions.
 
     Args:
         scene: Background image where the new image will be drawn.

--- a/src/supervision/draw/utils.py
+++ b/src/supervision/draw/utils.py
@@ -490,8 +490,7 @@ def draw_image(
 
 
 def calculate_optimal_text_scale(resolution_wh: tuple[int, int]) -> float:
-    """
-    Calculate optimal font scale based on image resolution.
+    """Calculate optimal font scale based on image resolution.
 
     Adjusts font scale proportionally to the smallest dimension of the given image resolution for
     consistent readability.
@@ -516,8 +515,7 @@ def calculate_optimal_text_scale(resolution_wh: tuple[int, int]) -> float:
 
 
 def calculate_optimal_line_thickness(resolution_wh: tuple[int, int]) -> int:
-    """
-    Calculate optimal line thickness based on image resolution.
+    """Calculate optimal line thickness based on image resolution.
 
     Adjusts the line thickness for readability depending on the smallest dimension of the provided
     image resolution.

--- a/src/supervision/draw/utils.py
+++ b/src/supervision/draw/utils.py
@@ -491,8 +491,9 @@ def draw_image(
 
 def calculate_optimal_text_scale(resolution_wh: tuple[int, int]) -> float:
     """
-    Calculate optimal font scale based on image resolution. Adjusts font scale
-    proportionally to the smallest dimension of the given image resolution for
+    Calculate optimal font scale based on image resolution.
+
+    Adjusts font scale proportionally to the smallest dimension of the given image resolution for
     consistent readability.
 
     Args:
@@ -516,8 +517,9 @@ def calculate_optimal_text_scale(resolution_wh: tuple[int, int]) -> float:
 
 def calculate_optimal_line_thickness(resolution_wh: tuple[int, int]) -> int:
     """
-    Calculate optimal line thickness based on image resolution. Adjusts the line
-    thickness for readability depending on the smallest dimension of the provided
+    Calculate optimal line thickness based on image resolution.
+
+    Adjusts the line thickness for readability depending on the smallest dimension of the provided
     image resolution.
 
     Args:

--- a/src/supervision/geometry/core.py
+++ b/src/supervision/geometry/core.py
@@ -50,8 +50,7 @@ class Point:
     y: float
 
     def as_xy_int_tuple(self) -> tuple[int, int]:
-        """
-        Returns the point as a tuple of integers.
+        """Returns the point as a tuple of integers.
 
         Returns:
             The point as (x, y) integers.
@@ -59,8 +58,7 @@ class Point:
         return int(self.x), int(self.y)
 
     def as_xy_float_tuple(self) -> tuple[float, float]:
-        """
-        Returns the point as a tuple of floats.
+        """Returns the point as a tuple of floats.
 
         Returns:
             The point as (x, y) floats.
@@ -96,8 +94,7 @@ class Vector:
 
     @property
     def magnitude(self) -> float:
-        """
-        Calculate the magnitude (length) of the vector.
+        """Calculate the magnitude (length) of the vector.
 
         Returns:
             The magnitude of the vector.
@@ -108,8 +105,7 @@ class Vector:
 
     @property
     def center(self) -> Point:
-        """
-        Calculate the center point of the vector.
+        """Calculate the center point of the vector.
 
         Returns:
             The center point of the vector.
@@ -120,8 +116,7 @@ class Vector:
         )
 
     def cross_product(self, point: Point) -> float:
-        """
-        Calculate the 2D cross product (also known as the vector product or outer
+        """Calculate the 2D cross product (also known as the vector product or outer
         product) of the vector and a point, treated as vectors in 2D space.
 
         Args:

--- a/src/supervision/geometry/core.py
+++ b/src/supervision/geometry/core.py
@@ -6,9 +6,7 @@ from math import sqrt
 
 
 class Position(Enum):
-    """
-    Enum representing the position of an anchor point.
-    """
+    """Enum representing the position of an anchor point."""
 
     CENTER = "CENTER"
     CENTER_LEFT = "CENTER_LEFT"

--- a/src/supervision/geometry/core.py
+++ b/src/supervision/geometry/core.py
@@ -27,8 +27,7 @@ class Position(Enum):
 
 @dataclass
 class Point:
-    """
-    Represents a point in 2D space.
+    """Represents a point in 2D space.
 
     Attributes:
         x: The x-coordinate of the point.
@@ -68,8 +67,7 @@ class Point:
 
 @dataclass
 class Vector:
-    """
-    Represents a vector in 2D space, defined by a start and an end point.
+    """Represents a vector in 2D space, defined by a start and an end point.
 
     Attributes:
         start: The starting point of the vector.
@@ -138,8 +136,7 @@ class Vector:
 
 @dataclass
 class Rect:
-    """
-    Represents a rectangle in 2D space.
+    """Represents a rectangle in 2D space.
 
     Attributes:
         x: The x-coordinate of the top-left corner of the rectangle.

--- a/src/supervision/geometry/utils.py
+++ b/src/supervision/geometry/utils.py
@@ -5,9 +5,8 @@ from supervision.geometry.core import Point
 
 
 def get_polygon_center(polygon: npt.NDArray[np.number]) -> Point:
-    """
-    Calculate the center of a polygon. The center is calculated as the center
-    of the solid figure formed by the points of the polygon
+    """Calculate the center of a polygon. The center is calculated as the center of the
+    solid figure formed by the points of the polygon.
 
     Args:
         polygon: A 2-dimensional numpy ndarray representing the vertices of the

--- a/src/supervision/key_points/annotators.py
+++ b/src/supervision/key_points/annotators.py
@@ -39,8 +39,9 @@ class BaseKeyPointAnnotator(ABC):
 
 class VertexAnnotator(BaseKeyPointAnnotator):
     """
-    A class that specializes in drawing skeleton vertices on images. It uses
-    specified key points to determine the locations where the vertices should be
+    A class that specializes in drawing skeleton vertices on images.
+
+    It uses specified key points to determine the locations where the vertices should be
     drawn.
     """
 
@@ -123,7 +124,9 @@ class VertexAnnotator(BaseKeyPointAnnotator):
 class EdgeAnnotator(BaseKeyPointAnnotator):
     """
     A class that specializes in drawing skeleton edges on images using specified key
-    points. It connects key points with lines to form the skeleton structure.
+    points.
+
+    It connects key points with lines to form the skeleton structure.
     """
 
     def __init__(
@@ -272,7 +275,8 @@ class EdgeAnnotator(BaseKeyPointAnnotator):
 
 
 class _BaseVertexEllipseAnnotator(BaseKeyPointAnnotator):
-    """Private base for ellipse-based keypoint annotators.
+    """
+    Private base for ellipse-based keypoint annotators.
 
     Handles sigma/color validation, sorting, covariance extraction and
     eigendecomposition shared by all VertexEllipse* variants.
@@ -382,15 +386,14 @@ class _BaseVertexEllipseAnnotator(BaseKeyPointAnnotator):
 
 class VertexEllipseAreaAnnotator(_BaseVertexEllipseAnnotator):
     """
-    Draws filled semi-transparent covariance ellipses at multiple sigma levels
-    around each keypoint, each ring in a different color.  This produces a
-    bullseye-like uncertainty visualization where inner rings represent higher
-    probability density.
+    Draws filled semi-transparent covariance ellipses at multiple sigma levels around
+    each keypoint, each ring in a different color.  This produces a bullseye-like
+    uncertainty visualization where inner rings represent higher probability density.
 
     !!! warning
 
-        This annotator uses `key_points.data["covariance"]` with shape
-        `(N, K, 2, 2)` in pixel coordinates.
+    This annotator uses `key_points.data["covariance"]` with shape `(N, K, 2, 2)` in
+    pixel coordinates.
     """
 
     def __init__(
@@ -485,13 +488,13 @@ class VertexEllipseAreaAnnotator(_BaseVertexEllipseAnnotator):
 
 class VertexEllipseOutlineAnnotator(_BaseVertexEllipseAnnotator):
     """
-    Draws stroke-only concentric covariance ellipse rings at multiple sigma
-    levels around each keypoint.
+    Draws stroke-only concentric covariance ellipse rings at multiple sigma levels
+    around each keypoint.
 
     !!! warning
 
-        This annotator uses `key_points.data["covariance"]` with shape
-        `(N, K, 2, 2)` in pixel coordinates.
+    This annotator uses `key_points.data["covariance"]` with shape `(N, K, 2, 2)` in
+    pixel coordinates.
     """
 
     def __init__(
@@ -584,15 +587,15 @@ class VertexEllipseOutlineAnnotator(_BaseVertexEllipseAnnotator):
 
 class VertexEllipseHaloAnnotator(_BaseVertexEllipseAnnotator):
     """
-    Draws filled covariance ellipses with a radial fade: full opacity at the
-    center, smoothly falling off to zero at the ellipse boundary.  The falloff
-    follows a power curve controlled by ``decay``, producing a soft glow that
-    is strongest near the keypoint.
+    Draws filled covariance ellipses with a radial fade: full opacity at the center,
+    smoothly falling off to zero at the ellipse boundary.  The falloff follows a power
+    curve controlled by ``decay``, producing a soft glow that is strongest near the
+    keypoint.
 
     !!! warning
 
-        This annotator uses `key_points.data["covariance"]` with shape
-        `(N, K, 2, 2)` in pixel coordinates.
+    This annotator uses `key_points.data["covariance"]` with shape `(N, K, 2, 2)` in
+    pixel coordinates.
     """
 
     _DECAY: float = 2.0
@@ -721,8 +724,10 @@ VertexEllipseAnnotator = VertexEllipseAreaAnnotator
 
 class VertexLabelAnnotator:
     """
-    A class that draws labels of skeleton vertices on images. It uses specified key
-    points to determine the locations where the vertices should be drawn.
+    A class that draws labels of skeleton vertices on images.
+
+    It uses specified key points to determine the locations where the vertices should be
+    drawn.
     """
 
     def __init__(

--- a/src/supervision/key_points/annotators.py
+++ b/src/supervision/key_points/annotators.py
@@ -38,8 +38,7 @@ class BaseKeyPointAnnotator(ABC):
 
 
 class VertexAnnotator(BaseKeyPointAnnotator):
-    """
-    A class that specializes in drawing skeleton vertices on images.
+    """A class that specializes in drawing skeleton vertices on images.
 
     It uses specified key points to determine the locations where the vertices should be
     drawn.
@@ -122,8 +121,7 @@ class VertexAnnotator(BaseKeyPointAnnotator):
 
 
 class EdgeAnnotator(BaseKeyPointAnnotator):
-    """
-    A class that specializes in drawing skeleton edges on images using specified key
+    """A class that specializes in drawing skeleton edges on images using specified key
     points.
 
     It connects key points with lines to form the skeleton structure.
@@ -275,8 +273,7 @@ class EdgeAnnotator(BaseKeyPointAnnotator):
 
 
 class _BaseVertexEllipseAnnotator(BaseKeyPointAnnotator):
-    """
-    Private base for ellipse-based keypoint annotators.
+    """Private base for ellipse-based keypoint annotators.
 
     Handles sigma/color validation, sorting, covariance extraction and
     eigendecomposition shared by all VertexEllipse* variants.
@@ -385,8 +382,7 @@ class _BaseVertexEllipseAnnotator(BaseKeyPointAnnotator):
 
 
 class VertexEllipseAreaAnnotator(_BaseVertexEllipseAnnotator):
-    """
-    Draws filled semi-transparent covariance ellipses at multiple sigma levels around
+    """Draws filled semi-transparent covariance ellipses at multiple sigma levels around
     each keypoint, each ring in a different color.  This produces a bullseye-like
     uncertainty visualization where inner rings represent higher probability density.
 
@@ -487,8 +483,7 @@ class VertexEllipseAreaAnnotator(_BaseVertexEllipseAnnotator):
 
 
 class VertexEllipseOutlineAnnotator(_BaseVertexEllipseAnnotator):
-    """
-    Draws stroke-only concentric covariance ellipse rings at multiple sigma levels
+    """Draws stroke-only concentric covariance ellipse rings at multiple sigma levels
     around each keypoint.
 
     !!! warning
@@ -586,8 +581,7 @@ class VertexEllipseOutlineAnnotator(_BaseVertexEllipseAnnotator):
 
 
 class VertexEllipseHaloAnnotator(_BaseVertexEllipseAnnotator):
-    """
-    Draws filled covariance ellipses with a radial fade: full opacity at the center,
+    """Draws filled covariance ellipses with a radial fade: full opacity at the center,
     smoothly falling off to zero at the ellipse boundary.  The falloff follows a power
     curve controlled by ``decay``, producing a soft glow that is strongest near the
     keypoint.
@@ -723,8 +717,7 @@ VertexEllipseAnnotator = VertexEllipseAreaAnnotator
 
 
 class VertexLabelAnnotator:
-    """
-    A class that draws labels of skeleton vertices on images.
+    """A class that draws labels of skeleton vertices on images.
 
     It uses specified key points to determine the locations where the vertices should be
     drawn.

--- a/src/supervision/key_points/annotators.py
+++ b/src/supervision/key_points/annotators.py
@@ -59,10 +59,9 @@ class VertexAnnotator(BaseKeyPointAnnotator):
 
     @ensure_cv2_image_for_class_method
     def annotate(self, scene: ImageType, key_points: KeyPoints) -> ImageType:
-        """
-        Annotates the given scene with skeleton vertices based on the provided key
-        points. It draws circles at each key point location. Anchors marked as
-        not visible via ``key_points.visible`` are skipped.
+        """Annotates the given scene with skeleton vertices based on the provided key
+        points. It draws circles at each key point location. Anchors marked as not
+        visible via ``key_points.visible`` are skipped.
 
         Args:
             scene: The image where skeleton vertices will be drawn. `ImageType` is a
@@ -152,9 +151,8 @@ class EdgeAnnotator(BaseKeyPointAnnotator):
 
     @ensure_cv2_image_for_class_method
     def annotate(self, scene: ImageType, key_points: KeyPoints) -> ImageType:
-        """
-        Annotates the given scene by drawing lines between specified key points to form
-        edges. Edges where either endpoint is marked as not visible via
+        """Annotates the given scene by drawing lines between specified key points to
+        form edges. Edges where either endpoint is marked as not visible via
         ``key_points.visible`` are skipped.
 
         Args:
@@ -416,8 +414,7 @@ class VertexEllipseAreaAnnotator(_BaseVertexEllipseAnnotator):
 
     @ensure_cv2_image_for_class_method
     def annotate(self, scene: ImageType, key_points: KeyPoints) -> ImageType:
-        """
-        Draws filled semi-transparent covariance ellipses around each keypoint.
+        """Draws filled semi-transparent covariance ellipses around each keypoint.
 
         Args:
             scene: The image to annotate. ``ImageType`` accepts either
@@ -515,8 +512,7 @@ class VertexEllipseOutlineAnnotator(_BaseVertexEllipseAnnotator):
 
     @ensure_cv2_image_for_class_method
     def annotate(self, scene: ImageType, key_points: KeyPoints) -> ImageType:
-        """
-        Draws stroke-only covariance ellipse outlines around each keypoint.
+        """Draws stroke-only covariance ellipse outlines around each keypoint.
 
         Args:
             scene: The image to annotate. ``ImageType`` accepts either
@@ -618,8 +614,7 @@ class VertexEllipseHaloAnnotator(_BaseVertexEllipseAnnotator):
 
     @ensure_cv2_image_for_class_method
     def annotate(self, scene: ImageType, key_points: KeyPoints) -> ImageType:
-        """
-        Draws radially-fading covariance ellipses around each keypoint.
+        """Draws radially-fading covariance ellipses around each keypoint.
 
         Args:
             scene: The image to annotate. ``ImageType`` accepts either
@@ -761,9 +756,8 @@ class VertexLabelAnnotator:
         key_points: KeyPoints,
         labels: list[str] | dict[int, list[str]] | None = None,
     ) -> ImageType:
-        """
-        Draws labels at skeleton vertex positions on the image. Vertices
-        marked not visible via ``key_points.visible`` are skipped.
+        """Draws labels at skeleton vertex positions on the image. Vertices marked not
+        visible via ``key_points.visible`` are skipped.
 
         Args:
             scene: The image where vertex labels will be drawn. `ImageType` is a

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -128,8 +128,7 @@ def _normalize_row_index(
 
 @dataclass(init=False)
 class KeyPoints:
-    """
-    The `sv.KeyPoints` class in the Supervision library standardizes results from
+    """The `sv.KeyPoints` class in the Supervision library standardizes results from
     various keypoint detection and pose estimation models into a consistent format. This
     class simplifies data manipulation and filtering, providing a uniform API for
     integration with Supervision [keypoints annotators](/latest/keypoint/annotators).
@@ -381,8 +380,7 @@ class KeyPoints:
         self.keypoint_confidence = value
 
     def __len__(self) -> int:
-        """
-        Returns the number of objects in the `sv.KeyPoints` object.
+        """Returns the number of objects in the `sv.KeyPoints` object.
 
         Returns:
             The number of objects.
@@ -410,10 +408,8 @@ class KeyPoints:
             _DetectionDataType,
         ]
     ]:
-        """
-        Iterates over the Keypoint object and yield a tuple of
-        `(xy, keypoint_confidence, class_id, data)` for each object detection.
-        """
+        """Iterates over the Keypoint object and yield a tuple of `(xy,
+        keypoint_confidence, class_id, data)` for each object detection."""
         for i in range(len(self.xy)):
             yield (
                 self.xy[i],
@@ -1211,8 +1207,7 @@ class KeyPoints:
         self,
         index: Index1D | Index2D | str,
     ) -> KeyPoints | npt.NDArray[np.generic] | list[Any] | None:
-        """
-        Get a subset of the KeyPoints object or access an item from its data field.
+        """Get a subset of the KeyPoints object or access an item from its data field.
 
         Supports detection-level (skeleton) filtering, keypoint-level (anchor)
         filtering, combined tuple indexing, and data field access by string key.
@@ -1254,8 +1249,7 @@ class KeyPoints:
         return self.select(index)
 
     def __setitem__(self, key: str, value: npt.NDArray[np.generic] | list[Any]) -> None:
-        """
-        Set a value in the data dictionary of the `sv.KeyPoints` object.
+        """Set a value in the data dictionary of the `sv.KeyPoints` object.
 
         Args:
             key: The key in the data dictionary to set.
@@ -1290,8 +1284,7 @@ class KeyPoints:
 
     @classmethod
     def empty(cls) -> KeyPoints:
-        """
-        Create an empty KeyPoints object with no key points.
+        """Create an empty KeyPoints object with no key points.
 
         Returns:
             An empty `sv.KeyPoints` object.
@@ -1308,8 +1301,7 @@ class KeyPoints:
         return cls(xy=np.empty((0, 0, 2), dtype=np.float32))
 
     def is_empty(self) -> bool:
-        """
-        Returns `True` if the `KeyPoints` object is considered empty.
+        """Returns `True` if the `KeyPoints` object is considered empty.
 
         Returns:
             `True` if the object is empty, `False` otherwise.
@@ -1327,8 +1319,7 @@ class KeyPoints:
 
     @classmethod
     def merge(cls, key_points_list: list[KeyPoints]) -> KeyPoints:
-        """
-        Merge a list of KeyPoints objects into a single KeyPoints object.
+        """Merge a list of KeyPoints objects into a single KeyPoints object.
 
         This method takes a list of KeyPoints objects and combines their
         respective fields (`xy`, `class_id`, `keypoint_confidence`,
@@ -1451,11 +1442,10 @@ class KeyPoints:
         class_agnostic: bool = False,
         overlap_metric: OverlapMetric = OverlapMetric.IOU,
     ) -> KeyPoints:
-        """
-        Performs non-max suppression on the keypoint detections. Bounding boxes
-        are derived from valid keypoints of each skeleton, and standard box NMS
-        is applied. A keypoint is considered valid when its coordinates are not
-        all-zero and its `visible` flag is `True` (if `visible` is set).
+        """Performs non-max suppression on the keypoint detections. Bounding boxes are
+        derived from valid keypoints of each skeleton, and standard box NMS is applied.
+        A keypoint is considered valid when its coordinates are not all-zero and its
+        `visible` flag is `True` (if `visible` is set).
 
         Args:
             threshold: The intersection-over-union threshold to use for
@@ -1536,10 +1526,9 @@ class KeyPoints:
     def as_detections(
         self, selected_keypoint_indices: Iterable[int] | None = None
     ) -> Detections:
-        """
-        Convert a KeyPoints object to a Detections object. This
-        approximates the bounding box of the detected object by
-        taking the bounding box that fits all key points.
+        """Convert a KeyPoints object to a Detections object. This approximates the
+        bounding box of the detected object by taking the bounding box that fits all key
+        points.
 
         Args:
             selected_keypoint_indices: The

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -53,8 +53,7 @@ _HAND_CLASS_ID_BY_LABEL: dict[str, int] = {"Left": 0, "Right": 1}
 def _handedness_pairs(
     top_categories: Iterable[Any], label_attr: str
 ) -> list[tuple[str, float]] | None:
-    """
-    Convert MediaPipe top-1 handedness categories into `(label, score)` pairs.
+    """Convert MediaPipe top-1 handedness categories into `(label, score)` pairs.
 
     Returns `None` as soon as any category is missing a label or a score, so the caller
     can drop handedness wholesale instead of emitting a partially filled array that
@@ -71,8 +70,7 @@ def _handedness_pairs(
 
 
 def _tasks_api_handedness(mediapipe_results: Any) -> list[tuple[str, float]] | None:
-    """
-    Read handedness `(label, score)` pairs from a Tasks API `HandLandmarkerResult`.
+    """Read handedness `(label, score)` pairs from a Tasks API `HandLandmarkerResult`.
 
     The Tasks API exposes `handedness` as one descending-score category list per hand;
     only the top-1 entry carries the `Left`/`Right` decision.
@@ -86,8 +84,7 @@ def _tasks_api_handedness(mediapipe_results: Any) -> list[tuple[str, float]] | N
 
 
 def _legacy_handedness(mediapipe_results: Any) -> list[tuple[str, float]] | None:
-    """
-    Read handedness `(label, score)` pairs from a legacy `Hands` solution result.
+    """Read handedness `(label, score)` pairs from a legacy `Hands` solution result.
 
     The legacy proto2 solution nests the same top-1 decision one level deeper, under
     `multi_handedness[i].classification`, and names the label field `label`.
@@ -109,8 +106,7 @@ def _legacy_handedness(mediapipe_results: Any) -> list[tuple[str, float]] | None
 def _normalize_row_index(
     i: _RowIndexInput,
 ) -> _NormalizedRowIndex:
-    """
-    Normalise *i* to a 1-D row index for 1-D per-object fields.
+    """Normalise *i* to a 1-D row index for 1-D per-object fields.
 
     Handles:
     - Python int or np.integer scalar  -> np.array([int(i)])
@@ -312,8 +308,7 @@ class KeyPoints:
         *,
         confidence: npt.NDArray[np.float32] | None = None,
     ) -> None:
-        """
-        Initialize KeyPoints.
+        """Initialize KeyPoints.
 
         Args:
             xy: Array of shape `(n, m, 2)` with keypoint coordinates.
@@ -367,8 +362,7 @@ class KeyPoints:
 
     @property
     def confidence(self) -> npt.NDArray[np.float32] | None:
-        """
-        Deprecated since 0.29.0.
+        """Deprecated since 0.29.0.
 
         Use ``keypoint_confidence`` instead.
         """
@@ -978,8 +972,7 @@ class KeyPoints:
             return cls.empty()
 
     def _get_by_2d_bool_mask(self, mask: npt.NDArray[np.bool_]) -> KeyPoints:
-        """
-        Filter keypoints using a 2D boolean mask of shape `(n, m)`.
+        """Filter keypoints using a 2D boolean mask of shape `(n, m)`.
 
         This method selects the **same set of keypoints from every object**, so
         every row of `mask` must contain the same number of `True` values.  The

--- a/src/supervision/key_points/core.py
+++ b/src/supervision/key_points/core.py
@@ -53,11 +53,12 @@ _HAND_CLASS_ID_BY_LABEL: dict[str, int] = {"Left": 0, "Right": 1}
 def _handedness_pairs(
     top_categories: Iterable[Any], label_attr: str
 ) -> list[tuple[str, float]] | None:
-    """Convert MediaPipe top-1 handedness categories into `(label, score)` pairs.
+    """
+    Convert MediaPipe top-1 handedness categories into `(label, score)` pairs.
 
-    Returns `None` as soon as any category is missing a label or a score, so the
-    caller can drop handedness wholesale instead of emitting a partially filled
-    array that would silently mis-align with `xy`.
+    Returns `None` as soon as any category is missing a label or a score, so the caller
+    can drop handedness wholesale instead of emitting a partially filled array that
+    would silently mis-align with `xy`.
     """
     pairs: list[tuple[str, float]] = []
     for top in top_categories:
@@ -70,10 +71,11 @@ def _handedness_pairs(
 
 
 def _tasks_api_handedness(mediapipe_results: Any) -> list[tuple[str, float]] | None:
-    """Read handedness `(label, score)` pairs from a Tasks API `HandLandmarkerResult`.
+    """
+    Read handedness `(label, score)` pairs from a Tasks API `HandLandmarkerResult`.
 
-    The Tasks API exposes `handedness` as one descending-score category list per
-    hand; only the top-1 entry carries the `Left`/`Right` decision.
+    The Tasks API exposes `handedness` as one descending-score category list per hand;
+    only the top-1 entry carries the `Left`/`Right` decision.
     """
     handedness = getattr(mediapipe_results, "handedness", None)
     if not handedness or not all(handedness):
@@ -84,7 +86,8 @@ def _tasks_api_handedness(mediapipe_results: Any) -> list[tuple[str, float]] | N
 
 
 def _legacy_handedness(mediapipe_results: Any) -> list[tuple[str, float]] | None:
-    """Read handedness `(label, score)` pairs from a legacy `Hands` solution result.
+    """
+    Read handedness `(label, score)` pairs from a legacy `Hands` solution result.
 
     The legacy proto2 solution nests the same top-1 decision one level deeper, under
     `multi_handedness[i].classification`, and names the label field `label`.
@@ -106,7 +109,8 @@ def _legacy_handedness(mediapipe_results: Any) -> list[tuple[str, float]] | None
 def _normalize_row_index(
     i: _RowIndexInput,
 ) -> _NormalizedRowIndex:
-    """Normalise *i* to a 1-D row index for 1-D per-object fields.
+    """
+    Normalise *i* to a 1-D row index for 1-D per-object fields.
 
     Handles:
     - Python int or np.integer scalar  -> np.array([int(i)])
@@ -308,7 +312,8 @@ class KeyPoints:
         *,
         confidence: npt.NDArray[np.float32] | None = None,
     ) -> None:
-        """Initialize KeyPoints.
+        """
+        Initialize KeyPoints.
 
         Args:
             xy: Array of shape `(n, m, 2)` with keypoint coordinates.
@@ -362,7 +367,11 @@ class KeyPoints:
 
     @property
     def confidence(self) -> npt.NDArray[np.float32] | None:
-        """Deprecated since 0.29.0. Use ``keypoint_confidence`` instead."""
+        """
+        Deprecated since 0.29.0.
+
+        Use ``keypoint_confidence`` instead.
+        """
         warn_deprecated(
             "'KeyPoints.confidence' is deprecated since 0.29.0 and will be "
             "removed in 0.32.0. Use 'KeyPoints.keypoint_confidence' instead."
@@ -969,7 +978,8 @@ class KeyPoints:
             return cls.empty()
 
     def _get_by_2d_bool_mask(self, mask: npt.NDArray[np.bool_]) -> KeyPoints:
-        """Filter keypoints using a 2D boolean mask of shape `(n, m)`.
+        """
+        Filter keypoints using a 2D boolean mask of shape `(n, m)`.
 
         This method selects the **same set of keypoints from every object**, so
         every row of `mask` must contain the same number of `True` values.  The

--- a/src/supervision/metrics/core.py
+++ b/src/supervision/metrics/core.py
@@ -12,8 +12,7 @@ class Metric(ABC, Generic[R]):
 
     @abstractmethod
     def update(self, *args: Any, **kwargs: Any) -> Metric[R]:
-        """
-        Add data to the metric, without computing the result.
+        """Add data to the metric, without computing the result.
 
         Return the metric itself to allow method chaining.
         """
@@ -31,8 +30,7 @@ class Metric(ABC, Generic[R]):
 
 
 class MetricTarget(Enum):
-    """
-    Specifies what type of detection is used to compute the metric.
+    """Specifies what type of detection is used to compute the metric.
 
     Attributes:
         BOXES: xyxy bounding boxes
@@ -46,8 +44,7 @@ class MetricTarget(Enum):
 
 
 class AveragingMethod(Enum):
-    """
-    Defines different ways of averaging the metric results.
+    """Defines different ways of averaging the metric results.
 
     Suppose, before returning the final result, a metric is computed for each class.
     How do you combine those to get the final number?

--- a/src/supervision/metrics/core.py
+++ b/src/supervision/metrics/core.py
@@ -8,30 +8,25 @@ R = TypeVar("R")
 
 
 class Metric(ABC, Generic[R]):
-    """
-    The base class for all supervision metrics.
-    """
+    """The base class for all supervision metrics."""
 
     @abstractmethod
     def update(self, *args: Any, **kwargs: Any) -> Metric[R]:
         """
         Add data to the metric, without computing the result.
+
         Return the metric itself to allow method chaining.
         """
         raise NotImplementedError
 
     @abstractmethod
     def reset(self) -> None:
-        """
-        Reset internal metric state.
-        """
+        """Reset internal metric state."""
         raise NotImplementedError
 
     @abstractmethod
     def compute(self, *args: Any, **kwargs: Any) -> R:
-        """
-        Compute the metric from the internal state and return the result.
-        """
+        """Compute the metric from the internal state and return the result."""
         raise NotImplementedError
 
 

--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -224,8 +224,7 @@ def _split_detections_by_outcome(
     iou_threshold: float,
     metric_target: MetricTarget = MetricTarget.BOXES,
 ) -> tuple[Detections, Detections, Detections]:
-    """
-    Split detections into true positives, false positives, and false negatives.
+    """Split detections into true positives, false positives, and false negatives.
 
     Matching follows the same attribution logic as
     ``ConfusionMatrix.evaluate_detection_batch``:
@@ -373,8 +372,7 @@ def _build_error_labels(
     detections: Detections,
     class_names: list[str] | None,
 ) -> list[str]:
-    """
-    Build per-detection label strings for annotation panels.
+    """Build per-detection label strings for annotation panels.
 
     Produces labels like ``"cat 0.95"`` (class name + confidence when available)
     or numeric class-id strings when ``class_names`` is ``None``.
@@ -409,8 +407,7 @@ def _build_error_labels(
 def _get_annotation_parameters(
     scene: npt.NDArray[np.uint8],
 ) -> tuple[int, float, int, int, int]:
-    """
-    Compute adaptive annotation parameters scaled to the panel size.
+    """Compute adaptive annotation parameters scaled to the panel size.
 
     Args:
         scene: The image panel for which to compute parameters.
@@ -439,8 +436,7 @@ def _annotate_detection_panel(
     class_names: list[str] | None,
     annotation_parameters: tuple[int, float, int, int, int],
 ) -> npt.NDArray[np.uint8]:
-    """
-    Render detections onto a copy of ``scene`` with a title overlay.
+    """Render detections onto a copy of ``scene`` with a title overlay.
 
     Args:
         scene: Source image panel (not mutated).
@@ -523,8 +519,7 @@ def _save_detection_validation_visualization(
     class_names: list[str] | None,
     metric_target: MetricTarget = MetricTarget.BOXES,
 ) -> None:
-    """
-    Build and save a 2x2 GT/TP/FP/FN mosaic for one image.
+    """Build and save a 2x2 GT/TP/FP/FN mosaic for one image.
 
     Splits ``predictions`` into true-positive, false-positive, and false-negative
     groups using the same matching logic as
@@ -644,8 +639,7 @@ def validate_input_tensors(
 
 @dataclass
 class ConfusionMatrix:
-    """
-    Confusion matrix for object detection tasks.
+    """Confusion matrix for object detection tasks.
 
     Attributes:
         matrix: An 2D `np.ndarray` of shape `(len(classes) + 1, len(classes) + 1)`
@@ -1029,8 +1023,7 @@ class ConfusionMatrix:
     def _drop_extra_matches(
         matches: npt.NDArray[np.float32],
     ) -> npt.NDArray[np.float32]:
-        """
-        Deduplicate matches.
+        """Deduplicate matches.
 
         If there are multiple matches for the same true or predicted box, only the one
         with the highest IoU is kept.
@@ -1158,8 +1151,7 @@ class ConfusionMatrix:
         normalize: bool = False,
         fig_size: tuple[int, int] = (12, 10),
     ) -> Figure:
-        """
-        Create confusion matrix plot and save it at selected location.
+        """Create confusion matrix plot and save it at selected location.
 
         Args:
             save_path: Path to save the plot. If not provided,
@@ -1250,8 +1242,7 @@ class ConfusionMatrix:
 )
 @dataclass(frozen=True)
 class MeanAveragePrecision:
-    """
-    !!! deprecated "Deprecated" `MeanAveragePrecision` is **deprecated** and will be
+    """!!! deprecated "Deprecated" `MeanAveragePrecision` is **deprecated** and will be
     removed in `supervision-0.31.0`.
 
         The deprecated implementation provides results that are inconsistent with
@@ -1517,8 +1508,7 @@ class MeanAveragePrecision:
         recall: npt.NDArray[np.float64],
         precision: npt.NDArray[np.float64],
     ) -> float:
-        """
-        Compute the average precision using 101-point interpolation (COCO), given the
+        """Compute the average precision using 101-point interpolation (COCO), given the
         recall and precision curves.
 
         Args:

--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -183,9 +183,7 @@ def _validate_input_tensors(
     targets: list[npt.NDArray[np.float32]],
     metric_target: MetricTarget = MetricTarget.BOXES,
 ) -> None:
-    """
-    Checks for shape consistency of input tensors.
-    """
+    """Checks for shape consistency of input tensors."""
     if len(predictions) != len(targets):
         raise ValueError(
             f"Number of predictions ({len(predictions)}) and"
@@ -252,7 +250,6 @@ def _split_detections_by_outcome(
         A 3-tuple ``(true_positives, false_positives, false_negatives)`` where
         each element is a ``Detections`` instance sliced from the input arrays.
     """
-
     if predictions.class_id is None:
         raise ValueError("Predictions must contain class_id values.")
 
@@ -376,7 +373,8 @@ def _build_error_labels(
     detections: Detections,
     class_names: list[str] | None,
 ) -> list[str]:
-    """Build per-detection label strings for annotation panels.
+    """
+    Build per-detection label strings for annotation panels.
 
     Produces labels like ``"cat 0.95"`` (class name + confidence when available)
     or numeric class-id strings when ``class_names`` is ``None``.
@@ -411,7 +409,8 @@ def _build_error_labels(
 def _get_annotation_parameters(
     scene: npt.NDArray[np.uint8],
 ) -> tuple[int, float, int, int, int]:
-    """Compute adaptive annotation parameters scaled to the panel size.
+    """
+    Compute adaptive annotation parameters scaled to the panel size.
 
     Args:
         scene: The image panel for which to compute parameters.
@@ -440,7 +439,8 @@ def _annotate_detection_panel(
     class_names: list[str] | None,
     annotation_parameters: tuple[int, float, int, int, int],
 ) -> npt.NDArray[np.uint8]:
-    """Render detections onto a copy of ``scene`` with a title overlay.
+    """
+    Render detections onto a copy of ``scene`` with a title overlay.
 
     Args:
         scene: Source image panel (not mutated).
@@ -523,7 +523,8 @@ def _save_detection_validation_visualization(
     class_names: list[str] | None,
     metric_target: MetricTarget = MetricTarget.BOXES,
 ) -> None:
-    """Build and save a 2x2 GT/TP/FP/FN mosaic for one image.
+    """
+    Build and save a 2x2 GT/TP/FP/FN mosaic for one image.
 
     Splits ``predictions`` into true-positive, false-positive, and false-negative
     groups using the same matching logic as
@@ -1029,8 +1030,10 @@ class ConfusionMatrix:
         matches: npt.NDArray[np.float32],
     ) -> npt.NDArray[np.float32]:
         """
-        Deduplicate matches. If there are multiple matches for the same true or
-        predicted box, only the one with the highest IoU is kept.
+        Deduplicate matches.
+
+        If there are multiple matches for the same true or predicted box, only the one
+        with the highest IoU is kept.
         """
         if matches.shape[0] > 0:
             matches = matches[matches[:, 2].argsort()[::-1]]
@@ -1248,9 +1251,8 @@ class ConfusionMatrix:
 @dataclass(frozen=True)
 class MeanAveragePrecision:
     """
-    !!! deprecated "Deprecated"
-        `MeanAveragePrecision` is **deprecated** and will be removed in
-        `supervision-0.31.0`.
+    !!! deprecated "Deprecated" `MeanAveragePrecision` is **deprecated** and will be
+    removed in `supervision-0.31.0`.
 
         The deprecated implementation provides results that are inconsistent with
         `pycocotools`. Please use
@@ -1516,8 +1518,8 @@ class MeanAveragePrecision:
         precision: npt.NDArray[np.float64],
     ) -> float:
         """
-        Compute the average precision using 101-point interpolation (COCO), given
-            the recall and precision curves.
+        Compute the average precision using 101-point interpolation (COCO), given the
+        recall and precision curves.
 
         Args:
             recall: The recall curve.

--- a/src/supervision/metrics/detection.py
+++ b/src/supervision/metrics/detection.py
@@ -65,8 +65,7 @@ def detections_to_tensor(
     with_confidence: bool = False,
     metric_target: MetricTarget = MetricTarget.BOXES,
 ) -> npt.NDArray[np.float32]:
-    """
-    Convert Supervision Detections to a numpy tensor for metric computation.
+    """Convert Supervision Detections to a numpy tensor for metric computation.
 
     Args:
         detections: Detections/Targets in the format of sv.Detections.
@@ -684,8 +683,7 @@ class ConfusionMatrix:
         iou_threshold: float = 0.5,
         metric_target: MetricTarget = MetricTarget.BOXES,
     ) -> ConfusionMatrix:
-        """
-        Calculate confusion matrix based on predicted and ground-truth detections.
+        """Calculate confusion matrix based on predicted and ground-truth detections.
 
         Args:
             targets: Detections objects from ground-truth.
@@ -768,8 +766,7 @@ class ConfusionMatrix:
         iou_threshold: float = 0.5,
         metric_target: MetricTarget = MetricTarget.BOXES,
     ) -> ConfusionMatrix:
-        """
-        Calculate confusion matrix based on predicted and ground-truth detections.
+        """Calculate confusion matrix based on predicted and ground-truth detections.
 
         Args:
             predictions: Each element of the list describes a single
@@ -861,8 +858,7 @@ class ConfusionMatrix:
         iou_threshold: float,
         metric_target: MetricTarget = MetricTarget.BOXES,
     ) -> npt.NDArray[np.int32]:
-        """
-        Calculate confusion matrix for a batch of detections for a single image.
+        """Calculate confusion matrix for a batch of detections for a single image.
 
         Args:
             predictions: Batch prediction. Describes a single image and
@@ -1047,8 +1043,7 @@ class ConfusionMatrix:
         *,
         save_directory_path: str | Path | None = None,
     ) -> ConfusionMatrix:
-        """
-        Calculate confusion matrix from dataset and callback function.
+        """Calculate confusion matrix from dataset and callback function.
 
         Args:
             dataset: Object detection dataset used for evaluation.
@@ -1275,8 +1270,8 @@ class MeanAveragePrecision:
         predictions: list[Detections],
         targets: list[Detections],
     ) -> MeanAveragePrecision:
-        """
-        Calculate mean average precision based on predicted and ground-truth detections.
+        """Calculate mean average precision based on predicted and ground-truth
+        detections.
 
         Args:
             targets: Detections objects from ground-truth.
@@ -1328,8 +1323,7 @@ class MeanAveragePrecision:
         dataset: DetectionDataset,
         callback: Callable[[npt.NDArray[np.uint8]], Detections],
     ) -> MeanAveragePrecision:
-        """
-        Calculate mean average precision from dataset and callback function.
+        """Calculate mean average precision from dataset and callback function.
 
         Args:
             dataset: Object detection dataset used for evaluation.
@@ -1374,9 +1368,8 @@ class MeanAveragePrecision:
         predictions: list[npt.NDArray[np.float32]],
         targets: list[npt.NDArray[np.float32]],
     ) -> MeanAveragePrecision:
-        """
-        Calculate Mean Average Precision based on predicted and ground-truth
-            detections at different threshold.
+        """Calculate Mean Average Precision based on predicted and ground-truth
+        detections at different threshold.
 
         Args:
             predictions: Each element of the list describes
@@ -1538,8 +1531,7 @@ class MeanAveragePrecision:
         targets: npt.NDArray[np.float32],
         iou_thresholds: npt.NDArray[np.float32],
     ) -> npt.NDArray[np.bool_]:
-        """
-        Match predictions with target labels based on IoU levels.
+        """Match predictions with target labels based on IoU levels.
 
         Args:
             predictions: Batch prediction. Describes a single image and

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -71,8 +71,7 @@ class F1Score(Metric["F1ScoreResult"]):
         metric_target: MetricTarget = MetricTarget.BOXES,
         averaging_method: AveragingMethod = AveragingMethod.WEIGHTED,
     ):
-        """
-        Initialize the F1Score metric.
+        """Initialize the F1Score metric.
 
         Args:
             metric_target: The type of detection data to use.
@@ -95,8 +94,7 @@ class F1Score(Metric["F1ScoreResult"]):
         predictions: Detections | list[Detections],
         targets: Detections | list[Detections],
     ) -> F1Score:
-        """
-        Add new predictions and targets to the metric, but do not compute the result.
+        """Add new predictions and targets to the metric, but do not compute the result.
 
         Args:
             predictions: The predicted detections.
@@ -122,9 +120,8 @@ class F1Score(Metric["F1ScoreResult"]):
         return self
 
     def compute(self) -> F1ScoreResult:
-        """
-        Calculate the F1 score metric based on the stored predictions and ground-truth
-        data, at different IoU thresholds.
+        """Calculate the F1 score metric based on the stored predictions and ground-
+        truth data, at different IoU thresholds.
 
         Returns:
             The F1 score metric result.
@@ -148,8 +145,7 @@ class F1Score(Metric["F1ScoreResult"]):
         targets_list: list[Detections],
         size_category: ObjectSizeCategory = ObjectSizeCategory.ANY,
     ) -> F1ScoreResult:
-        """
-        Build per-image stats tuples and delegate to class-level computation.
+        """Build per-image stats tuples and delegate to class-level computation.
 
         Each stats tuple is
         ``(matches, ignored_matches, confidence, class_ids, true_class_ids)``:
@@ -360,8 +356,7 @@ class F1Score(Metric["F1ScoreResult"]):
         npt.NDArray[np.float64],
         npt.NDArray[np.int32],
     ]:
-        """
-        Compute F1 scores from concatenated stats across all images.
+        """Compute F1 scores from concatenated stats across all images.
 
         ``unique_classes`` is the union of GT and predicted classes so that predictions
         of classes absent from GT still count as false positives.
@@ -426,8 +421,7 @@ class F1Score(Metric["F1ScoreResult"]):
         unique_classes: npt.NDArray[np.int32],
         class_counts: npt.NDArray[np.int32],
     ) -> npt.NDArray[np.float64]:
-        """
-        Compute the confusion matrix for each class and IoU threshold.
+        """Compute the confusion matrix for each class and IoU threshold.
 
         Assumes the matches and prediction_class_ids are sorted by confidence
         in descending order.
@@ -484,8 +478,7 @@ class F1Score(Metric["F1ScoreResult"]):
     def _compute_f1(
         confusion_matrix: npt.NDArray[np.float64],
     ) -> npt.NDArray[np.float64]:
-        """
-        Broadcastable function, computing the F1 score from the confusion matrix.
+        """Broadcastable function, computing the F1 score from the confusion matrix.
 
         Args:
             confusion_matrix: shape (N, ..., 3), where the last dimension
@@ -518,8 +511,7 @@ class F1Score(Metric["F1ScoreResult"]):
     def _detections_content(
         self, detections: Detections
     ) -> npt.NDArray[Any] | CompactMask:
-        """
-        Return boxes, masks or oriented bounding boxes from detections.
+        """Return boxes, masks or oriented bounding boxes from detections.
 
         For the mask target this may return a
         :class:`~supervision.detection.compact_mask.CompactMask` rather than a
@@ -604,8 +596,7 @@ class F1Score(Metric["F1ScoreResult"]):
 
 @dataclass
 class F1ScoreResult:
-    """
-    The results of the F1 score metric calculation.
+    """The results of the F1 score metric calculation.
 
     Defaults to `0` if no detections or targets were provided.
 
@@ -722,8 +713,7 @@ class F1ScoreResult:
         return out_str
 
     def to_pandas(self) -> pd.DataFrame:
-        """
-        Convert the result to a pandas DataFrame.
+        """Convert the result to a pandas DataFrame.
 
         Returns:
             The result as a DataFrame.
@@ -752,8 +742,7 @@ class F1ScoreResult:
         return pd.DataFrame(pandas_data, index=[0])
 
     def plot(self) -> None:
-        """
-        Plot the F1 results.
+        """Plot the F1 results.
 
         ![example_plot](
         https://media.roboflow.com/supervision-docs/metrics/f1_plot_example.png

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -86,9 +86,7 @@ class F1Score(Metric["F1ScoreResult"]):
         self._targets_list: list[Detections] = []
 
     def reset(self) -> None:
-        """
-        Reset the metric to its initial state, clearing all stored data.
-        """
+        """Reset the metric to its initial state, clearing all stored data."""
         self._predictions_list = []
         self._targets_list = []
 
@@ -150,7 +148,8 @@ class F1Score(Metric["F1ScoreResult"]):
         targets_list: list[Detections],
         size_category: ObjectSizeCategory = ObjectSizeCategory.ANY,
     ) -> F1ScoreResult:
-        """Build per-image stats tuples and delegate to class-level computation.
+        """
+        Build per-image stats tuples and delegate to class-level computation.
 
         Each stats tuple is
         ``(matches, ignored_matches, confidence, class_ids, true_class_ids)``:
@@ -361,10 +360,11 @@ class F1Score(Metric["F1ScoreResult"]):
         npt.NDArray[np.float64],
         npt.NDArray[np.int32],
     ]:
-        """Compute F1 scores from concatenated stats across all images.
+        """
+        Compute F1 scores from concatenated stats across all images.
 
-        ``unique_classes`` is the union of GT and predicted classes so that
-        predictions of classes absent from GT still count as false positives.
+        ``unique_classes`` is the union of GT and predicted classes so that predictions
+        of classes absent from GT still count as false positives.
         """
         sorted_indices = np.argsort(-prediction_confidence)
         matches = matches[sorted_indices]
@@ -448,7 +448,6 @@ class F1Score(Metric["F1ScoreResult"]):
             shape (C, Th, 3), containing the true positives, false
                 positives, and false negatives for each class and IoU threshold.
         """
-
         num_thresholds = sorted_matches.shape[1]
         num_classes = unique_classes.shape[0]
 
@@ -519,7 +518,8 @@ class F1Score(Metric["F1ScoreResult"]):
     def _detections_content(
         self, detections: Detections
     ) -> npt.NDArray[Any] | CompactMask:
-        """Return boxes, masks or oriented bounding boxes from detections.
+        """
+        Return boxes, masks or oriented bounding boxes from detections.
 
         For the mask target this may return a
         :class:`~supervision.detection.compact_mask.CompactMask` rather than a
@@ -589,9 +589,7 @@ class F1Score(Metric["F1ScoreResult"]):
         targets_list: list[Detections],
         size_category: ObjectSizeCategory,
     ) -> tuple[list[Detections], list[Detections]]:
-        """
-        Filter predictions and targets by object size category.
-        """
+        """Filter predictions and targets by object size category."""
         new_predictions_list = []
         new_targets_list = []
         for predictions, targets in zip(predictions_list, targets_list):
@@ -758,7 +756,7 @@ class F1ScoreResult:
         Plot the F1 results.
 
         ![example_plot](
-            https://media.roboflow.com/supervision-docs/metrics/f1_plot_example.png
+        https://media.roboflow.com/supervision-docs/metrics/f1_plot_example.png
         ){ align=center width="800" }
         """
         from matplotlib import pyplot as plt

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -31,8 +31,7 @@ if TYPE_CHECKING:
 
 
 class F1Score(Metric["F1ScoreResult"]):
-    """
-    F1 Score is a metric used to evaluate object detection models. It is the harmonic
+    """F1 Score is a metric used to evaluate object detection models. It is the harmonic
     mean of precision and recall, calculated at different IoU thresholds.
 
     In simple terms, F1 Score is a measure of a model's balance between precision and
@@ -645,8 +644,7 @@ class F1ScoreResult:
     large_objects: F1ScoreResult | None
 
     def __str__(self) -> str:
-        """
-        Format as a pretty string.
+        """Format as a pretty string.
 
         Example:
             ```pycon

--- a/src/supervision/metrics/mean_average_precision.py
+++ b/src/supervision/metrics/mean_average_precision.py
@@ -101,7 +101,7 @@ class MeanAveragePrecisionResult:
 
     @property
     def map50_95(self) -> float:
-        """the mAP score at IoU thresholds from `0.5` to `0.95`."""
+        """The mAP score at IoU thresholds from `0.5` to `0.95`."""
         valid_scores = self.mAP_scores[self.mAP_scores > -1]
         if len(valid_scores) > 0:
             return float(valid_scores.mean())
@@ -110,12 +110,12 @@ class MeanAveragePrecisionResult:
 
     @property
     def map50(self) -> float:
-        """the mAP score at IoU threshold of `0.5`."""
+        """The mAP score at IoU threshold of `0.5`."""
         return float(self.mAP_scores[0])
 
     @property
     def map75(self) -> float:
-        """the mAP score at IoU threshold of `0.75`."""
+        """The mAP score at IoU threshold of `0.75`."""
         return float(self.mAP_scores[5])
 
     mAP_scores: npt.NDArray[np.float64]
@@ -225,7 +225,7 @@ class MeanAveragePrecisionResult:
         Plot the mAP results.
 
         ![example_plot](
-            https://media.roboflow.com/supervision-docs/metrics/mAP_plot_example.png
+        https://media.roboflow.com/supervision-docs/metrics/mAP_plot_example.png
         ){ align=center width="800" }
         """
         from matplotlib import pyplot as plt
@@ -298,8 +298,8 @@ class EvaluationDataset:
 
     def __init__(self, targets: _TypeCocoDataset | None = None) -> None:
         """
-        Constructor of EvaluationDataset object used to evaluate models with
-        Mean Average Precision.
+        Constructor of EvaluationDataset object used to evaluate models with Mean
+        Average Precision.
 
         Args:
             targets: The targets (ground truth) of the dataset in a the
@@ -326,9 +326,7 @@ class EvaluationDataset:
         return cls(targets=None)
 
     def create_class_members(self) -> None:
-        """
-        Create index elements for the dataset.
-        """
+        """Create index elements for the dataset."""
         anns: dict[int, _TypeCocoDict] = {}
         cats: dict[int, _TypeCocoDict] = {}
         imgs: dict[int, _TypeCocoDict] = {}
@@ -629,9 +627,7 @@ def _mask_iou_with_jaccard(
 
 
 class ObjectSize(Enum):
-    """
-    Enum for object size.
-    """
+    """Enum for object size."""
 
     ALL = "all"
     SMALL = "small"
@@ -640,13 +636,10 @@ class ObjectSize(Enum):
 
 
 class COCOEvaluatorParameters:
-    """
-    Parameters for COCOEvaluator
-    """
+    """Parameters for COCOEvaluator."""
 
     def __init__(self) -> None:
-        """Initialize all parameters for evaluation"""
-
+        """Initialize all parameters for evaluation."""
         self.img_ids: list[int] = []
         self.cat_ids: list[int] = []
 
@@ -678,9 +671,7 @@ class COCOEvaluatorParameters:
 
 
 class COCOEvaluator:
-    """
-    Evaluator class to compute COCO metrics.
-    """
+    """Evaluator class to compute COCO metrics."""
 
     def __init__(
         self,
@@ -729,9 +720,7 @@ class COCOEvaluator:
         self.params.cat_ids = sorted(self.coco_targets.get_category_ids())
 
     def _prepare_targets_and_predictions(self) -> None:
-        """
-        Prepare targets and predictions for evaluation.
-        """
+        """Prepare targets and predictions for evaluation."""
         # Get the target samples for the evaluation
         annotation_ids = self.coco_targets.get_annotation_ids(
             img_ids=self.params.img_ids, cat_ids=self.params.cat_ids
@@ -776,7 +765,6 @@ class COCOEvaluator:
         Returns:
             The IoU between the targets and predictions.
         """
-
         gt = self._targets[img_id, cat_id]
         dt = self._predictions[img_id, cat_id]
 
@@ -945,8 +933,8 @@ class COCOEvaluator:
         }
 
     def _accumulate(self) -> None:
-        """
-        Accumulate per image evaluation results and store the result in self.results
+        """Accumulate per image evaluation results and store the result in
+        self.results.
         """
         # Get the number of thresholds, categories, area ranges, and max detections
         num_iou_thresholds = len(self.params.iou_thrs)
@@ -1219,9 +1207,7 @@ class COCOEvaluator:
         }
 
     def _pycocotools_summarize(self) -> None:
-        """
-        Compute and display summary metrics for evaluation results.
-        """
+        """Compute and display summary metrics for evaluation results."""
 
         def _summarize(
             use_ap: bool = True,
@@ -1316,8 +1302,7 @@ class COCOEvaluator:
             self.stats = _summarize_predictions().tolist()
 
     def evaluate(self) -> None:
-        """
-        Start the per image evaluation on all images and keeep results in
+        """Start the per image evaluation on all images and keeep results in
         self.eval_imgs (a list of dictionaries).
         """
         # Select all parameters to evaluate
@@ -1412,9 +1397,7 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
         self._image_indices = image_indices
 
     def reset(self) -> None:
-        """
-        Reset the metric to its initial state, clearing all stored data.
-        """
+        """Reset the metric to its initial state, clearing all stored data."""
         self._predictions_list = []
         self._targets_list = []
 
@@ -1461,8 +1444,9 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
         return self
 
     def _detections_content(self, detections: Detections) -> npt.NDArray[Any] | None:
-        """Return per-detection masks or oriented boxes for the metric target,
-        or `None` for the box target and for empty detections."""
+        """Return per-detection masks or oriented boxes for the metric target, or `None`
+        for the box target and for empty detections.
+        """
         if self._metric_target == MetricTarget.BOXES or len(detections) == 0:
             return None
         if self._metric_target == MetricTarget.MASKS:
@@ -1487,8 +1471,9 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
     def _content_area(
         self, xywh: list[float], content: npt.NDArray[Any] | None, idx: int
     ) -> float:
-        """Compute the default annotation area for the metric target: bbox area
-        for boxes, pixel count for masks, polygon area for oriented boxes."""
+        """Compute the default annotation area for the metric target: bbox area for
+        boxes, pixel count for masks, polygon area for oriented boxes.
+        """
         if content is None:
             return float(xywh[2] * xywh[3])
         if self._metric_target == MetricTarget.MASKS:
@@ -1500,7 +1485,9 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
     def _prepare_targets(
         self, targets: list[Detections]
     ) -> dict[str, list[_TypeCocoDict]]:
-        """Transform targets into a dictionary that can be used by the COCO evaluator"""
+        """Transform targets into a dictionary that can be used by the COCO
+        evaluator.
+        """
         images: list[_TypeCocoDict] = [{"id": img_id} for img_id in range(len(targets))]
         if self._image_indices is not None:
             images = [{"id": self._image_indices[img["id"]]} for img in images]
@@ -1583,7 +1570,8 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
         self, predictions: list[Detections]
     ) -> list[_TypeCocoDict]:
         """Transform predictions into a list of predictions that can be used by the COCO
-        evaluator."""
+        evaluator.
+        """
         coco_predictions: list[_TypeCocoDict] = []
         for image_id, image_predictions in enumerate(predictions):
             if self._image_indices is not None:

--- a/src/supervision/metrics/mean_average_precision.py
+++ b/src/supervision/metrics/mean_average_precision.py
@@ -126,8 +126,8 @@ class MeanAveragePrecisionResult:
     large_objects: MeanAveragePrecisionResult | None = None
 
     def __str__(self) -> str:
-        """
-        Formats the evaluation output metrics to match the structure used by pycocotools
+        """Formats the evaluation output metrics to match the structure used by
+        pycocotools.
 
         Example:
            ```pycon
@@ -288,10 +288,8 @@ class MeanAveragePrecisionResult:
 
 
 class EvaluationDataset:
-    """
-    Class used representing a dataset in the right format needed by the
-    `COCOEvaluator` class.
-    """
+    """Class used representing a dataset in the right format needed by the
+    `COCOEvaluator` class."""
 
     def __init__(self, targets: _TypeCocoDataset | None = None) -> None:
         """Constructor of EvaluationDataset object used to evaluate models with Mean
@@ -1322,9 +1320,9 @@ class COCOEvaluator:
 
 
 class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
-    """
-    Mean Average Precision (mAP) is a metric used to evaluate object detection models.
-    It is the average of the precision-recall curves at different IoU thresholds.
+    """Mean Average Precision (mAP) is a metric used to evaluate object detection
+    models. It is the average of the precision-recall curves at different IoU
+    thresholds.
 
     Examples:
         ```pycon

--- a/src/supervision/metrics/mean_average_precision.py
+++ b/src/supervision/metrics/mean_average_precision.py
@@ -71,8 +71,7 @@ class _TypeEvaluationImageResult(TypedDict):
 
 @dataclass
 class MeanAveragePrecisionResult:
-    """
-    The result of the Mean Average Precision calculation.
+    """The result of the Mean Average Precision calculation.
 
     Returns `-1` sentinel scores when no detections or targets are present.
 
@@ -186,8 +185,7 @@ class MeanAveragePrecisionResult:
         )
 
     def to_pandas(self) -> pd.DataFrame:
-        """
-        Convert the result to a pandas DataFrame.
+        """Convert the result to a pandas DataFrame.
 
         Returns:
             The result as a DataFrame.
@@ -221,8 +219,7 @@ class MeanAveragePrecisionResult:
         )
 
     def plot(self) -> None:
-        """
-        Plot the mAP results.
+        """Plot the mAP results.
 
         ![example_plot](
         https://media.roboflow.com/supervision-docs/metrics/mAP_plot_example.png
@@ -297,8 +294,7 @@ class EvaluationDataset:
     """
 
     def __init__(self, targets: _TypeCocoDataset | None = None) -> None:
-        """
-        Constructor of EvaluationDataset object used to evaluate models with Mean
+        """Constructor of EvaluationDataset object used to evaluate models with Mean
         Average Precision.
 
         Args:
@@ -363,8 +359,7 @@ class EvaluationDataset:
         area_range: tuple[float, float] | None = None,
         iscrowd: bool = False,
     ) -> list[int]:
-        """
-        Get annotation ids that satisfy given filter conditions.
+        """Get annotation ids that satisfy given filter conditions.
 
         Args:
             img_ids: ids of the images that we want to retrieve.
@@ -416,8 +411,7 @@ class EvaluationDataset:
         supercategory_names: list[str] | None = None,
         cat_ids: list[int] | None = None,
     ) -> list[int]:
-        """
-        Get category ids that satisfy given filter conditions.
+        """Get category ids that satisfy given filter conditions.
 
         Args:
             cat_names: names of the categories to retrieve.
@@ -461,8 +455,7 @@ class EvaluationDataset:
         img_ids: list[int] | None = None,
         cat_ids: list[int] | None = None,
     ) -> list[int]:
-        """
-        Get image ids that satisfy given filter conditions.
+        """Get image ids that satisfy given filter conditions.
 
         Args:
             img_ids: ids of the images to retrieve.
@@ -488,8 +481,7 @@ class EvaluationDataset:
         return list(ids_set)
 
     def get_annotations(self, ids: list[int] | None = None) -> list[_TypeCocoDict]:
-        """
-        Get annotations with the specified ids.
+        """Get annotations with the specified ids.
 
         Args:
             ids: integer ids specifying annotations.
@@ -502,8 +494,7 @@ class EvaluationDataset:
         return [self.anns[idx] for idx in ids]
 
     def load_predictions(self, predictions: list[_TypeCocoDict]) -> EvaluationDataset:
-        """
-        Load prediction result into an EvaluationDataset object.
+        """Load prediction result into an EvaluationDataset object.
 
         Args:
             predictions: prediction result.
@@ -679,8 +670,7 @@ class COCOEvaluator:
         coco_predictions: EvaluationDataset,
         metric_target: MetricTarget = MetricTarget.BOXES,
     ) -> None:
-        """
-        Constructor of COCOEvaluator object.
+        """Constructor of COCOEvaluator object.
 
         Args:
             coco_targets: The dataset with the ground truths.
@@ -753,8 +743,7 @@ class COCOEvaluator:
         self.results = {}
 
     def _compute_iou(self, img_id: int, cat_id: int) -> npt.NDArray[np.float32]:
-        """
-        Compute the IoU between the targets and predictions for a given image and
+        """Compute the IoU between the targets and predictions for a given image and
         category, using boxes, masks or oriented bounding boxes depending on the
         configured metric target.
 
@@ -934,8 +923,7 @@ class COCOEvaluator:
 
     def _accumulate(self) -> None:
         """Accumulate per image evaluation results and store the result in
-        self.results.
-        """
+        self.results."""
         # Get the number of thresholds, categories, area ranges, and max detections
         num_iou_thresholds = len(self.params.iou_thrs)
         num_recall_thresholds = len(self.params.rec_thrs)
@@ -1303,8 +1291,7 @@ class COCOEvaluator:
 
     def evaluate(self) -> None:
         """Start the per image evaluation on all images and keeep results in
-        self.eval_imgs (a list of dictionaries).
-        """
+        self.eval_imgs (a list of dictionaries)."""
         # Select all parameters to evaluate
         self.params.img_ids = list(np.unique(self.params.img_ids))
         self.params.cat_ids = list(np.unique(self.params.cat_ids))
@@ -1379,8 +1366,7 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
         class_mapping: dict[int, int] | None = None,
         image_indices: list[int] | None = None,
     ) -> None:
-        """
-        Initialize the Mean Average Precision metric.
+        """Initialize the Mean Average Precision metric.
 
         Args:
             metric_target: The type of detection data to use.
@@ -1406,8 +1392,7 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
         predictions: Detections | list[Detections],
         targets: Detections | list[Detections],
     ) -> MeanAveragePrecision:
-        """
-        Add new predictions and targets to the metric, but do not compute the result.
+        """Add new predictions and targets to the metric, but do not compute the result.
 
         Args:
             predictions: The predicted detections.
@@ -1445,8 +1430,7 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
 
     def _detections_content(self, detections: Detections) -> npt.NDArray[Any] | None:
         """Return per-detection masks or oriented boxes for the metric target, or `None`
-        for the box target and for empty detections.
-        """
+        for the box target and for empty detections."""
         if self._metric_target == MetricTarget.BOXES or len(detections) == 0:
             return None
         if self._metric_target == MetricTarget.MASKS:
@@ -1472,8 +1456,7 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
         self, xywh: list[float], content: npt.NDArray[Any] | None, idx: int
     ) -> float:
         """Compute the default annotation area for the metric target: bbox area for
-        boxes, pixel count for masks, polygon area for oriented boxes.
-        """
+        boxes, pixel count for masks, polygon area for oriented boxes."""
         if content is None:
             return float(xywh[2] * xywh[3])
         if self._metric_target == MetricTarget.MASKS:
@@ -1486,8 +1469,7 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
         self, targets: list[Detections]
     ) -> dict[str, list[_TypeCocoDict]]:
         """Transform targets into a dictionary that can be used by the COCO
-        evaluator.
-        """
+        evaluator."""
         images: list[_TypeCocoDict] = [{"id": img_id} for img_id in range(len(targets))]
         if self._image_indices is not None:
             images = [{"id": self._image_indices[img["id"]]} for img in images]
@@ -1570,8 +1552,7 @@ class MeanAveragePrecision(Metric[MeanAveragePrecisionResult]):
         self, predictions: list[Detections]
     ) -> list[_TypeCocoDict]:
         """Transform predictions into a list of predictions that can be used by the COCO
-        evaluator.
-        """
+        evaluator."""
         coco_predictions: list[_TypeCocoDict] = []
         for image_id, image_predictions in enumerate(predictions):
             if self._image_indices is not None:

--- a/src/supervision/metrics/mean_average_recall.py
+++ b/src/supervision/metrics/mean_average_recall.py
@@ -198,8 +198,8 @@ class MeanAverageRecallResult:
         Plot the Mean Average Recall results.
 
         ![example_plot](\
-            https://media.roboflow.com/supervision-docs/metrics/mAR_plot_example.png\
-            ){ align=center width="800" }
+        https://media.roboflow.com/supervision-docs/metrics/mAR_plot_example.png\
+        ){ align=center width="800" }
         """
         from matplotlib import pyplot as plt
 
@@ -325,9 +325,7 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
         self.max_detections = np.array([1, 10, 100])
 
     def reset(self) -> None:
-        """
-        Reset the metric to its initial state, clearing all stored data.
-        """
+        """Reset the metric to its initial state, clearing all stored data."""
         self._predictions_list = []
         self._targets_list = []
 
@@ -364,8 +362,8 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
 
     def compute(self) -> MeanAverageRecallResult:
         """
-        Calculate the Mean Average Recall metric based on the stored predictions
-        and ground-truth, at different IoU thresholds and maximum detection counts.
+        Calculate the Mean Average Recall metric based on the stored predictions and
+        ground-truth, at different IoU thresholds and maximum detection counts.
 
         Returns:
             The Mean Average Recall metric result.
@@ -671,7 +669,8 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
     def _detections_content(
         self, detections: Detections
     ) -> npt.NDArray[Any] | CompactMask:
-        """Return boxes, masks or oriented bounding boxes from detections.
+        """
+        Return boxes, masks or oriented bounding boxes from detections.
 
         For the mask target this may return a
         :class:`~supervision.detection.compact_mask.CompactMask` rather than a

--- a/src/supervision/metrics/mean_average_recall.py
+++ b/src/supervision/metrics/mean_average_recall.py
@@ -32,8 +32,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class MeanAverageRecallResult:
-    """
-    The results of the Mean Average Recall metric calculation.
+    """The results of the Mean Average Recall metric calculation.
 
     Defaults to `0` if no detections or targets were provided.
 
@@ -163,8 +162,7 @@ class MeanAverageRecallResult:
         return out_str
 
     def to_pandas(self) -> pd.DataFrame:
-        """
-        Convert the result to a pandas DataFrame.
+        """Convert the result to a pandas DataFrame.
 
         Returns:
             The result as a DataFrame.
@@ -194,8 +192,7 @@ class MeanAverageRecallResult:
         return pd.DataFrame(pandas_data, index=[0])
 
     def plot(self) -> None:
-        """
-        Plot the Mean Average Recall results.
+        """Plot the Mean Average Recall results.
 
         ![example_plot](\
         https://media.roboflow.com/supervision-docs/metrics/mAR_plot_example.png\
@@ -311,8 +308,7 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
         self,
         metric_target: MetricTarget = MetricTarget.BOXES,
     ):
-        """
-        Initialize the Mean Average Recall metric.
+        """Initialize the Mean Average Recall metric.
 
         Args:
             metric_target: The type of detection data to use.
@@ -334,8 +330,7 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
         predictions: Detections | list[Detections],
         targets: Detections | list[Detections],
     ) -> MeanAverageRecall:
-        """
-        Add new predictions and targets to the metric, but do not compute the result.
+        """Add new predictions and targets to the metric, but do not compute the result.
 
         Args:
             predictions: The predicted detections.
@@ -361,8 +356,7 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
         return self
 
     def compute(self) -> MeanAverageRecallResult:
-        """
-        Calculate the Mean Average Recall metric based on the stored predictions and
+        """Calculate the Mean Average Recall metric based on the stored predictions and
         ground-truth, at different IoU thresholds and maximum detection counts.
 
         Returns:
@@ -574,8 +568,7 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
         unique_classes: npt.NDArray[np.integer],
         class_counts: npt.NDArray[np.integer],
     ) -> npt.NDArray[np.float64]:
-        """
-        Compute the confusion matrix for each class and IoU threshold.
+        """Compute the confusion matrix for each class and IoU threshold.
 
         Assumes the matches and prediction_class_ids are sorted by confidence
         in descending order.
@@ -637,8 +630,7 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
     def _compute_recall(
         confusion_matrix: npt.NDArray[np.float64],
     ) -> npt.NDArray[np.float64]:
-        """
-        Broadcastable function, computing the recall from the confusion matrix.
+        """Broadcastable function, computing the recall from the confusion matrix.
 
         Args:
             confusion_matrix: shape (N, ..., 3), where the last dimension
@@ -669,8 +661,7 @@ class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
     def _detections_content(
         self, detections: Detections
     ) -> npt.NDArray[Any] | CompactMask:
-        """
-        Return boxes, masks or oriented bounding boxes from detections.
+        """Return boxes, masks or oriented bounding boxes from detections.
 
         For the mask target this may return a
         :class:`~supervision.detection.compact_mask.CompactMask` rather than a

--- a/src/supervision/metrics/mean_average_recall.py
+++ b/src/supervision/metrics/mean_average_recall.py
@@ -86,8 +86,7 @@ class MeanAverageRecallResult:
     large_objects: MeanAverageRecallResult | None
 
     def __str__(self) -> str:
-        """
-        Format as a pretty string.
+        """Format as a pretty string.
 
         Example:
             ```pycon
@@ -267,10 +266,9 @@ class MeanAverageRecallResult:
 
 
 class MeanAverageRecall(Metric["MeanAverageRecallResult"]):
-    """
-    Mean Average Recall (mAR) measures how well the model detects
-    and retrieves relevant objects by averaging recall over multiple
-    IoU thresholds, classes and detection limits.
+    """Mean Average Recall (mAR) measures how well the model detects and retrieves
+    relevant objects by averaging recall over multiple IoU thresholds, classes and
+    detection limits.
 
     Intuitively, while Recall measures the ability to find all relevant
     objects, mAR narrows down how many detections are considered for each

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -88,9 +88,7 @@ class Precision(Metric["PrecisionResult"]):
         self._targets_list: list[Detections] = []
 
     def reset(self) -> None:
-        """
-        Reset the metric to its initial state, clearing all stored data.
-        """
+        """Reset the metric to its initial state, clearing all stored data."""
         self._predictions_list = []
         self._targets_list = []
 
@@ -152,7 +150,8 @@ class Precision(Metric["PrecisionResult"]):
         targets_list: list[Detections],
         size_category: ObjectSizeCategory = ObjectSizeCategory.ANY,
     ) -> PrecisionResult:
-        """Build per-image stats tuples and delegate to class-level computation.
+        """
+        Build per-image stats tuples and delegate to class-level computation.
 
         Each stats tuple is
         ``(matches, ignored_matches, confidence, class_ids, true_class_ids)``:
@@ -357,10 +356,11 @@ class Precision(Metric["PrecisionResult"]):
         npt.NDArray[np.float64],
         npt.NDArray[np.int32],
     ]:
-        """Compute precision scores from concatenated stats across all images.
+        """
+        Compute precision scores from concatenated stats across all images.
 
-        ``unique_classes`` is the union of GT and predicted classes so that
-        predictions of classes absent from GT still count as false positives.
+        ``unique_classes`` is the union of GT and predicted classes so that predictions
+        of classes absent from GT still count as false positives.
         """
         sorted_indices = np.argsort(-prediction_confidence)
         matches = matches[sorted_indices]
@@ -446,7 +446,6 @@ class Precision(Metric["PrecisionResult"]):
             shape (C, Th, 3), containing the true positives, false
                 positives, and false negatives for each class and IoU threshold.
         """
-
         num_thresholds = sorted_matches.shape[1]
         num_classes = unique_classes.shape[0]
 
@@ -579,9 +578,7 @@ class Precision(Metric["PrecisionResult"]):
         targets_list: list[Detections],
         size_category: ObjectSizeCategory,
     ) -> tuple[list[Detections], list[Detections]]:
-        """
-        Filter predictions and targets by object size category.
-        """
+        """Filter predictions and targets by object size category."""
         new_predictions_list = []
         new_targets_list = []
         for predictions, targets in zip(predictions_list, targets_list):
@@ -752,10 +749,9 @@ class PrecisionResult:
         Plot the precision results.
 
         ![example_plot](
-            https://media.roboflow.com/supervision-docs/metrics/precision_plot_example.png
+        https://media.roboflow.com/supervision-docs/metrics/precision_plot_example.png
         ){ align=center width="800" }
         """
-
         from matplotlib import pyplot as plt
 
         labels = ["Precision@50", "Precision@75"]

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -30,10 +30,9 @@ if TYPE_CHECKING:
 
 
 class Precision(Metric["PrecisionResult"]):
-    """
-    Precision is a metric used to evaluate object detection models. It is the ratio of
-    true positive detections to the total number of predicted detections. We calculate
-    it at different IoU thresholds.
+    """Precision is a metric used to evaluate object detection models. It is the ratio
+    of true positive detections to the total number of predicted detections. We
+    calculate it at different IoU thresholds.
 
     In simple terms, Precision is a measure of a model's accuracy, calculated as:
 
@@ -635,8 +634,7 @@ class PrecisionResult:
     large_objects: PrecisionResult | None
 
     def __str__(self) -> str:
-        """
-        Format as a pretty string.
+        """Format as a pretty string.
 
         Example:
             ```pycon

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -73,8 +73,7 @@ class Precision(Metric["PrecisionResult"]):
         metric_target: MetricTarget = MetricTarget.BOXES,
         averaging_method: AveragingMethod = AveragingMethod.WEIGHTED,
     ):
-        """
-        Initialize the Precision metric.
+        """Initialize the Precision metric.
 
         Args:
             metric_target: The type of detection data to use.
@@ -97,8 +96,7 @@ class Precision(Metric["PrecisionResult"]):
         predictions: Detections | list[Detections],
         targets: Detections | list[Detections],
     ) -> Precision:
-        """
-        Add new predictions and targets to the metric, but do not compute the result.
+        """Add new predictions and targets to the metric, but do not compute the result.
 
         Args:
             predictions: The predicted detections.
@@ -124,9 +122,8 @@ class Precision(Metric["PrecisionResult"]):
         return self
 
     def compute(self) -> PrecisionResult:
-        """
-        Calculate the precision metric based on the stored predictions and ground-truth
-        data, at different IoU thresholds.
+        """Calculate the precision metric based on the stored predictions and ground-
+        truth data, at different IoU thresholds.
 
         Returns:
             The precision metric result.
@@ -150,8 +147,7 @@ class Precision(Metric["PrecisionResult"]):
         targets_list: list[Detections],
         size_category: ObjectSizeCategory = ObjectSizeCategory.ANY,
     ) -> PrecisionResult:
-        """
-        Build per-image stats tuples and delegate to class-level computation.
+        """Build per-image stats tuples and delegate to class-level computation.
 
         Each stats tuple is
         ``(matches, ignored_matches, confidence, class_ids, true_class_ids)``:
@@ -356,8 +352,7 @@ class Precision(Metric["PrecisionResult"]):
         npt.NDArray[np.float64],
         npt.NDArray[np.int32],
     ]:
-        """
-        Compute precision scores from concatenated stats across all images.
+        """Compute precision scores from concatenated stats across all images.
 
         ``unique_classes`` is the union of GT and predicted classes so that predictions
         of classes absent from GT still count as false positives.
@@ -424,8 +419,7 @@ class Precision(Metric["PrecisionResult"]):
         unique_classes: npt.NDArray[np.int32],
         class_counts: npt.NDArray[np.int32],
     ) -> npt.NDArray[np.float64]:
-        """
-        Compute the confusion matrix for each class and IoU threshold.
+        """Compute the confusion matrix for each class and IoU threshold.
 
         Assumes the matches and prediction_class_ids are sorted by confidence
         in descending order.
@@ -481,8 +475,7 @@ class Precision(Metric["PrecisionResult"]):
     def _compute_precision(
         confusion_matrix: npt.NDArray[np.float64],
     ) -> npt.NDArray[np.float64]:
-        """
-        Broadcastable function, computing the precision from the confusion matrix.
+        """Broadcastable function, computing the precision from the confusion matrix.
 
         Args:
             confusion_matrix: shape (N, ..., 3), where the last dimension
@@ -593,8 +586,7 @@ class Precision(Metric["PrecisionResult"]):
 
 @dataclass
 class PrecisionResult:
-    """
-    The results of the precision metric calculation.
+    """The results of the precision metric calculation.
 
     Defaults to `0` if no detections or targets were provided.
 
@@ -715,8 +707,7 @@ class PrecisionResult:
         return out_str
 
     def to_pandas(self) -> pd.DataFrame:
-        """
-        Convert the result to a pandas DataFrame.
+        """Convert the result to a pandas DataFrame.
 
         Returns:
             The result as a DataFrame.
@@ -745,8 +736,7 @@ class PrecisionResult:
         return pd.DataFrame(pandas_data, index=[0])
 
     def plot(self) -> None:
-        """
-        Plot the precision results.
+        """Plot the precision results.
 
         ![example_plot](
         https://media.roboflow.com/supervision-docs/metrics/precision_plot_example.png

--- a/src/supervision/metrics/recall.py
+++ b/src/supervision/metrics/recall.py
@@ -114,9 +114,7 @@ class Recall(Metric["RecallResult"]):
         self._targets_list: list[Detections] = []
 
     def reset(self) -> None:
-        """
-        Reset the metric to its initial state, clearing all stored data.
-        """
+        """Reset the metric to its initial state, clearing all stored data."""
         self._predictions_list = []
         self._targets_list = []
 
@@ -470,7 +468,6 @@ class Recall(Metric["RecallResult"]):
             shape (C, Th, 3), containing the true positives, false
                 positives, and false negatives for each class and IoU threshold.
         """
-
         num_thresholds = sorted_matches.shape[1]
         num_classes = unique_classes.shape[0]
 
@@ -538,7 +535,8 @@ class Recall(Metric["RecallResult"]):
     def _detections_content(
         self, detections: Detections
     ) -> npt.NDArray[Any] | CompactMask:
-        """Return boxes, masks or oriented bounding boxes from detections.
+        """
+        Return boxes, masks or oriented bounding boxes from detections.
 
         For the mask target this may return a
         :class:`~supervision.detection.compact_mask.CompactMask` rather than a
@@ -613,9 +611,7 @@ class Recall(Metric["RecallResult"]):
         targets_list: list[Detections],
         size_category: ObjectSizeCategory,
     ) -> tuple[list[Detections], list[Detections]]:
-        """
-        Filter predictions and targets by object size category.
-        """
+        """Filter predictions and targets by object size category."""
         new_predictions_list = []
         new_targets_list = []
         for predictions, targets in zip(predictions_list, targets_list):
@@ -784,7 +780,7 @@ class RecallResult:
         Plot the recall results.
 
         ![example_plot](
-            https://media.roboflow.com/supervision-docs/metrics/recall_plot_example.png
+        https://media.roboflow.com/supervision-docs/metrics/recall_plot_example.png
         ){ align=center width="800" }
         """
         from matplotlib import pyplot as plt

--- a/src/supervision/metrics/recall.py
+++ b/src/supervision/metrics/recall.py
@@ -99,8 +99,7 @@ class Recall(Metric["RecallResult"]):
         metric_target: MetricTarget = MetricTarget.BOXES,
         averaging_method: AveragingMethod = AveragingMethod.WEIGHTED,
     ):
-        """
-        Initialize the Recall metric.
+        """Initialize the Recall metric.
 
         Args:
             metric_target: The type of detection data to use.
@@ -123,8 +122,7 @@ class Recall(Metric["RecallResult"]):
         predictions: Detections | list[Detections],
         targets: Detections | list[Detections],
     ) -> Recall:
-        """
-        Add new predictions and targets to the metric, but do not compute the result.
+        """Add new predictions and targets to the metric, but do not compute the result.
 
         Args:
             predictions: The predicted detections.
@@ -150,8 +148,7 @@ class Recall(Metric["RecallResult"]):
         return self
 
     def compute(self) -> RecallResult:
-        """
-        Calculate the recall metric based on the stored predictions and ground-truth
+        """Calculate the recall metric based on the stored predictions and ground-truth
         data, at different IoU thresholds.
 
         Returns:
@@ -446,8 +443,7 @@ class Recall(Metric["RecallResult"]):
         unique_classes: npt.NDArray[np.integer],
         class_counts: npt.NDArray[np.integer],
     ) -> npt.NDArray[np.float64]:
-        """
-        Compute the confusion matrix for each class and IoU threshold.
+        """Compute the confusion matrix for each class and IoU threshold.
 
         Assumes the matches and prediction_class_ids are sorted by confidence
         in descending order.
@@ -503,8 +499,7 @@ class Recall(Metric["RecallResult"]):
     def _compute_recall(
         confusion_matrix: npt.NDArray[np.float64],
     ) -> npt.NDArray[np.float64]:
-        """
-        Broadcastable function, computing the recall from the confusion matrix.
+        """Broadcastable function, computing the recall from the confusion matrix.
 
         Args:
             confusion_matrix: shape (N, ..., 3), where the last dimension
@@ -535,8 +530,7 @@ class Recall(Metric["RecallResult"]):
     def _detections_content(
         self, detections: Detections
     ) -> npt.NDArray[Any] | CompactMask:
-        """
-        Return boxes, masks or oriented bounding boxes from detections.
+        """Return boxes, masks or oriented bounding boxes from detections.
 
         For the mask target this may return a
         :class:`~supervision.detection.compact_mask.CompactMask` rather than a
@@ -626,8 +620,7 @@ class Recall(Metric["RecallResult"]):
 
 @dataclass
 class RecallResult:
-    """
-    The results of the recall metric calculation.
+    """The results of the recall metric calculation.
 
     Defaults to `0` if no detections or targets were provided.
 
@@ -746,8 +739,7 @@ class RecallResult:
         return out_str
 
     def to_pandas(self) -> pd.DataFrame:
-        """
-        Convert the result to a pandas DataFrame.
+        """Convert the result to a pandas DataFrame.
 
         Returns:
             The result as a DataFrame.
@@ -776,8 +768,7 @@ class RecallResult:
         return pd.DataFrame(pandas_data, index=[0])
 
     def plot(self) -> None:
-        """
-        Plot the recall results.
+        """Plot the recall results.
 
         ![example_plot](
         https://media.roboflow.com/supervision-docs/metrics/recall_plot_example.png

--- a/src/supervision/metrics/recall.py
+++ b/src/supervision/metrics/recall.py
@@ -31,8 +31,7 @@ if TYPE_CHECKING:
 
 
 class Recall(Metric["RecallResult"]):
-    """
-    Recall is a metric used to evaluate object detection models. It is the ratio of
+    """Recall is a metric used to evaluate object detection models. It is the ratio of
     true positive detections to the total number of ground truth instances. We calculate
     it at different IoU thresholds.
 
@@ -669,8 +668,7 @@ class RecallResult:
     large_objects: RecallResult | None
 
     def __str__(self) -> str:
-        """
-        Format as a pretty string.
+        """Format as a pretty string.
 
         Example:
             ```pycon

--- a/src/supervision/metrics/utils/object_size.py
+++ b/src/supervision/metrics/utils/object_size.py
@@ -131,7 +131,8 @@ def get_bbox_size_category(xyxy: npt.NDArray[np.number]) -> npt.NDArray[np.int_]
 def get_area_size_category(
     areas: npt.NDArray[np.number],
 ) -> npt.NDArray[np.int_]:
-    """Get object size categories from per-detection pixel areas.
+    """
+    Get object size categories from per-detection pixel areas.
 
     Args:
         areas: One-dimensional pixel areas shaped (N,).

--- a/src/supervision/metrics/utils/object_size.py
+++ b/src/supervision/metrics/utils/object_size.py
@@ -47,8 +47,7 @@ def get_object_size_category(
     data: npt.NDArray[np.number] | npt.NDArray[np.bool_],
     metric_target: MetricTarget,
 ) -> npt.NDArray[np.int_]:
-    """
-    Get the size category of an object. Distinguish based on the metric target.
+    """Get the size category of an object. Distinguish based on the metric target.
 
     Args:
         data: The object data, shaped (N, ...).
@@ -87,8 +86,7 @@ def get_object_size_category(
 
 
 def get_bbox_size_category(xyxy: npt.NDArray[np.number]) -> npt.NDArray[np.int_]:
-    """
-    Get the size category of a bounding boxes array.
+    """Get the size category of a bounding boxes array.
 
     Args:
         xyxy: The bounding boxes array shaped (N, 4).
@@ -165,8 +163,7 @@ def get_area_size_category(
 def get_mask_size_category(
     mask: npt.NDArray[np.bool_] | CompactMask,
 ) -> npt.NDArray[np.int_]:
-    """
-    Get the size category of detection masks.
+    """Get the size category of detection masks.
 
     Args:
         mask: The mask array shaped (N, H, W), or a
@@ -210,8 +207,7 @@ def get_mask_size_category(
 
 
 def get_obb_size_category(xyxyxyxy: npt.NDArray[np.number]) -> npt.NDArray[np.int_]:
-    """
-    Get the size category of a oriented bounding boxes array.
+    """Get the size category of a oriented bounding boxes array.
 
     Args:
         xyxyxyxy: The bounding boxes array shaped (N, 4, 2).

--- a/src/supervision/metrics/utils/object_size.py
+++ b/src/supervision/metrics/utils/object_size.py
@@ -18,8 +18,7 @@ SIZE_THRESHOLDS = (32**2, 96**2)
 
 
 class ObjectSizeCategory(Enum):
-    """
-    Enum for object size categories based on area in pixels.
+    """Enum for object size categories based on area in pixels.
 
     Small: area < 32^2
     Medium: 32^2 <= area < 96^2
@@ -131,8 +130,7 @@ def get_bbox_size_category(xyxy: npt.NDArray[np.number]) -> npt.NDArray[np.int_]
 def get_area_size_category(
     areas: npt.NDArray[np.number],
 ) -> npt.NDArray[np.int_]:
-    """
-    Get object size categories from per-detection pixel areas.
+    """Get object size categories from per-detection pixel areas.
 
     Args:
         areas: One-dimensional pixel areas shaped (N,).

--- a/src/supervision/tracker/byte_tracker/core.py
+++ b/src/supervision/tracker/byte_tracker/core.py
@@ -169,10 +169,10 @@ class ByteTrack:
         """
         Resets the internal state of the ByteTrack tracker.
 
-        This method clears the tracking data, including tracked, lost,
-        and removed tracks, as well as resetting the frame counter. It's
-        particularly useful when processing multiple videos sequentially,
-        ensuring the tracker starts with a clean state for each new video.
+        This method clears the tracking data, including tracked, lost, and removed
+        tracks, as well as resetting the frame counter. It's particularly useful when
+        processing multiple videos sequentially, ensuring the tracker starts with a
+        clean state for each new video.
         """
         self.frame_id = 0
         self.internal_id_counter.reset()
@@ -212,7 +212,7 @@ class ByteTrack:
         scores_second = scores[inds_second]
 
         if len(dets) > 0:
-            """Detections"""
+            """Detections."""
             detections = [
                 STrack(
                     STrack.tlbr_to_tlwh(tlbr),
@@ -226,8 +226,8 @@ class ByteTrack:
             ]
         else:
             detections = []
-
-        """ Add newly detected tracklets to tracked_stracks"""
+        \
+        """Add newly detected tracklets to tracked_stracks."""
         unconfirmed = []
         tracked_stracks: list[STrack] = []
 
@@ -236,8 +236,8 @@ class ByteTrack:
                 unconfirmed.append(track)
             else:
                 tracked_stracks.append(track)
-
-        """ Step 2: First association, with high score detection boxes"""
+        \
+        """Step 2: First association, with high score detection boxes."""
         strack_pool = joint_tracks(tracked_stracks, self.lost_tracks)
         # Predict the current location with KF
         STrack.multi_predict(strack_pool, self.shared_kalman)
@@ -257,11 +257,11 @@ class ByteTrack:
             else:
                 track.re_activate(det, self.frame_id)
                 refind_stracks.append(track)
-
-        """ Step 3: Second association, with low score detection boxes"""
+        \
+        """Step 3: Second association, with low score detection boxes."""
         # association the untrack to the low score detections
         if len(dets_second) > 0:
-            """Detections"""
+            """Detections."""
             detections_second = [
                 STrack(
                     STrack.tlbr_to_tlwh(tlbr),
@@ -299,8 +299,10 @@ class ByteTrack:
             if not track.state == TrackState.Lost:
                 track.state = TrackState.Lost
                 lost_stracks.append(track)
-
-        """Deal with unconfirmed tracks, usually tracks with only one beginning frame"""
+        \
+        """Deal with unconfirmed tracks, usually tracks with only one beginning
+        frame.
+        """
         detections = [detections[i] for i in u_detection]
         dists = matching.iou_distance(unconfirmed, detections)
 
@@ -315,15 +317,16 @@ class ByteTrack:
             track = unconfirmed[it]
             track.state = TrackState.Removed
             removed_stracks.append(track)
-
-        """ Step 4: Init new stracks"""
+        \
+        """Step 4: Init new stracks."""
         for inew in u_detection:
             track = detections[inew]
             if track.score < self.det_thresh:
                 continue
             track.activate(self.kalman_filter, self.frame_id)
             activated_starcks.append(track)
-        """ Step 5: Update state"""
+        \
+        """Step 5: Update state."""
         for track in self.lost_tracks:
             if self.frame_id - track.frame_id > self.max_time_lost:
                 track.state = TrackState.Removed
@@ -350,8 +353,8 @@ def joint_tracks(
     track_list_a: list[STrack], track_list_b: list[STrack]
 ) -> list[STrack]:
     """
-    Joins two lists of tracks, ensuring that the resulting list does not
-    contain tracks with duplicate internal_track_id values.
+    Joins two lists of tracks, ensuring that the resulting list does not contain tracks
+    with duplicate internal_track_id values.
 
     Args:
         track_list_a: First list of tracks.
@@ -374,8 +377,8 @@ def joint_tracks(
 
 def sub_tracks(track_list_a: list[STrack], track_list_b: list[STrack]) -> list[STrack]:
     """
-    Returns a list of tracks from track_list_a after removing any tracks
-    that share the same internal_track_id with tracks in track_list_b.
+    Returns a list of tracks from track_list_a after removing any tracks that share the
+    same internal_track_id with tracks in track_list_b.
 
     Args:
         track_list_a: List of tracks.

--- a/src/supervision/tracker/byte_tracker/core.py
+++ b/src/supervision/tracker/byte_tracker/core.py
@@ -29,8 +29,7 @@ def _valid_tracking_tensors(
     remove_in="0.31.0",
 )
 class ByteTrack:
-    """
-    Initialize the ByteTrack object.
+    """Initialize the ByteTrack object.
 
     !!! deprecated "Deprecated"
 
@@ -166,8 +165,7 @@ class ByteTrack:
             return detections
 
     def reset(self) -> None:
-        """
-        Resets the internal state of the ByteTrack tracker.
+        """Resets the internal state of the ByteTrack tracker.
 
         This method clears the tracking data, including tracked, lost, and removed
         tracks, as well as resetting the frame counter. It's particularly useful when
@@ -182,8 +180,7 @@ class ByteTrack:
         self.removed_tracks = []
 
     def update_with_tensors(self, tensors: npt.NDArray[np.float32]) -> list[STrack]:
-        """
-        Updates the tracker with the provided tensors and returns the updated tracks.
+        """Updates the tracker with the provided tensors and returns the updated tracks.
 
         Args:
             tensors: The new tensors to update with.
@@ -226,7 +223,6 @@ class ByteTrack:
             ]
         else:
             detections = []
-        \
         """Add newly detected tracklets to tracked_stracks."""
         unconfirmed = []
         tracked_stracks: list[STrack] = []
@@ -236,7 +232,6 @@ class ByteTrack:
                 unconfirmed.append(track)
             else:
                 tracked_stracks.append(track)
-        \
         """Step 2: First association, with high score detection boxes."""
         strack_pool = joint_tracks(tracked_stracks, self.lost_tracks)
         # Predict the current location with KF
@@ -257,7 +252,6 @@ class ByteTrack:
             else:
                 track.re_activate(det, self.frame_id)
                 refind_stracks.append(track)
-        \
         """Step 3: Second association, with low score detection boxes."""
         # association the untrack to the low score detections
         if len(dets_second) > 0:
@@ -301,8 +295,7 @@ class ByteTrack:
                 lost_stracks.append(track)
         \
         """Deal with unconfirmed tracks, usually tracks with only one beginning
-        frame.
-        """
+        frame."""
         detections = [detections[i] for i in u_detection]
         dists = matching.iou_distance(unconfirmed, detections)
 
@@ -317,7 +310,6 @@ class ByteTrack:
             track = unconfirmed[it]
             track.state = TrackState.Removed
             removed_stracks.append(track)
-        \
         """Step 4: Init new stracks."""
         for inew in u_detection:
             track = detections[inew]
@@ -325,7 +317,6 @@ class ByteTrack:
                 continue
             track.activate(self.kalman_filter, self.frame_id)
             activated_starcks.append(track)
-        \
         """Step 5: Update state."""
         for track in self.lost_tracks:
             if self.frame_id - track.frame_id > self.max_time_lost:
@@ -352,9 +343,8 @@ class ByteTrack:
 def joint_tracks(
     track_list_a: list[STrack], track_list_b: list[STrack]
 ) -> list[STrack]:
-    """
-    Joins two lists of tracks, ensuring that the resulting list does not contain tracks
-    with duplicate internal_track_id values.
+    """Joins two lists of tracks, ensuring that the resulting list does not contain
+    tracks with duplicate internal_track_id values.
 
     Args:
         track_list_a: First list of tracks.
@@ -376,9 +366,8 @@ def joint_tracks(
 
 
 def sub_tracks(track_list_a: list[STrack], track_list_b: list[STrack]) -> list[STrack]:
-    """
-    Returns a list of tracks from track_list_a after removing any tracks that share the
-    same internal_track_id with tracks in track_list_b.
+    """Returns a list of tracks from track_list_a after removing any tracks that share
+    the same internal_track_id with tracks in track_list_b.
 
     Args:
         track_list_a: List of tracks.

--- a/src/supervision/tracker/byte_tracker/core.py
+++ b/src/supervision/tracker/byte_tracker/core.py
@@ -92,8 +92,7 @@ class ByteTrack:
         self.external_id_counter = IdCounter(start_id=1)
 
     def update_with_detections(self, detections: Detections) -> Detections:
-        """
-        Updates the tracker with the provided detections and returns the updated
+        """Updates the tracker with the provided detections and returns the updated
         detection results.
 
         Args:
@@ -293,7 +292,6 @@ class ByteTrack:
             if not track.state == TrackState.Lost:
                 track.state = TrackState.Lost
                 lost_stracks.append(track)
-        \
         """Deal with unconfirmed tracks, usually tracks with only one beginning
         frame."""
         detections = [detections[i] for i in u_detection]

--- a/src/supervision/tracker/byte_tracker/kalman_filter.py
+++ b/src/supervision/tracker/byte_tracker/kalman_filter.py
@@ -4,8 +4,7 @@ import scipy.linalg
 
 
 class KalmanFilter:
-    """
-    A simple Kalman filter for tracking bounding boxes in image space.
+    """A simple Kalman filter for tracking bounding boxes in image space.
 
     The 8-dimensional state space is (x, y, a, h, vx, vy, va, vh), where (x, y) is the
     bounding box center, a is the aspect ratio (w/h), h is the height, and their
@@ -29,8 +28,7 @@ class KalmanFilter:
     def initiate(
         self, measurement: npt.NDArray[np.float32]
     ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
-        """
-        Create track from unassociated measurement.
+        """Create track from unassociated measurement.
 
         Args:
             measurement: The initial measurement vector.
@@ -58,8 +56,7 @@ class KalmanFilter:
     def predict(
         self, mean: npt.NDArray[np.float32], covariance: npt.NDArray[np.float32]
     ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
-        """
-        Run Kalman filter prediction step.
+        """Run Kalman filter prediction step.
 
         Args:
             mean: The object state mean at the previous time step.
@@ -93,8 +90,7 @@ class KalmanFilter:
     def project(
         self, mean: npt.NDArray[np.float32], covariance: npt.NDArray[np.float32]
     ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
-        """
-        Project state distribution to measurement space.
+        """Project state distribution to measurement space.
 
         Args:
             mean: The state's mean vector.
@@ -160,8 +156,7 @@ class KalmanFilter:
         covariance: npt.NDArray[np.float32],
         measurement: npt.NDArray[np.float32],
     ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
-        """
-        Run Kalman filter correction step.
+        """Run Kalman filter correction step.
 
         Args:
             mean: The predicted state's mean vector.

--- a/src/supervision/tracker/byte_tracker/kalman_filter.py
+++ b/src/supervision/tracker/byte_tracker/kalman_filter.py
@@ -7,13 +7,12 @@ class KalmanFilter:
     """
     A simple Kalman filter for tracking bounding boxes in image space.
 
-    The 8-dimensional state space is (x, y, a, h, vx, vy, va, vh), where
-    (x, y) is the bounding box center, a is the aspect ratio (w/h), h is
-    the height, and their respective velocities.
+    The 8-dimensional state space is (x, y, a, h, vx, vy, va, vh), where (x, y) is the
+    bounding box center, a is the aspect ratio (w/h), h is the height, and their
+    respective velocities.
 
-    Object motion follows a constant velocity model. The bounding box location
-    (x, y, a, h) is taken as direct observation of the state space (linear
-    observation model).
+    Object motion follows a constant velocity model. The bounding box location (x, y, a,
+    h) is taken as direct observation of the state space (linear observation model).
     """
 
     def __init__(self) -> None:

--- a/src/supervision/tracker/byte_tracker/single_object_track.py
+++ b/src/supervision/tracker/byte_tracker/single_object_track.py
@@ -111,8 +111,7 @@ class STrack:
         self.score = new_track.score
 
     def update(self, new_track: STrack, frame_id: int) -> None:
-        """
-        Update a matched track.
+        """Update a matched track.
 
         Args:
             new_track: The new track data.
@@ -139,8 +138,7 @@ class STrack:
     @property
     def tlwh(self) -> npt.NDArray[np.float32]:
         """Get current position in bounding box format `(top left x, top left y, width,
-        height)`.
-        """
+        height)`."""
         if self.mean is None:
             return cast(npt.NDArray[np.float32], self._tlwh.copy())
         ret = self.mean[:4].copy()
@@ -151,8 +149,7 @@ class STrack:
     @property
     def tlbr(self) -> npt.NDArray[np.float32]:
         """Convert bounding box to format `(min x, min y, max x, max y)`, i.e., `(top
-        left, bottom right)`.
-        """
+        left, bottom right)`."""
         ret = self.tlwh.copy()
         ret[2:] += ret[:2]
         return cast(npt.NDArray[np.float32], ret)
@@ -160,8 +157,7 @@ class STrack:
     @staticmethod
     def tlwh_to_xyah(tlwh: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
         """Convert bounding box to format `(center x, center y, aspect ratio, height)`,
-        where the aspect ratio is `width / height`.
-        """
+        where the aspect ratio is `width / height`."""
         ret = np.asarray(tlwh).copy()
         ret[:2] += ret[2:] / 2
         ret[2] /= ret[3]

--- a/src/supervision/tracker/byte_tracker/single_object_track.py
+++ b/src/supervision/tracker/byte_tracker/single_object_track.py
@@ -138,8 +138,8 @@ class STrack:
 
     @property
     def tlwh(self) -> npt.NDArray[np.float32]:
-        """Get current position in bounding box format `(top left x, top left y,
-        width, height)`.
+        """Get current position in bounding box format `(top left x, top left y, width,
+        height)`.
         """
         if self.mean is None:
             return cast(npt.NDArray[np.float32], self._tlwh.copy())
@@ -150,8 +150,8 @@ class STrack:
 
     @property
     def tlbr(self) -> npt.NDArray[np.float32]:
-        """Convert bounding box to format `(min x, min y, max x, max y)`, i.e.,
-        `(top left, bottom right)`.
+        """Convert bounding box to format `(min x, min y, max x, max y)`, i.e., `(top
+        left, bottom right)`.
         """
         ret = self.tlwh.copy()
         ret[2:] += ret[:2]
@@ -159,8 +159,8 @@ class STrack:
 
     @staticmethod
     def tlwh_to_xyah(tlwh: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
-        """Convert bounding box to format `(center x, center y, aspect ratio,
-        height)`, where the aspect ratio is `width / height`.
+        """Convert bounding box to format `(center x, center y, aspect ratio, height)`,
+        where the aspect ratio is `width / height`.
         """
         ret = np.asarray(tlwh).copy()
         ret[:2] += ret[2:] / 2

--- a/src/supervision/tracker/byte_tracker/utils.py
+++ b/src/supervision/tracker/byte_tracker/utils.py
@@ -1,7 +1,6 @@
 class IdCounter:
     def __init__(self, start_id: int = 0) -> None:
-        """
-        Initialize the ID counter.
+        """Initialize the ID counter.
 
         Args:
             start_id: The starting integer for the counter.
@@ -19,8 +18,7 @@ class IdCounter:
         self._id = self.start_id
 
     def new_id(self) -> int:
-        """
-        Get the current ID and increment the counter.
+        """Get the current ID and increment the counter.
 
         Returns:
             The newly assigned ID.

--- a/src/supervision/utils/conversion.py
+++ b/src/supervision/utils/conversion.py
@@ -17,9 +17,8 @@ def ensure_cv2_image_for_class_method(
     annotate_func: F,
 ) -> F:
     """
-    Decorates `BaseAnnotator.annotate` implementations, converts scene to
-    an image type used internally by the annotators, converts back when annotation
-    is complete.
+    Decorates `BaseAnnotator.annotate` implementations, converts scene to an image type
+    used internally by the annotators, converts back when annotation is complete.
 
     Assumes the annotators modify the scene in-place.
 
@@ -137,8 +136,8 @@ def images_to_cv2(
     images: list[npt.NDArray[np.uint8] | Image.Image],
 ) -> list[npt.NDArray[np.uint8]]:
     """
-    Converts images provided either as Pillow images or OpenCV
-    images into OpenCV format.
+    Converts images provided either as Pillow images or OpenCV images into OpenCV
+    format.
 
     Args:
         images: Images to be converted
@@ -146,7 +145,6 @@ def images_to_cv2(
     Returns:
         List of input images in OpenCV format
             (with order preserved).
-
     """
     result: list[npt.NDArray[np.uint8]] = []
     for image in images:

--- a/src/supervision/utils/conversion.py
+++ b/src/supervision/utils/conversion.py
@@ -16,9 +16,8 @@ F = TypeVar("F", bound=Callable[..., Any])
 def ensure_cv2_image_for_class_method(
     annotate_func: F,
 ) -> F:
-    """
-    Decorates `BaseAnnotator.annotate` implementations, converts scene to an image type
-    used internally by the annotators, converts back when annotation is complete.
+    """Decorates `BaseAnnotator.annotate` implementations, converts scene to an image
+    type used internally by the annotators, converts back when annotation is complete.
 
     Assumes the annotators modify the scene in-place.
 
@@ -56,9 +55,8 @@ def ensure_cv2_image_for_annotation(
 def ensure_cv2_image_for_standalone_function(
     image_processing_fun: F,
 ) -> F:
-    """
-    Decorates image processing functions that accept np.ndarray, converting `image` to
-    np.ndarray, converts back when processing is complete.
+    """Decorates image processing functions that accept np.ndarray, converting `image`
+    to np.ndarray, converts back when processing is complete.
 
     Assumes the annotators do NOT modify the scene in-place.
 
@@ -84,9 +82,8 @@ def ensure_cv2_image_for_standalone_function(
 def ensure_pil_image_for_class_method(
     annotate_func: F,
 ) -> F:
-    """
-    Decorates image processing functions that accept np.ndarray, converting `image` to
-    PIL image, converts back when processing is complete.
+    """Decorates image processing functions that accept np.ndarray, converting `image`
+    to PIL image, converts back when processing is complete.
 
     Assumes the annotators modify the scene in-place.
 
@@ -135,8 +132,7 @@ def ensure_cv2_image_for_processing(
 def images_to_cv2(
     images: list[npt.NDArray[np.uint8] | Image.Image],
 ) -> list[npt.NDArray[np.uint8]]:
-    """
-    Converts images provided either as Pillow images or OpenCV images into OpenCV
+    """Converts images provided either as Pillow images or OpenCV images into OpenCV
     format.
 
     Args:

--- a/src/supervision/utils/conversion.py
+++ b/src/supervision/utils/conversion.py
@@ -152,11 +152,10 @@ def images_to_cv2(
 
 
 def pillow_to_cv2(image: Image.Image) -> npt.NDArray[np.uint8]:
-    """
-    Converts Pillow image into OpenCV image, handling RGB -> BGR
-    conversion. Palette images are first expanded to RGB so palette indices are
-    resolved to their actual colors. RGBA images are converted to BGR, matching
-    OpenCV by dropping the alpha channel.
+    """Converts Pillow image into OpenCV image, handling RGB -> BGR conversion. Palette
+    images are first expanded to RGB so palette indices are resolved to their actual
+    colors. RGBA images are converted to BGR, matching OpenCV by dropping the alpha
+    channel.
 
     Args:
         image: Pillow image in RGB, RGBA, grayscale, or palette mode.
@@ -190,9 +189,8 @@ def pillow_to_cv2(image: Image.Image) -> npt.NDArray[np.uint8]:
 
 
 def cv2_to_pillow(image: npt.NDArray[np.uint8]) -> Image.Image:
-    """
-    Converts an OpenCV image into a Pillow image, reordering channels from
-    OpenCV's BGR(A) convention to Pillow's RGB(A).
+    """Converts an OpenCV image into a Pillow image, reordering channels from OpenCV's
+    BGR(A) convention to Pillow's RGB(A).
 
     Args:
         image: OpenCV image. Accepted shapes:

--- a/src/supervision/utils/file.py
+++ b/src/supervision/utils/file.py
@@ -14,8 +14,7 @@ SUPERVISION_CACHE_DIR = Path(tempfile.gettempdir()) / "supervision"
 
 
 def _normalize_http_url(url: str) -> str:
-    """
-    Validate and normalize an HTTP(S) URL.
+    """Validate and normalize an HTTP(S) URL.
 
     Args:
         url: URL to validate.
@@ -54,8 +53,7 @@ def _normalize_http_url(url: str) -> str:
 def _download_to_file(
     url: str, target: Path, *, timeout: float = 30.0, stream: bool = False
 ) -> None:
-    """
-    Download `url` to `target` atomically using a temporary file and `os.replace`.
+    """Download `url` to `target` atomically using a temporary file and `os.replace`.
 
     Args:
         url: HTTP(S) URL to download.
@@ -219,8 +217,7 @@ def read_txt_file(file_path: str | Path, skip_empty: bool = False) -> list[str]:
 
 
 def save_text_file(lines: list[str], file_path: str | Path) -> None:
-    """
-    Write a list of strings to a text file, each string on a new line.
+    """Write a list of strings to a text file, each string on a new line.
 
     Args:
         lines: The list of strings to be written to the file.
@@ -263,8 +260,7 @@ def read_json_file(file_path: str | Path) -> dict[str, Any]:
 def save_json_file(
     data: dict[str, Any], file_path: str | Path, indent: int = 3
 ) -> None:
-    """
-    Write a dict to a json file.
+    """Write a dict to a json file.
 
     Args:
         data: dict with unique keys and value as pair.
@@ -276,8 +272,7 @@ def save_json_file(
 
 
 def read_yaml_file(file_path: str | Path) -> dict[str, Any]:
-    """
-    Read a yaml file and return a dict.
+    """Read a yaml file and return a dict.
 
     Args:
         file_path: The file path as a string or Path object.
@@ -291,8 +286,7 @@ def read_yaml_file(file_path: str | Path) -> dict[str, Any]:
 
 
 def save_yaml_file(data: dict[str, Any], file_path: str | Path) -> None:
-    """
-    Save a dict to a yaml file.
+    """Save a dict to a yaml file.
 
     Args:
         data: dict with unique keys and value as pair.

--- a/src/supervision/utils/file.py
+++ b/src/supervision/utils/file.py
@@ -112,9 +112,8 @@ class NumpyJsonEncoder(json.JSONEncoder):
 def list_files_with_extensions(
     directory: str | Path, extensions: list[str] | None = None
 ) -> list[Path]:
-    """
-    List files in a directory with specified extensions or
-        all files if no extensions are provided.
+    """List files in a directory with specified extensions or all files if no extensions
+    are provided.
 
     Args:
         directory: The directory path as a string or Path object.
@@ -180,8 +179,7 @@ def list_files_with_extensions(
 
 
 def read_txt_file(file_path: str | Path, skip_empty: bool = False) -> list[str]:
-    """
-    Read a text file and return a list of strings without newline characters.
+    """Read a text file and return a list of strings without newline characters.
     Optionally skip empty lines.
 
     Args:
@@ -229,8 +227,7 @@ def save_text_file(lines: list[str], file_path: str | Path) -> None:
 
 
 def read_json_file(file_path: str | Path) -> dict[str, Any]:
-    """
-    Read a json file and return a dict.
+    """Read a json file and return a dict.
 
     Args:
         file_path: The file path as a string or Path object.

--- a/src/supervision/utils/file.py
+++ b/src/supervision/utils/file.py
@@ -298,6 +298,5 @@ def save_yaml_file(data: dict[str, Any], file_path: str | Path) -> None:
         data: dict with unique keys and value as pair.
         file_path: The file path as a string or Path object.
     """
-
     with open(str(file_path), "w") as outfile:
         yaml.dump(data, outfile, sort_keys=False, default_flow_style=None)

--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -46,9 +46,7 @@ DEFAULT_IMAGE_URL_CACHE_DIR = SUPERVISION_CACHE_DIR / "image-url"
 
 
 def _get_image_url_cache_path(value: str, cache_dir: str | Path | None) -> Path:
-    """
-    Build the cache file path for a URL: `<cache root>/<md5(url)><suffix>`.
-    """
+    """Build the cache file path for a URL: `<cache root>/<md5(url)><suffix>`."""
     cache_root = (
         DEFAULT_IMAGE_URL_CACHE_DIR
         if cache_dir is None
@@ -64,9 +62,7 @@ def _decode_image_from_bytes(
     value: bytes,
     cv_imread_flags: int,
 ) -> npt.NDArray[np.uint8]:
-    """
-    Decode raw image bytes into an OpenCV image, raising on undecodable data.
-    """
+    """Decode raw image bytes into an OpenCV image, raising on undecodable data."""
     image = cv2.imdecode(
         np.frombuffer(value, dtype=np.uint8),
         cv_imread_flags,
@@ -472,7 +468,8 @@ def _overlay_image(
     overlay: npt.NDArray[np.uint8],
     anchor: tuple[int, int],
 ) -> npt.NDArray[np.uint8]:
-    """Overlay `overlay` onto `image` at `anchor`, clipping to scene bounds.
+    """
+    Overlay `overlay` onto `image` at `anchor`, clipping to scene bounds.
 
     Non-deprecated internal implementation backing the public `overlay_image`.
     Kept separate so library-internal callers do not emit a deprecation warning.
@@ -657,8 +654,8 @@ class ImageSink:
     """
     Save sequential images into a directory through a context manager.
 
-    `ImageSink` creates the target directory on entry and writes each image
-    using `save_image`, incrementing the image name pattern after every save.
+    `ImageSink` creates the target directory on entry and writes each image using
+    `save_image`, incrementing the image name pattern after every save.
     """
 
     def __init__(
@@ -768,10 +765,10 @@ def create_tiles(
     default_title_placement: RelativePosition = "top",
 ) -> ImageType:
     """
-    Creates tiles mosaic from input images, automating grid placement and
-    converting images to common resolution maintaining aspect ratio. It is
-    also possible to render text titles on tiles, using optional set of
-    parameters specifying text drawing (see parameters description).
+    Creates tiles mosaic from input images, automating grid placement and converting
+    images to common resolution maintaining aspect ratio. It is also possible to render
+    text titles on tiles, using optional set of parameters specifying text drawing (see
+    parameters description).
 
     Automated grid placement will try to maintain square shape of grid
     (with size being the nearest integer square root of #images), up to two exceptions:

--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -468,8 +468,7 @@ def _overlay_image(
     overlay: npt.NDArray[np.uint8],
     anchor: tuple[int, int],
 ) -> npt.NDArray[np.uint8]:
-    """
-    Overlay `overlay` onto `image` at `anchor`, clipping to scene bounds.
+    """Overlay `overlay` onto `image` at `anchor`, clipping to scene bounds.
 
     Non-deprecated internal implementation backing the public `overlay_image`.
     Kept separate so library-internal callers do not emit a deprecation warning.
@@ -651,8 +650,7 @@ def get_image_resolution_wh(image: ImageType) -> tuple[int, int]:
 
 
 class ImageSink:
-    """
-    Save sequential images into a directory through a context manager.
+    """Save sequential images into a directory through a context manager.
 
     `ImageSink` creates the target directory on entry and writes each image using
     `save_image`, incrementing the image name pattern after every save.
@@ -710,8 +708,7 @@ class ImageSink:
     def save_image(
         self, image: npt.NDArray[np.uint8], image_name: str | None = None
     ) -> None:
-        """
-        Save image to target directory with optional custom filename.
+        """Save image to target directory with optional custom filename.
 
         Args:
             image: Image to save with shape `(height, width, 3)`
@@ -764,8 +761,7 @@ def create_tiles(
     titles_background_color: tuple[int, int, int] | Color = Color.from_hex("#D9D9D9"),
     default_title_placement: RelativePosition = "top",
 ) -> ImageType:
-    """
-    Creates tiles mosaic from input images, automating grid placement and converting
+    """Creates tiles mosaic from input images, automating grid placement and converting
     images to common resolution maintaining aspect ratio. It is also possible to render
     text titles on tiles, using optional set of parameters specifying text drawing (see
     parameters description).

--- a/src/supervision/utils/image.py
+++ b/src/supervision/utils/image.py
@@ -81,8 +81,7 @@ def load_image_from_url(
     cache_dir: str | Path | None = None,
     force_reload: bool = False,
 ) -> npt.NDArray[np.uint8]:
-    """
-    Load an image from a URL as an OpenCV image.
+    """Load an image from a URL as an OpenCV image.
 
     Args:
         value: HTTP(S) URL of the image.
@@ -153,8 +152,7 @@ def crop_image(
     image: ImageType,
     xyxy: npt.NDArray[np.number] | list[int] | tuple[int, int, int, int],
 ) -> ImageType:
-    """
-    Crop image based on bounding box coordinates.
+    """Crop image based on bounding box coordinates.
 
     Args:
         image: The image to crop.
@@ -223,8 +221,7 @@ def crop_image(
 
 @ensure_cv2_image_for_standalone_function
 def scale_image(image: ImageType, scale_factor: float) -> ImageType:
-    """
-    Scale image by given factor. Scale factor > 1.0 zooms in, < 1.0 zooms out.
+    """Scale image by given factor. Scale factor > 1.0 zooms in, < 1.0 zooms out.
 
     Args:
         image: The image to scale.
@@ -281,8 +278,7 @@ def resize_image(
     resolution_wh: tuple[int, int],
     keep_aspect_ratio: bool = False,
 ) -> ImageType:
-    """
-    Resize image to specified resolution. Can optionally maintain aspect ratio.
+    """Resize image to specified resolution. Can optionally maintain aspect ratio.
 
     Args:
         image: The image to resize.
@@ -350,9 +346,8 @@ def letterbox_image(
     resolution_wh: tuple[int, int],
     color: tuple[int, int, int] | Color = Color.BLACK,
 ) -> ImageType:
-    """
-    Resize image and pad with color to achieve desired resolution while
-    maintaining aspect ratio.
+    """Resize image and pad with color to achieve desired resolution while maintaining
+    aspect ratio.
 
     Args:
         image: The image to resize and pad. Accepts BGR arrays of shape
@@ -428,9 +423,8 @@ def overlay_image(
     overlay: npt.NDArray[np.uint8],
     anchor: tuple[int, int],
 ) -> npt.NDArray[np.uint8]:
-    """
-    Deprecated since 0.27.0; removal in 0.31.0. Use `_overlay_image` for
-    internal callers, or avoid calling `overlay_image` directly in external code.
+    """Deprecated since 0.27.0; removal in 0.31.0. Use `_overlay_image` for internal
+    callers, or avoid calling `overlay_image` directly in external code.
 
     Overlay image onto scene at specified anchor point. Handles cases where
     overlay position is partially or completely outside scene bounds.
@@ -528,8 +522,7 @@ def tint_image(
     color: Color = Color.BLACK,
     opacity: float = 0.5,
 ) -> ImageType:
-    """
-    Tint image with solid color overlay at specified opacity.
+    """Tint image with solid color overlay at specified opacity.
 
     Args:
         image: The image to tint.
@@ -572,9 +565,8 @@ def tint_image(
 
 @ensure_cv2_image_for_standalone_function
 def grayscale_image(image: ImageType) -> ImageType:
-    """
-    Convert image to 3-channel grayscale. Luminance channel is broadcast to
-    all three channels for compatibility with color-based drawing helpers.
+    """Convert image to 3-channel grayscale. Luminance channel is broadcast to all three
+    channels for compatibility with color-based drawing helpers.
 
     Args:
         image: The image to convert to
@@ -603,8 +595,8 @@ def grayscale_image(image: ImageType) -> ImageType:
 
 
 def get_image_resolution_wh(image: ImageType) -> tuple[int, int]:
-    """
-    Get image width and height as a tuple `(width, height)` for various image formats.
+    """Get image width and height as a tuple `(width, height)` for various image
+    formats.
 
     Supports both `numpy.ndarray` images (with shape `(H, W, ...)`) and
     `PIL.Image.Image` inputs.
@@ -662,8 +654,7 @@ class ImageSink:
         overwrite: bool = False,
         image_name_pattern: str = "image_{:05d}.png",
     ) -> None:
-        """
-        Initialize context manager for saving images to directory.
+        """Initialize context manager for saving images to directory.
 
         Args:
             target_dir_path: Target directory path where images will be

--- a/src/supervision/utils/image_window.py
+++ b/src/supervision/utils/image_window.py
@@ -89,7 +89,8 @@ class ImageWindow:
         self._display_offset_y: float = 0.0
 
     def show(self, image: npt.NDArray[np.uint8]) -> None:
-        """Display a BGR, grayscale, or BGRA frame in the window.
+        """
+        Display a BGR, grayscale, or BGRA frame in the window.
 
         The image is scaled to fit the current window dimensions. Aspect ratio is
         preserved unless `keep_aspect_ratio=False`. Resizing the window rescales live.
@@ -116,7 +117,8 @@ class ImageWindow:
         self._root.update()
 
     def wait_key(self, delay_ms: int = 0) -> str | None:
-        """Wait for a keypress and return its name.
+        """
+        Wait for a keypress and return its name.
 
         Args:
             delay_ms: How long to wait in milliseconds. ``0`` blocks until a
@@ -144,7 +146,8 @@ class ImageWindow:
         return self._key_queue.pop(0) if self._key_queue else None
 
     def set_mouse_callback(self, callback: MouseCallback | None) -> None:
-        """Register a callback for mouse events on the image.
+        """
+        Register a callback for mouse events on the image.
 
         Args:
             callback: Callable receiving ``(x, y, event_type)`` where
@@ -213,13 +216,14 @@ class ImageWindow:
         self._label.configure(image=self._photo)
 
     def _update_display_transform(self, fitted: Image.Image) -> None:
-        """Record the scale and letterbox offset from the last display pass.
+        """
+        Record the scale and letterbox offset from the last display pass.
 
-        The fitted image is drawn centered inside the label, so mouse events on
-        the label carry display-space coordinates. Storing the per-axis scale
-        and centering offset lets `_on_mouse` invert the transform back to
-        original image-pixel coordinates. Falls back to an identity transform
-        while the window geometry is still unknown.
+        The fitted image is drawn centered inside the label, so mouse events on the
+        label carry display-space coordinates. Storing the per-axis scale and centering
+        offset lets `_on_mouse` invert the transform back to original image-pixel
+        coordinates. Falls back to an identity transform while the window geometry is
+        still unknown.
         """
         if self._pil_image is None:
             return
@@ -243,13 +247,14 @@ class ImageWindow:
         self._mouse_callback(x, y, event_type)
 
     def _to_image_coords(self, event_x: int, event_y: int) -> tuple[int, int]:
-        """Map label-space event coordinates to original image pixels.
+        """
+        Map label-space event coordinates to original image pixels.
 
-        Inverts the scale and letterbox offset recorded by `_update_display`
-        so callbacks receive coordinates in the source image's pixel space,
-        regardless of how the window has been resized. Results are rounded to
-        the nearest pixel and clamped inside the image bounds. When no image
-        has been shown, the raw event coordinates are returned unchanged.
+        Inverts the scale and letterbox offset recorded by `_update_display` so
+        callbacks receive coordinates in the source image's pixel space, regardless of
+        how the window has been resized. Results are rounded to the nearest pixel and
+        clamped inside the image bounds. When no image has been shown, the raw event
+        coordinates are returned unchanged.
         """
         if self._pil_image is None:
             return event_x, event_y
@@ -314,10 +319,10 @@ def _fit_image(
 
 
 def _bgr_to_pil(image: npt.NDArray[np.uint8]) -> Image.Image:
-    """Convert a BGR, grayscale, or BGRA OpenCV array to a Pillow image.
+    """
+    Convert a BGR, grayscale, or BGRA OpenCV array to a Pillow image.
 
-    Thin wrapper delegating to `sv.cv2_to_pillow`, which reorders channels
-    from OpenCV's BGR(A) convention to Pillow's RGB(A) and passes grayscale
-    arrays through unchanged.
+    Thin wrapper delegating to `sv.cv2_to_pillow`, which reorders channels from OpenCV's
+    BGR(A) convention to Pillow's RGB(A) and passes grayscale arrays through unchanged.
     """
     return cv2_to_pillow(image)

--- a/src/supervision/utils/image_window.py
+++ b/src/supervision/utils/image_window.py
@@ -89,8 +89,7 @@ class ImageWindow:
         self._display_offset_y: float = 0.0
 
     def show(self, image: npt.NDArray[np.uint8]) -> None:
-        """
-        Display a BGR, grayscale, or BGRA frame in the window.
+        """Display a BGR, grayscale, or BGRA frame in the window.
 
         The image is scaled to fit the current window dimensions. Aspect ratio is
         preserved unless `keep_aspect_ratio=False`. Resizing the window rescales live.
@@ -117,8 +116,7 @@ class ImageWindow:
         self._root.update()
 
     def wait_key(self, delay_ms: int = 0) -> str | None:
-        """
-        Wait for a keypress and return its name.
+        """Wait for a keypress and return its name.
 
         Args:
             delay_ms: How long to wait in milliseconds. ``0`` blocks until a
@@ -146,8 +144,7 @@ class ImageWindow:
         return self._key_queue.pop(0) if self._key_queue else None
 
     def set_mouse_callback(self, callback: MouseCallback | None) -> None:
-        """
-        Register a callback for mouse events on the image.
+        """Register a callback for mouse events on the image.
 
         Args:
             callback: Callable receiving ``(x, y, event_type)`` where
@@ -216,8 +213,7 @@ class ImageWindow:
         self._label.configure(image=self._photo)
 
     def _update_display_transform(self, fitted: Image.Image) -> None:
-        """
-        Record the scale and letterbox offset from the last display pass.
+        """Record the scale and letterbox offset from the last display pass.
 
         The fitted image is drawn centered inside the label, so mouse events on the
         label carry display-space coordinates. Storing the per-axis scale and centering
@@ -247,8 +243,7 @@ class ImageWindow:
         self._mouse_callback(x, y, event_type)
 
     def _to_image_coords(self, event_x: int, event_y: int) -> tuple[int, int]:
-        """
-        Map label-space event coordinates to original image pixels.
+        """Map label-space event coordinates to original image pixels.
 
         Inverts the scale and letterbox offset recorded by `_update_display` so
         callbacks receive coordinates in the source image's pixel space, regardless of
@@ -319,8 +314,7 @@ def _fit_image(
 
 
 def _bgr_to_pil(image: npt.NDArray[np.uint8]) -> Image.Image:
-    """
-    Convert a BGR, grayscale, or BGRA OpenCV array to a Pillow image.
+    """Convert a BGR, grayscale, or BGRA OpenCV array to a Pillow image.
 
     Thin wrapper delegating to `sv.cv2_to_pillow`, which reorders channels from OpenCV's
     BGR(A) convention to Pillow's RGB(A) and passes grayscale arrays through unchanged.

--- a/src/supervision/utils/internal.py
+++ b/src/supervision/utils/internal.py
@@ -131,8 +131,8 @@ T = TypeVar("T")
 class classproperty(Generic[T]):
     """A decorator that combines @classmethod and @property.
 
-    It allows a method to be accessed as a property of the class, rather than an instance, similar to a
-    classmethod.
+    It allows a method to be accessed as a property of the class, rather than an
+    instance, similar to a classmethod.
 
     Usage:
         @classproperty

--- a/src/supervision/utils/internal.py
+++ b/src/supervision/utils/internal.py
@@ -57,8 +57,7 @@ def deprecated_parameter(
     "deprecated: use '{new_parameter}' instead.",
     **message_kwargs: Any,
 ) -> Callable[[Any], Any]:
-    """
-    A decorator to mark a function's parameter as deprecated and issue a warning when
+    """A decorator to mark a function's parameter as deprecated and issue a warning when
     used.
 
     Args:
@@ -165,8 +164,7 @@ class classproperty(Generic[T]):
 
 
 def get_instance_variables(instance: Any, include_properties: bool = False) -> set[str]:
-    """
-    Get the public variables of a class instance.
+    """Get the public variables of a class instance.
 
     Args:
         instance: The instance of a class

--- a/src/supervision/utils/internal.py
+++ b/src/supervision/utils/internal.py
@@ -7,11 +7,13 @@ from typing import Any, Generic, TypeVar
 
 
 class SupervisionWarnings(Warning):
-    """Supervision warning category.
-    Set the deprecation warnings visibility for Supervision library.
-    You can set the environment variable SUPERVISION_DEPRECATION_WARNING to '0'
-    to disable the deprecation warnings. The legacy misspelled
-    SUPERVISON_DEPRECATION_WARNING variable is still accepted.
+    """
+    Supervision warning category.
+
+    Set the deprecation warnings visibility for Supervision library. You can set the
+    environment variable SUPERVISION_DEPRECATION_WARNING to '0' to disable the
+    deprecation warnings. The legacy misspelled SUPERVISON_DEPRECATION_WARNING variable
+    is still accepted.
     """
 
     pass
@@ -24,8 +26,7 @@ def format_warning(
     lineno: int,
     line: str | None = None,
 ) -> str:
-    """
-    Format a warning the same way as the default formatter, but also include the
+    """Format a warning the same way as the default formatter, but also include the
     category name in the output.
     """
     return f"{category.__name__}: {message}\n"
@@ -133,9 +134,9 @@ T = TypeVar("T")
 
 class classproperty(Generic[T]):
     """
-    A decorator that combines @classmethod and @property.
-    It allows a method to be accessed as a property of the class,
-    rather than an instance, similar to a classmethod.
+    A decorator that combines @classmethod and @property. It allows a method to be
+    accessed as a property of the class, rather than an instance, similar to a
+    classmethod.
 
     Usage:
         @classproperty

--- a/src/supervision/utils/internal.py
+++ b/src/supervision/utils/internal.py
@@ -7,8 +7,7 @@ from typing import Any, Generic, TypeVar
 
 
 class SupervisionWarnings(Warning):
-    """
-    Supervision warning category.
+    """Supervision warning category.
 
     Set the deprecation warnings visibility for Supervision library. You can set the
     environment variable SUPERVISION_DEPRECATION_WARNING to '0' to disable the
@@ -27,8 +26,7 @@ def format_warning(
     line: str | None = None,
 ) -> str:
     """Format a warning the same way as the default formatter, but also include the
-    category name in the output.
-    """
+    category name in the output."""
     return f"{category.__name__}: {message}\n"
 
 
@@ -43,8 +41,7 @@ else:
 
 
 def warn_deprecated(message: str) -> None:
-    """
-    Issue a warning that a function is deprecated.
+    """Issue a warning that a function is deprecated.
 
     Args:
         message: The message to display when the function is called.
@@ -133,9 +130,9 @@ T = TypeVar("T")
 
 
 class classproperty(Generic[T]):
-    """
-    A decorator that combines @classmethod and @property. It allows a method to be
-    accessed as a property of the class, rather than an instance, similar to a
+    """A decorator that combines @classmethod and @property.
+
+    It allows a method to be accessed as a property of the class, rather than an instance, similar to a
     classmethod.
 
     Usage:
@@ -152,8 +149,7 @@ class classproperty(Generic[T]):
         self.fget = fget
 
     def __get__(self, owner_self: Any, owner_cls: type | None = None) -> T:
-        """
-        Override the __get__ method to return the result of the function call.
+        """Override the __get__ method to return the result of the function call.
 
         Args:
             owner_self: The instance through which the attribute was accessed, or None.

--- a/src/supervision/utils/iterables.py
+++ b/src/supervision/utils/iterables.py
@@ -8,9 +8,8 @@ def create_batches(
     sequence: Iterable[V], batch_size: int
 ) -> Generator[list[V], None, None]:
     """
-    Provides a generator that yields chunks of the input sequence
-    of the size specified by the `batch_size` parameter. The last
-    chunk may be a smaller batch.
+    Provides a generator that yields chunks of the input sequence of the size specified
+    by the `batch_size` parameter. The last chunk may be a smaller batch.
 
     Args:
         sequence: The sequence to be split into batches.
@@ -44,8 +43,7 @@ def create_batches(
 
 def fill(sequence: list[V], desired_size: int, content: V) -> list[V]:
     """
-    Fill the sequence with padding elements until the sequence reaches
-    the desired size.
+    Fill the sequence with padding elements until the sequence reaches the desired size.
 
     Args:
         sequence: The input sequence.

--- a/src/supervision/utils/iterables.py
+++ b/src/supervision/utils/iterables.py
@@ -7,9 +7,8 @@ V = TypeVar("V")
 def create_batches(
     sequence: Iterable[V], batch_size: int
 ) -> Generator[list[V], None, None]:
-    """
-    Provides a generator that yields chunks of the input sequence of the size specified
-    by the `batch_size` parameter. The last chunk may be a smaller batch.
+    """Provides a generator that yields chunks of the input sequence of the size
+    specified by the `batch_size` parameter. The last chunk may be a smaller batch.
 
     Args:
         sequence: The sequence to be split into batches.
@@ -42,8 +41,8 @@ def create_batches(
 
 
 def fill(sequence: list[V], desired_size: int, content: V) -> list[V]:
-    """
-    Fill the sequence with padding elements until the sequence reaches the desired size.
+    """Fill the sequence with padding elements until the sequence reaches the desired
+    size.
 
     Args:
         sequence: The input sequence.
@@ -72,8 +71,7 @@ def fill(sequence: list[V], desired_size: int, content: V) -> list[V]:
 
 
 def find_duplicates(sequence: list[V]) -> list[V]:
-    """
-    Find all duplicate elements in the input sequence.
+    """Find all duplicate elements in the input sequence.
 
     Args:
         sequence: The input sequence.

--- a/src/supervision/utils/notebook.py
+++ b/src/supervision/utils/notebook.py
@@ -10,8 +10,7 @@ from supervision.utils.conversion import pillow_to_cv2
 def plot_image(
     image: ImageType, size: tuple[int, int] = (12, 12), cmap: str | None = "gray"
 ) -> None:
-    """
-    Plots image using matplotlib.
+    """Plots image using matplotlib.
 
     Args:
         image: The frame to be displayed ImageType
@@ -57,8 +56,7 @@ def plot_images_grid(
     size: tuple[int, int] = (12, 12),
     cmap: str | None = "gray",
 ) -> None:
-    """
-    Plots images in a grid using matplotlib.
+    """Plots images in a grid using matplotlib.
 
     Args:
        images: A list of images as ImageType

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -578,9 +578,7 @@ def process_video(
 
 
 class FPSMonitor:
-    """
-    A class for monitoring frames per second (FPS) to benchmark latency.
-    """
+    """A class for monitoring frames per second (FPS) to benchmark latency."""
 
     def __init__(self, sample_size: int = 30) -> None:
         """
@@ -620,13 +618,9 @@ class FPSMonitor:
         return frame_intervals / taken_time if taken_time != 0 else 0.0
 
     def tick(self) -> None:
-        """
-        Adds a new time stamp to the deque for FPS calculation.
-        """
+        """Adds a new time stamp to the deque for FPS calculation."""
         self.all_timestamps.append(time.monotonic())
 
     def reset(self) -> None:
-        """
-        Clears all the time stamps from the deque.
-        """
+        """Clears all the time stamps from the deque."""
         self.all_timestamps.clear()

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -143,8 +143,7 @@ class VideoSink:
         return self
 
     def write_frame(self, frame: npt.NDArray[np.uint8]) -> None:
-        """
-        Writes a single video frame to the target video file.
+        """Writes a single video frame to the target video file.
 
         Args:
             frame: The video frame to be written to the file. The frame
@@ -604,8 +603,7 @@ class FPSMonitor:
 
     @property
     def fps(self) -> float:
-        """
-        Computes and returns the average FPS based on the stored time stamps.
+        """Computes and returns the average FPS based on the stored time stamps.
 
         Returns:
             The average FPS across the recorded intervals. Returns 0.0 if fewer

--- a/src/supervision/utils/video.py
+++ b/src/supervision/utils/video.py
@@ -22,9 +22,8 @@ logger = _get_logger(__name__)
 
 @dataclass
 class VideoInfo:
-    """
-    A class to store video information, including width, height, fps and
-        total number of frames.
+    """A class to store video information, including width, height, fps and total number
+    of frames.
 
     Attributes:
         width: width of the video in pixels
@@ -88,8 +87,7 @@ class VideoInfo:
 
 
 class VideoSink:
-    """
-    Context manager that saves video frames to a file using OpenCV.
+    """Context manager that saves video frames to a file using OpenCV.
 
     Attributes:
         target_path: The path to the output file where the video will be saved.
@@ -198,8 +196,7 @@ def get_video_frames_generator(
     iterative_seek: bool = False,
     prefetch: int = 0,
 ) -> Generator[npt.NDArray[np.uint8], None, None]:
-    """
-    Get a generator that yields the frames of the video.
+    """Get a generator that yields the frames of the video.
 
     Args:
         source_path: The path of the video file.
@@ -385,8 +382,7 @@ def process_video(
     progress_message: str = "Processing video",
     preserve_audio: bool = False,
 ) -> None:
-    """
-    Process video frames asynchronously using a threaded pipeline.
+    """Process video frames asynchronously using a threaded pipeline.
 
     This function orchestrates a three-stage pipeline to optimize video processing
     throughput:

--- a/tests/annotators/test_core.py
+++ b/tests/annotators/test_core.py
@@ -1,6 +1,4 @@
-"""
-Tests for supervision/annotators/core.py
-"""
+"""Tests for supervision/annotators/core.py."""
 
 import warnings
 from collections.abc import Iterator
@@ -113,13 +111,13 @@ class TestAnnotatorMaskPolicy:
 
 @pytest.fixture
 def test_image() -> np.ndarray:
-    """Create a simple blank test image fixture"""
+    """Create a simple blank test image fixture."""
     return np.zeros((100, 100, 3), dtype=np.uint8)
 
 
 @pytest.fixture
 def test_mask() -> np.ndarray:
-    """Create a simple rectangular mask fixture"""
+    """Create a simple rectangular mask fixture."""
     mask = np.zeros((100, 100), dtype=bool)
     mask[20:80, 20:80] = True
     return mask
@@ -127,7 +125,7 @@ def test_mask() -> np.ndarray:
 
 @pytest.fixture
 def gradient_image() -> np.ndarray:
-    """Create a gradient test image fixture"""
+    """Create a gradient test image fixture."""
     image = np.zeros((100, 100, 3), dtype=np.uint8)
     for i in range(100):
         for j in range(100):
@@ -183,16 +181,14 @@ def test_hex_color_support_across_annotators(
 
 
 class TestBoxAnnotator:
-    """
-    Verify that BoxAnnotator correctly draws bounding boxes on an image.
+    """Verify that BoxAnnotator correctly draws bounding boxes on an image.
 
     Ensures that `BoxAnnotator` correctly draws bounding boxes on an image, which is
     essential for users to visualize detection results.
     """
 
     def test_annotate_with_no_detections(self, test_image: np.ndarray) -> None:
-        """
-        Verify that annotation with no detections does not change the image.
+        """Verify that annotation with no detections does not change the image.
 
         Scenario: Annotating an image with an empty set of detections.
         Expected: The scene remains unchanged, ensuring no ghost boxes are drawn.
@@ -203,8 +199,7 @@ class TestBoxAnnotator:
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image: np.ndarray) -> None:
-        """
-        Verify that annotation with a single detection draws a bounding box.
+        """Verify that annotation with a single detection draws a bounding box.
 
         Scenario: Annotating an image with a single bounding box.
         Expected: The scene is modified by drawing a box, allowing users to identify
@@ -218,8 +213,7 @@ class TestBoxAnnotator:
         assert_image_mostly_same(test_image, result, similarity_threshold=0.85)
 
     def test_annotate_with_multiple_detections(self, test_image: np.ndarray) -> None:
-        """
-        Verify that annotation with multiple detections draws all bounding boxes.
+        """Verify that annotation with multiple detections draws all bounding boxes.
 
         Scenario: Annotating an image with multiple bounding boxes of different classes.
         Expected: All boxes are drawn, enabling visualization of complex scenes with
@@ -236,8 +230,7 @@ class TestBoxAnnotator:
         assert_image_mostly_same(test_image, result, similarity_threshold=0.85)
 
     def test_annotate_with_numpy_color_lookup(self, test_image: np.ndarray) -> None:
-        """
-        Verify that annotation respects custom NumPy color lookup array.
+        """Verify that annotation respects custom NumPy color lookup array.
 
         Scenario: Providing a custom NumPy array for color lookup instead of class IDs.
         Expected: Annotator respects the custom mapping, giving users flexible control
@@ -265,17 +258,17 @@ class TestBoxAnnotator:
 
 
 class TestOrientedBoxAnnotator:
-    """Tests for OrientedBoxAnnotator class"""
+    """Tests for OrientedBoxAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = OrientedBoxAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_without_oriented_boxes(self, test_image):
-        """Test that annotate method returns unmodified image when no OBB data"""
+        """Test that annotate method returns unmodified image when no OBB data."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]])
         annotator = OrientedBoxAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
@@ -283,24 +276,24 @@ class TestOrientedBoxAnnotator:
 
 
 class TestMaskAnnotator:
-    """Tests for MaskAnnotator class"""
+    """Tests for MaskAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = MaskAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_without_masks(self, test_image):
-        """Test that annotate method returns unmodified image when no masks"""
+        """Test that annotate method returns unmodified image when no masks."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = MaskAnnotator(color_lookup=ColorLookup.INDEX)
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_mask(self, test_image, test_mask):
-        """Test that annotate method correctly draws a single mask"""
+        """Test that annotate method correctly draws a single mask."""
         detections = _create_detections(
             xyxy=[[10, 10, 90, 90]], mask=[test_mask], class_id=[0]
         )
@@ -476,24 +469,24 @@ class TestMaskAnnotator:
 
 
 class TestPolygonAnnotator:
-    """Tests for PolygonAnnotator class"""
+    """Tests for PolygonAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = PolygonAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_without_masks(self, test_image):
-        """Test that annotate method returns unmodified image when no masks"""
+        """Test that annotate method returns unmodified image when no masks."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = PolygonAnnotator(color_lookup=ColorLookup.INDEX)
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_mask(self, test_image, test_mask):
-        """Test that annotate method correctly draws a single polygon from mask"""
+        """Test that annotate method correctly draws a single polygon from mask."""
         detections = _create_detections(
             xyxy=[[10, 10, 90, 90]], mask=[test_mask], class_id=[0]
         )
@@ -562,8 +555,8 @@ class TestPolygonAnnotator:
     def test_annotate_with_all_false_compact_mask_unchanged(self):
         """All-False CompactMask crop (no contours) leaves scene pixels unchanged.
 
-        A detection whose mask is entirely False produces no polygons; the
-        annotator must not paint any pixels for that detection.
+        A detection whose mask is entirely False produces no polygons; the annotator
+        must not paint any pixels for that detection.
         """
         height, width = 60, 80
         scene = np.zeros((height, width, 3), dtype=np.uint8)
@@ -601,8 +594,8 @@ class TestPolygonAnnotator:
     def test_annotate_compact_mask_float_xyxy_truncation(self):
         """Float xyxy with sub-pixel values are truncated to int before crop decode.
 
-        CompactMask stores bbox origins as int32 (via truncation); PolygonAnnotator
-        must produce the same output whether xyxy is integral or has fractional parts.
+        CompactMask stores bbox origins as int32 (via truncation); PolygonAnnotator must
+        produce the same output whether xyxy is integral or has fractional parts.
         """
         height, width = 60, 80
         scene = np.zeros((height, width, 3), dtype=np.uint8)
@@ -630,9 +623,9 @@ class TestPolygonAnnotator:
     def test_compact_mask_disjoint_contours_offset_correct(self):
         """Disjoint-contour mask: both polygon blobs translate to correct image coords.
 
-        Verifies coordinate-level correctness of crop→image offset for a mask
-        with two separate blobs. After annotation, boundary pixels of each blob
-        must be painted; pixels between the blobs must remain unpainted.
+        Verifies coordinate-level correctness of crop→image offset for a mask with two
+        separate blobs. After annotation, boundary pixels of each blob must be painted;
+        pixels between the blobs must remain unpainted.
         """
         height, width = 80, 90
         scene = np.zeros((height, width, 3), dtype=np.uint8)
@@ -659,17 +652,17 @@ class TestPolygonAnnotator:
 
 
 class TestColorAnnotator:
-    """Tests for ColorAnnotator class"""
+    """Tests for ColorAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = ColorAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws a single color box"""
+        """Test that annotate method correctly draws a single color box."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = ColorAnnotator(
             color=Color.RED, opacity=1.0, color_lookup=ColorLookup.INDEX
@@ -679,24 +672,24 @@ class TestColorAnnotator:
 
 
 class TestHaloAnnotator:
-    """Tests for HaloAnnotator class"""
+    """Tests for HaloAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = HaloAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_without_masks(self, test_image):
-        """Test that annotate method returns unmodified image when no masks"""
+        """Test that annotate method returns unmodified image when no masks."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = HaloAnnotator(color_lookup=ColorLookup.INDEX)
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_mask(self, test_image, test_mask):
-        """Test that annotate method correctly draws a single halo"""
+        """Test that annotate method correctly draws a single halo."""
         detections = _create_detections(
             xyxy=[[10, 10, 90, 90]], mask=[test_mask], class_id=[0]
         )
@@ -802,9 +795,9 @@ class TestPaintMasksByArea:
     def test_compact_mask_drops_pixels_outside_bbox(self):
         """CompactMask is lossy: True pixels outside xyxy bbox are silently dropped.
 
-        This test documents that compact and dense paths diverge when a mask has
-        True pixels outside its bounding box — the 'bit-identical' claim holds
-        only for bbox-contained masks.
+        This test documents that compact and dense paths diverge when a mask has True
+        pixels outside its bounding box — the 'bit-identical' claim holds only for bbox-
+        contained masks.
         """
         height, width = 50, 60
         mask = np.zeros((height, width), dtype=bool)
@@ -934,7 +927,7 @@ class TestCompactMaskParity:
 
 
 class TestHeatMapAnnotator:
-    """Tests for HeatMapAnnotator class"""
+    """Tests for HeatMapAnnotator class."""
 
     def test_annotate_with_no_detections_does_not_warn(
         self, test_image: np.ndarray
@@ -1003,18 +996,17 @@ class TestHeatMapAnnotator:
         assert region_painted > 100
 
     def test_reset_clears_accumulated_heat(self, test_image: np.ndarray) -> None:
-        """reset() must zero accumulation so a reused annotator matches a fresh one.
+        """Reset() must zero accumulation so a reused annotator matches a fresh one.
 
-        The heatmap colours each pixel by its heat *relative to the current
-        maximum*, so a single uniformly-painted region always renders identically
-        regardless of its absolute count. To make the assertion actually depend on
-        reset having zeroed the buffer, heat is first built up on region A alone,
-        then after reset both region A and a fresh region B are annotated together.
-        If reset truly zeroed the buffer, A and B carry equal heat and the frame
-        matches a never-used annotator; if reset were a no-op, A's carried-over
-        count would dominate the max-normalisation and B would render a different
-        hue — so byte-equality with the fresh annotator can only hold when the
-        accumulation was genuinely discarded.
+        The heatmap colours each pixel by its heat *relative to the current maximum*, so
+        a single uniformly-painted region always renders identically regardless of its
+        absolute count. To make the assertion actually depend on reset having zeroed the
+        buffer, heat is first built up on region A alone, then after reset both region A
+        and a fresh region B are annotated together. If reset truly zeroed the buffer, A
+        and B carry equal heat and the frame matches a never-used annotator; if reset
+        were a no-op, A's carried-over count would dominate the max-normalisation and B
+        would render a different hue — so byte-equality with the fresh annotator can
+        only hold when the accumulation was genuinely discarded.
         """
         region_a = _create_detections(xyxy=[[10, 10, 30, 30]])
         region_a_and_b = _create_detections(xyxy=[[10, 10, 30, 30], [60, 60, 90, 90]])
@@ -1035,17 +1027,17 @@ class TestHeatMapAnnotator:
 
 
 class TestEllipseAnnotator:
-    """Tests for EllipseAnnotator class"""
+    """Tests for EllipseAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = EllipseAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws a single ellipse"""
+        """Test that annotate method correctly draws a single ellipse."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = EllipseAnnotator(
             color=Color.YELLOW, thickness=2, color_lookup=ColorLookup.INDEX
@@ -1055,17 +1047,17 @@ class TestEllipseAnnotator:
 
 
 class TestBoxCornerAnnotator:
-    """Tests for BoxCornerAnnotator class"""
+    """Tests for BoxCornerAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = BoxCornerAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws box corners"""
+        """Test that annotate method correctly draws box corners."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = BoxCornerAnnotator(
             color=Color.WHITE,
@@ -1078,17 +1070,17 @@ class TestBoxCornerAnnotator:
 
 
 class TestCircleAnnotator:
-    """Tests for CircleAnnotator class"""
+    """Tests for CircleAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = CircleAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws a circle"""
+        """Test that annotate method correctly draws a circle."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = CircleAnnotator(
             color=Color.GREEN, thickness=2, color_lookup=ColorLookup.INDEX
@@ -1098,17 +1090,17 @@ class TestCircleAnnotator:
 
 
 class TestDotAnnotator:
-    """Tests for DotAnnotator class"""
+    """Tests for DotAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = DotAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws a dot"""
+        """Test that annotate method correctly draws a dot."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = DotAnnotator(
             color=Color.RED,
@@ -1121,7 +1113,7 @@ class TestDotAnnotator:
 
 
 class TestLabelAnnotator:
-    """Tests for LabelAnnotator class"""
+    """Tests for LabelAnnotator class."""
 
     @pytest.mark.parametrize(
         "border_radius",
@@ -1135,8 +1127,8 @@ class TestLabelAnnotator:
     ) -> None:
         """Non-positive radius fills the same pixels as a plain rectangle.
 
-        For border_radius < 0: previously raised cv2.error: radius >= 0 in
-        function 'circle'; fast path now silently draws square corners instead.
+        For border_radius < 0: previously raised cv2.error: radius >= 0 in function
+        'circle'; fast path now silently draws square corners instead.
         """
         scene = np.full((100, 120, 3), 9, dtype=np.uint8)
 
@@ -1171,14 +1163,14 @@ class TestLabelAnnotator:
         assert np.array_equal(result, expected)
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = LabelAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws a label"""
+        """Test that annotate method correctly draws a label."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = LabelAnnotator(color_lookup=ColorLookup.INDEX)
         result = annotator.annotate(
@@ -1217,17 +1209,17 @@ class TestLabelAnnotator:
 
 
 class TestRichLabelAnnotator:
-    """Tests for RichLabelAnnotator class"""
+    """Tests for RichLabelAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = RichLabelAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws a rich label"""
+        """Test that annotate method correctly draws a rich label."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = RichLabelAnnotator(color_lookup=ColorLookup.INDEX)
         result = annotator.annotate(
@@ -1270,17 +1262,17 @@ class TestRichLabelAnnotator:
 
 
 class TestBlurAnnotator:
-    """Tests for BlurAnnotator class"""
+    """Tests for BlurAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = BlurAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, gradient_image):
-        """Test that annotate method correctly blurs a region"""
+        """Test that annotate method correctly blurs a region."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = BlurAnnotator(kernel_size=15)
         result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
@@ -1301,17 +1293,17 @@ class TestBlurAnnotator:
 
 
 class TestPixelateAnnotator:
-    """Tests for PixelateAnnotator class"""
+    """Tests for PixelateAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = PixelateAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, gradient_image):
-        """Test that annotate method correctly pixelates a region"""
+        """Test that annotate method correctly pixelates a region."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = PixelateAnnotator(pixel_size=10)
         result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
@@ -1334,8 +1326,8 @@ class TestPixelateAnnotator:
     def test_annotate_grayscale_image_does_not_raise(self):
         """PixelateAnnotator must work on single-channel (grayscale) images.
 
-        The small-ROI avg-fill branch previously sliced cv2.mean()[:3] into a
-        2-D array, causing a NumPy broadcast error on grayscale frames.
+        The small-ROI avg-fill branch previously sliced cv2.mean()[:3] into a 2-D array,
+        causing a NumPy broadcast error on grayscale frames.
         """
         gray = np.random.randint(0, 255, (100, 100), dtype=np.uint8)
         # Normal-size detection — exercises the resize path on a grayscale frame
@@ -1370,17 +1362,17 @@ class TestPixelateAnnotator:
 
 
 class TestTriangleAnnotator:
-    """Tests for TriangleAnnotator class"""
+    """Tests for TriangleAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = TriangleAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws a triangle"""
+        """Test that annotate method correctly draws a triangle."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = TriangleAnnotator(
             color=Color.RED, base=20, height=20, color_lookup=ColorLookup.INDEX
@@ -1390,17 +1382,17 @@ class TestTriangleAnnotator:
 
 
 class TestRoundBoxAnnotator:
-    """Tests for RoundBoxAnnotator class"""
+    """Tests for RoundBoxAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = RoundBoxAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws a round box"""
+        """Test that annotate method correctly draws a round box."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = RoundBoxAnnotator(
             color=Color.BLUE, thickness=2, roundness=0.5, color_lookup=ColorLookup.INDEX
@@ -1410,17 +1402,17 @@ class TestRoundBoxAnnotator:
 
 
 class TestPercentageBarAnnotator:
-    """Tests for PercentageBarAnnotator class"""
+    """Tests for PercentageBarAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = PercentageBarAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, test_image):
-        """Test that annotate method correctly draws a percentage bar"""
+        """Test that annotate method correctly draws a percentage bar."""
         detections = _create_detections(
             xyxy=[[10, 10, 90, 90]], confidence=[0.75], class_id=[0]
         )
@@ -1456,17 +1448,17 @@ class TestPositionHelpers:
 
 
 class TestCropAnnotator:
-    """Tests for CropAnnotator class"""
+    """Tests for CropAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = CropAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self, gradient_image):
-        """Test that annotate method correctly draws a crop"""
+        """Test that annotate method correctly draws a crop."""
         detections = _create_detections(xyxy=[[10, 10, 90, 90]], class_id=[0])
         annotator = CropAnnotator(border_color_lookup=ColorLookup.INDEX)
         result = annotator.annotate(scene=gradient_image.copy(), detections=detections)
@@ -1516,7 +1508,7 @@ class TestCropAnnotator:
     def test_annotate_with_box_crossing_scene_border(
         self, gradient_image, xyxy: list[int]
     ) -> None:
-        """Boxes extending past the scene border are clipped instead of raising"""
+        """Boxes extending past the scene border are clipped instead of raising."""
         detections = _create_detections(xyxy=[xyxy], class_id=[0])
         annotator = CropAnnotator()
 
@@ -1536,7 +1528,7 @@ class TestCropAnnotator:
     def test_annotate_skips_boxes_empty_after_clipping(
         self, gradient_image, xyxy: list[int]
     ) -> None:
-        """Boxes with no visible area are skipped instead of raising cv2.error"""
+        """Boxes with no visible area are skipped instead of raising cv2.error."""
         detections = _create_detections(xyxy=[xyxy], class_id=[0])
         annotator = CropAnnotator()
 
@@ -1545,7 +1537,7 @@ class TestCropAnnotator:
         assert np.array_equal(gradient_image, result)
 
     def test_annotate_mixed_valid_and_degenerate_boxes(self, gradient_image) -> None:
-        """A degenerate box does not prevent valid boxes from being drawn"""
+        """A degenerate box does not prevent valid boxes from being drawn."""
         detections = _create_detections(
             xyxy=[[150, 150, 200, 200], [10, 10, 90, 90]], class_id=[0, 1]
         )
@@ -1558,9 +1550,9 @@ class TestCropAnnotator:
     def test_annotate_overlapping_crops_sample_from_original_scene(self) -> None:
         """Later crops must sample the original un-annotated scene.
 
-        box1 is pasted into the region that box2 crops from. Without the
-        source_scene = scene.copy() fix, box2 reads box1's paste value
-        instead of the original pixel — the aliasing regression.
+        box1 is pasted into the region that box2 crops from. Without the source_scene =
+        scene.copy() fix, box2 reads box1's paste value instead of the original pixel —
+        the aliasing regression.
         """
         # Arrange: two distinct pixel bands; box1's paste region overlaps box2's crop
         scene = np.full((80, 80, 3), 50, dtype=np.uint8)
@@ -1594,7 +1586,7 @@ class TestCropAnnotator:
 
 
 class TestIconAnnotator:
-    """Tests for IconAnnotator class"""
+    """Tests for IconAnnotator class."""
 
     def test_annotate_emits_no_deprecation_warning(self, test_image, tmp_path):
         """Internal overlay must not surface the deprecated `overlay_image` warning."""
@@ -1642,17 +1634,17 @@ class TestIconAnnotator:
 
 
 class TestBackgroundOverlayAnnotator:
-    """Tests for BackgroundOverlayAnnotator class"""
+    """Tests for BackgroundOverlayAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections = Detections.empty()
         annotator = BackgroundOverlayAnnotator()
         result = annotator.annotate(scene=test_image.copy(), detections=detections)
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection(self):
-        """Test that annotate method correctly draws background overlay"""
+        """Test that annotate method correctly draws background overlay."""
         image = np.ones((100, 100, 3), dtype=np.uint8) * 255
         detections = _create_detections(xyxy=[[10, 10, 90, 90]])
         annotator = BackgroundOverlayAnnotator(color=Color.BLACK, opacity=0.5)
@@ -1672,7 +1664,7 @@ class TestBackgroundOverlayAnnotator:
     def test_annotate_preserves_detection_crossing_scene_border(
         self, xyxy: list[int], inside_xy: tuple[int, int], outside_xy: tuple[int, int]
     ) -> None:
-        """The visible part of a box crossing the border keeps original pixels"""
+        """The visible part of a box crossing the border keeps original pixels."""
         image = np.full((100, 100, 3), 200, dtype=np.uint8)
         detections = _create_detections(xyxy=[xyxy])
         annotator = BackgroundOverlayAnnotator(color=Color.BLACK, opacity=0.5)
@@ -1685,7 +1677,8 @@ class TestBackgroundOverlayAnnotator:
         assert np.array_equal(result[y_out, x_out], np.array([100, 100, 100]))
 
     def test_annotate_fully_out_negative_box_does_not_corrupt(self) -> None:
-        """Both-negative OOB box must not restore an in-bounds region via wrap-around"""
+        """Both-negative OOB box must not restore an in-bounds region via wrap-
+        around."""
         image = np.full((100, 100, 3), 200, dtype=np.uint8)
         detections = _create_detections(xyxy=[[-30, -30, -5, -5]])
         annotator = BackgroundOverlayAnnotator(color=Color.BLACK, opacity=0.5)
@@ -1695,7 +1688,7 @@ class TestBackgroundOverlayAnnotator:
         assert np.array_equal(result[80, 80], np.array([100, 100, 100]))
 
     def test_annotate_force_box_preserves_detection_crossing_scene_border(self):
-        """force_box with a border-crossing box keeps the visible detection region"""
+        """force_box with a border-crossing box keeps the visible detection region."""
         image = np.full((100, 100, 3), 200, dtype=np.uint8)
         mask = np.zeros((100, 100), dtype=bool)
         mask[20:60, 0:40] = True
@@ -1710,7 +1703,7 @@ class TestBackgroundOverlayAnnotator:
         assert np.array_equal(result[80, 60], np.array([100, 100, 100]))
 
     def test_annotate_with_fully_out_of_bounds_detection(self):
-        """A box fully outside the scene leaves the whole scene tinted"""
+        """A box fully outside the scene leaves the whole scene tinted."""
         image = np.full((100, 100, 3), 200, dtype=np.uint8)
         detections = _create_detections(xyxy=[[150, 150, 200, 200]])
         annotator = BackgroundOverlayAnnotator(color=Color.BLACK, opacity=0.5)
@@ -1738,10 +1731,10 @@ class TestBackgroundOverlayAnnotator:
 
 
 class TestComparisonAnnotator:
-    """Tests for ComparisonAnnotator class"""
+    """Tests for ComparisonAnnotator class."""
 
     def test_annotate_with_no_detections(self, test_image):
-        """Test that annotate method returns unmodified image when no detections"""
+        """Test that annotate method returns unmodified image when no detections."""
         detections1 = Detections.empty()
         detections2 = Detections.empty()
         annotator = ComparisonAnnotator()
@@ -1751,7 +1744,7 @@ class TestComparisonAnnotator:
         assert np.array_equal(test_image, result)
 
     def test_annotate_with_single_detection_each(self):
-        """Test that annotate method correctly compares two detections"""
+        """Test that annotate method correctly compares two detections."""
         image = np.ones((100, 100, 3), dtype=np.uint8) * 255
         detections1 = _create_detections(xyxy=[[10, 10, 50, 50]])
         detections2 = _create_detections(xyxy=[[30, 30, 70, 70]])
@@ -1766,7 +1759,7 @@ class TestTraceAnnotatorReset:
     """Tests for TraceAnnotator.reset() clearing accumulated trace history."""
 
     def test_reset_empties_trace_buffers(self, test_image: np.ndarray) -> None:
-        """reset() must clear the underlying Trace buffers to their empty state."""
+        """Reset() must clear the underlying Trace buffers to their empty state."""
         annotator = TraceAnnotator(trace_length=10)
         detections = _create_detections(
             xyxy=[[10, 10, 30, 30]], class_id=[1], tracker_id=[7]
@@ -1783,14 +1776,13 @@ class TestTraceAnnotatorReset:
     def test_reset_matches_fresh_annotator(self, test_image: np.ndarray) -> None:
         """After reset() a reused annotator must render identically to a fresh one.
 
-        The two streams reuse the same ``tracker_id`` but follow spatially
-        distinct paths. If reset were a no-op, ``Trace.get`` would return the
-        first stream's points concatenated with the second's and draw a spurious
-        polyline bridging the two paths; only a genuine reset leaves solely the
-        second stream's points, so byte-equality with a never-used annotator can
-        hold only when the prior history was actually discarded. ``trace_length``
-        is large enough that no windowing prunes away the stale points that a
-        broken reset would leave behind.
+        The two streams reuse the same ``tracker_id`` but follow spatially distinct
+        paths. If reset were a no-op, ``Trace.get`` would return the first stream's
+        points concatenated with the second's and draw a spurious polyline bridging the
+        two paths; only a genuine reset leaves solely the second stream's points, so
+        byte-equality with a never-used annotator can hold only when the prior history
+        was actually discarded. ``trace_length`` is large enough that no windowing
+        prunes away the stale points that a broken reset would leave behind.
         """
         first_stream = [
             _create_detections(
@@ -1829,11 +1821,11 @@ class TestTraceAnnotatorSmoothStationary:
     """Regression tests for TraceAnnotator(smooth=True) on stationary tracker ids."""
 
     def test_stationary_tracker_does_not_crash_spline_fit(self, test_image):
-        """
-        When the same tracker stays at an identical anchor point for several
-        frames the trace buffer accumulates duplicate points. `scipy.splprep`
-        rejects a zero-length input curve with `ValueError: Invalid inputs.`,
-        so the annotator must survive this input without raising.
+        """When the same tracker stays at an identical anchor point for several frames
+        the trace buffer accumulates duplicate points.
+
+        `scipy.splprep` rejects a zero-length input curve with `ValueError: Invalid
+        inputs.`, so the annotator must survive this input without raising.
         """
         detections = _create_detections(
             xyxy=[[100, 100, 120, 120]],
@@ -1849,9 +1841,9 @@ class TestTraceAnnotatorSmoothStationary:
     def test_smooth_trace_still_renders_for_moving_tracker(self, test_image):
         """Moving tracker must produce a spline trace distinct from the raw polyline.
 
-        Compares smooth=True output against smooth=False for the same movement
-        path to confirm the smoothing path is actually exercised (not just that
-        some pixels changed).
+        Compares smooth=True output against smooth=False for the same movement path to
+        confirm the smoothing path is actually exercised (not just that some pixels
+        changed).
         """
         smooth_annotator = TraceAnnotator(smooth=True, trace_length=10, thickness=2)
         raw_annotator = TraceAnnotator(smooth=False, trace_length=10, thickness=2)
@@ -1880,10 +1872,10 @@ class TestTraceAnnotatorSmoothStationary:
     def test_smooth_does_not_crash_for_unique_point_counts(
         self, test_image, unique_positions
     ):
-        """smooth=True must not crash for any unique-position count from 1 to 4.
+        """Smooth=True must not crash for any unique-position count from 1 to 4.
 
-        Each position is repeated twice to simulate brief holds between moves.
-        Covers the boundary at len(unique_xy) == 4 where splprep first fires.
+        Each position is repeated twice to simulate brief holds between moves. Covers
+        the boundary at len(unique_xy) == 4 where splprep first fires.
         """
         annotator = TraceAnnotator(smooth=True, trace_length=10, thickness=2)
         scene = test_image.copy()
@@ -1929,8 +1921,8 @@ class TestTraceAnnotatorSmoothStationary:
     def test_smooth_true_single_frame_does_not_crash(self, test_image):
         """A single annotate() call with smooth=True must not crash.
 
-        When len(xy) == 1 the drawing guard skips cv2.polylines entirely;
-        the dedup path runs safely on an empty np.diff result.
+        When len(xy) == 1 the drawing guard skips cv2.polylines entirely; the dedup path
+        runs safely on an empty np.diff result.
         """
         detections = _create_detections(
             xyxy=[[50, 50, 70, 70]],
@@ -1942,7 +1934,7 @@ class TestTraceAnnotatorSmoothStationary:
         assert scene.shape == test_image.shape
 
     def test_smooth_false_stationary_tracker_does_not_crash(self, test_image):
-        """smooth=False with a stationary tracker must not crash (regression guard).
+        """Smooth=False with a stationary tracker must not crash (regression guard).
 
         Ensures the refactor did not accidentally alter the smooth=False code path.
         """
@@ -2014,9 +2006,9 @@ class TestTraceAnnotatorEmptyDetections:
     ) -> None:
         """`CENTER_OF_MASS` must not demand a mask from an empty batch.
 
-        `Position.CENTER_OF_MASS` normally requires a detection mask, but an
-        empty frame carries no anchors to compute, so `annotate` must not
-        raise even though `TraceAnnotator` was configured for that anchor.
+        `Position.CENTER_OF_MASS` normally requires a detection mask, but an empty frame
+        carries no anchors to compute, so `annotate` must not raise even though
+        `TraceAnnotator` was configured for that anchor.
         """
         annotator = TraceAnnotator(position=Position.CENTER_OF_MASS)
 

--- a/tests/annotators/test_docs.py
+++ b/tests/annotators/test_docs.py
@@ -88,9 +88,9 @@ def _extract_annotator_tab_groups() -> dict[str, list[str]]:
 def test_all_expected_annotators_have_tab_entries() -> None:
     """Assert every annotator in EXPECTED_ANNOTATOR_TAB_GROUPS has a tab in the docs.
 
-    Tests flat membership only — does not enforce which category each annotator
-    belongs to. Update EXPECTED_ANNOTATOR_TAB_GROUPS when adding or removing
-    annotator tab entries.
+    Tests flat membership only — does not enforce which category each annotator belongs
+    to. Update EXPECTED_ANNOTATOR_TAB_GROUPS when adding or removing annotator tab
+    entries.
     """
     tab_groups = _extract_annotator_tab_groups()
     actual_tabs = {tab for group in tab_groups.values() for tab in group}

--- a/tests/annotators/test_utils.py
+++ b/tests/annotators/test_utils.py
@@ -377,7 +377,7 @@ class TestGetLabelsText:
         assert get_labels_text(detections, custom) is custom
 
     def test_uses_class_name_data_field_with_non_str_dtype(self) -> None:
-        """str() coercion is load-bearing when class_name holds a non-str dtype."""
+        """Str() coercion is load-bearing when class_name holds a non-str dtype."""
         detections = _create_detections(
             xyxy=[[0, 0, 1, 1], [1, 1, 2, 2]],
             class_id=[0, 1],
@@ -479,9 +479,9 @@ class TestTraceEmptyFrames:
     def test_center_of_mass_anchor_accepts_an_empty_first_frame(self) -> None:
         """An empty batch never reaches the mask-requiring anchor lookup.
 
-        `Position.CENTER_OF_MASS` normally demands a detection mask, but an
-        empty batch is short-circuited before `get_anchors_coordinates` is
-        called, so it must not raise even though it carries no mask.
+        `Position.CENTER_OF_MASS` normally demands a detection mask, but an empty batch
+        is short-circuited before `get_anchors_coordinates` is called, so it must not
+        raise even though it carries no mask.
         """
         trace = Trace(anchor=Position.CENTER_OF_MASS)
 
@@ -514,8 +514,8 @@ class TestTraceEmptyFrames:
     ) -> None:
         """A populated, maskless batch still raises for `CENTER_OF_MASS`.
 
-        The empty-batch short-circuit must not swallow the mask requirement
-        for frames that actually carry detections.
+        The empty-batch short-circuit must not swallow the mask requirement for frames
+        that actually carry detections.
         """
         trace = Trace(anchor=Position.CENTER_OF_MASS)
         trace.put(Detections.empty())

--- a/tests/cv2/test_integration.py
+++ b/tests/cv2/test_integration.py
@@ -42,8 +42,7 @@ def _blocked_cv2_environment(tmp_path: Path) -> dict[str, str]:
     """Create a subprocess environment that rejects every cv2 import."""
     blocker = tmp_path / "sitecustomize.py"
     blocker.write_text(
-        """
-        Import sys.
+        """Import sys.
 
         class BlockCv2:
             def find_spec(self, fullname, path=None, target=None):
@@ -54,7 +53,7 @@ def _blocked_cv2_environment(tmp_path: Path) -> dict[str, str]:
 
         sys.meta_path.insert(0, BlockCv2())
         """
-   ,
+           ,
         encoding="utf-8",
     )
     environment = os.environ.copy()

--- a/tests/cv2/test_integration.py
+++ b/tests/cv2/test_integration.py
@@ -52,8 +52,7 @@ def _blocked_cv2_environment(tmp_path: Path) -> dict[str, str]:
 
 
         sys.meta_path.insert(0, BlockCv2())
-        """
-           ,
+        """,
         encoding="utf-8",
     )
     environment = os.environ.copy()

--- a/tests/cv2/test_integration.py
+++ b/tests/cv2/test_integration.py
@@ -42,17 +42,18 @@ def _blocked_cv2_environment(tmp_path: Path) -> dict[str, str]:
     """Create a subprocess environment that rejects every cv2 import."""
     blocker = tmp_path / "sitecustomize.py"
     blocker.write_text(
-        """Import sys.
-
-        class BlockCv2:
-            def find_spec(self, fullname, path=None, target=None):
-                if fullname == "cv2":
-                    raise ModuleNotFoundError("blocked for integration test")
-                return None
-
-
-        sys.meta_path.insert(0, BlockCv2())
-        """,
+        (
+            "import sys\n"
+            "\n"
+            "class BlockCv2:\n"
+            "    def find_spec(self, fullname, path=None, target=None):\n"
+            '        if fullname == "cv2":\n'
+            '            raise ModuleNotFoundError("blocked for integration test")\n'
+            "        return None\n"
+            "\n"
+            "\n"
+            "sys.meta_path.insert(0, BlockCv2())\n"
+        ),
         encoding="utf-8",
     )
     environment = os.environ.copy()

--- a/tests/cv2/test_integration.py
+++ b/tests/cv2/test_integration.py
@@ -42,18 +42,19 @@ def _blocked_cv2_environment(tmp_path: Path) -> dict[str, str]:
     """Create a subprocess environment that rejects every cv2 import."""
     blocker = tmp_path / "sitecustomize.py"
     blocker.write_text(
-        """import sys
+        """
+        Import sys.
+
+        class BlockCv2:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "cv2":
+                    raise ModuleNotFoundError("blocked for integration test")
+                return None
 
 
-class BlockCv2:
-    def find_spec(self, fullname, path=None, target=None):
-        if fullname == "cv2":
-            raise ModuleNotFoundError("blocked for integration test")
-        return None
-
-
-sys.meta_path.insert(0, BlockCv2())
-""",
+        sys.meta_path.insert(0, BlockCv2())
+        """
+   ,
         encoding="utf-8",
     )
     environment = os.environ.copy()

--- a/tests/cv2/test_text.py
+++ b/tests/cv2/test_text.py
@@ -143,7 +143,8 @@ class TestPutText:
         assert rows.max() <= org[1] + baseline
 
     def test_reported_baseline_encloses_thick_stroke_descent(self) -> None:
-        """Keep the baseline padding matching the stroke_width putText renders.
+        """
+        Keep the baseline padding matching the stroke_width putText renders.
 
         A thickness of 7 (stroke_width 6) is past the point where the old
         ``thickness // 2`` baseline formula under-padded relative to the

--- a/tests/cv2/test_text.py
+++ b/tests/cv2/test_text.py
@@ -143,8 +143,7 @@ class TestPutText:
         assert rows.max() <= org[1] + baseline
 
     def test_reported_baseline_encloses_thick_stroke_descent(self) -> None:
-        """
-        Keep the baseline padding matching the stroke_width putText renders.
+        """Keep the baseline padding matching the stroke_width putText renders.
 
         A thickness of 7 (stroke_width 6) is past the point where the old
         ``thickness // 2`` baseline formula under-padded relative to the

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1851,8 +1851,7 @@ def test_coco_round_trip_preserves_class_ids_and_writes_one_indexed_categories(
     tmp_path,
 ) -> None:
     """as_coco -> from_coco is lossless for internal class_ids while the on-disk COCO
-    category ids are 1-indexed (regression for #1181).
-    """
+    category ids are 1-indexed (regression for #1181)."""
     classes = ["cat", "dog"]
     image_paths: list[str] = []
     annotations: dict[str, Detections] = {}
@@ -1898,8 +1897,7 @@ def test_coco_round_trip_preserves_class_ids_and_writes_one_indexed_categories(
 def _tiny_detection_dataset(
     tmp_path, prefix: str, num_images: int, dets_per_image: int
 ) -> DetectionDataset:
-    """
-    Build a DetectionDataset of ``num_images`` 10x10 RGB images on disk, each holding
+    """Build a DetectionDataset of ``num_images`` 10x10 RGB images on disk, each holding
     ``dets_per_image`` 1x1 detections of class 0.
 
     Image content is irrelevant; only the per-image Detections drive the COCO write
@@ -1996,8 +1994,7 @@ def test_save_coco_annotations_respects_starting_ids(tmp_path):
 
 def test_as_coco_chains_ids_across_splits_without_collision(tmp_path):
     """Regression for #768: exporting train/valid/test splits with the returned ids fed
-    forward yields globally unique image and annotation ids.
-    """
+    forward yields globally unique image and annotation ids."""
     train = _tiny_detection_dataset(tmp_path, "train", num_images=3, dets_per_image=2)
     valid = _tiny_detection_dataset(tmp_path, "valid", num_images=2, dets_per_image=4)
     test = _tiny_detection_dataset(tmp_path, "test", num_images=1, dets_per_image=5)
@@ -2038,8 +2035,7 @@ def test_as_coco_chains_ids_across_splits_without_collision(tmp_path):
 
 def test_save_coco_annotations_empty_dataset_returns_starting_ids(tmp_path):
     """An empty dataset writes a valid (but empty) COCO file and returns the starting
-    ids unchanged so chaining still composes around it.
-    """
+    ids unchanged so chaining still composes around it."""
     dataset = DetectionDataset(classes=["object"], images=[], annotations={})
     annotation_path = tmp_path / "annotations.json"
 
@@ -2059,8 +2055,7 @@ def test_save_coco_annotations_empty_dataset_returns_starting_ids(tmp_path):
 
 def test_as_coco_without_annotations_path_returns_starting_ids(tmp_path):
     """When only writing images, the starting ids round-trip unchanged so chaining still
-    works in the images-only branch.
-    """
+    works in the images-only branch."""
     dataset = _tiny_detection_dataset(tmp_path, "img", num_images=2, dets_per_image=1)
     next_image_id, next_annotation_id = dataset.as_coco(
         images_directory_path=str(tmp_path / "imgs"),
@@ -2073,8 +2068,7 @@ def test_as_coco_without_annotations_path_returns_starting_ids(tmp_path):
 
 def test_save_coco_annotations_annotation_image_id_references_correct_image(tmp_path):
     """Every annotation's image_id must reference an image id present in the same file,
-    even when a non-default starting_image_id is used.
-    """
+    even when a non-default starting_image_id is used."""
     dataset = _tiny_detection_dataset(tmp_path, "img", num_images=3, dets_per_image=2)
     annotation_path = tmp_path / "annotations.json"
 
@@ -2096,8 +2090,7 @@ def test_save_coco_annotations_annotation_image_id_references_correct_image(tmp_
 
 def test_save_coco_annotations_zero_annotation_images(tmp_path):
     """Dataset with images but zero detections per image: image ids are assigned
-    sequentially but annotation list stays empty.
-    """
+    sequentially but annotation list stays empty."""
     dataset = _tiny_detection_dataset(tmp_path, "img", num_images=2, dets_per_image=0)
     annotation_path = tmp_path / "annotations.json"
 
@@ -2180,8 +2173,7 @@ class TestSaveCocoAnnotationsHeaderSizeReads:
 
 def test_from_coco_loads_legacy_zero_indexed_category_ids(tmp_path) -> None:
     """COCO files with 0-indexed category ids (written by supervision <=0.28.x) must
-    still load and produce correct internal 0-indexed class_ids.
-    """
+    still load and produce correct internal 0-indexed class_ids."""
     images_dir = tmp_path / "images"
     images_dir.mkdir()
     img_path = images_dir / "img.jpg"
@@ -2383,8 +2375,7 @@ def test_coco_polygon_segmentation_survives_roundtrip(
     area: float,
     expected_min_polygon_count: int,
 ) -> None:
-    """
-    COCO polygon segmentation survives the load/export sequence.
+    """COCO polygon segmentation survives the load/export sequence.
 
     1. Write source COCO JSON with polygon segmentation.
     2. Load it through DetectionDataset.from_coco().
@@ -2433,8 +2424,7 @@ def test_coco_polygon_segmentation_survives_roundtrip(
 def test_coco_raw_segmentation_preserved_when_masks_not_decoded() -> None:
     """When masks are NOT decoded (with_masks=False), raw polygon data stored in
     data['segmentation'] is used as a lossless fallback so as_coco() still emits non-
-    empty segmentation.
-    """
+    empty segmentation."""
     image_annotations = [
         _coco_annotation_with_segmentation(segmentation=[[0, 0, 4, 0, 4, 4, 0, 4]])
     ]

--- a/tests/dataset/formats/test_coco.py
+++ b/tests/dataset/formats/test_coco.py
@@ -1211,7 +1211,7 @@ def test_detections_to_coco_annotations_round_trip_disjoint_mask() -> None:
 
 
 def test_detections_to_coco_annotations_preserves_area_from_data() -> None:
-    """area stored in detections.data should be used instead of bbox area."""
+    """Area stored in detections.data should be used instead of bbox area."""
     detections = Detections(
         xyxy=np.array([[10.0, 20.0, 110.0, 120.0]], dtype=np.float32),
         class_id=np.array([0], dtype=int),
@@ -1233,7 +1233,7 @@ def test_detections_to_coco_annotations_preserves_area_from_data() -> None:
 def test_detections_to_coco_annotations_preserves_iscrowd_from_data_when_no_mask() -> (
     None
 ):
-    """iscrowd stored in detections.data should be used when no mask is present."""
+    """Iscrowd stored in detections.data should be used when no mask is present."""
     detections = Detections(
         xyxy=np.array([[0.0, 0.0, 100.0, 100.0]], dtype=np.float32),
         class_id=np.array([0], dtype=int),
@@ -1253,7 +1253,7 @@ def test_detections_to_coco_annotations_preserves_iscrowd_from_data_when_no_mask
 
 
 def test_detections_to_coco_annotations_iscrowd_is_int_when_mask_provided() -> None:
-    """iscrowd should be stored as int (0 or 1), not as Python bool."""
+    """Iscrowd should be stored as int (0 or 1), not as Python bool."""
     mask = np.zeros((1, 5, 5), dtype=bool)
     mask[0, 0:3, 0:3] = True  # simple single-component rectangle
 
@@ -1275,7 +1275,7 @@ def test_detections_to_coco_annotations_iscrowd_is_int_when_mask_provided() -> N
 
 
 def test_detections_to_coco_annotations_data_area_overrides_bbox_with_mask() -> None:
-    """data["area"] should override computed bbox area even when a mask is present."""
+    """Data["area"] should override computed bbox area even when a mask is present."""
     mask = np.zeros((1, 10, 10), dtype=bool)
     mask[0, 0:4, 0:4] = True  # 16-pixel polygon area
 
@@ -1850,8 +1850,9 @@ def test_detections_to_coco_annotations_category_id_is_one_indexed() -> None:
 def test_coco_round_trip_preserves_class_ids_and_writes_one_indexed_categories(
     tmp_path,
 ) -> None:
-    """as_coco -> from_coco is lossless for internal class_ids while the
-    on-disk COCO category ids are 1-indexed (regression for #1181)."""
+    """as_coco -> from_coco is lossless for internal class_ids while the on-disk COCO
+    category ids are 1-indexed (regression for #1181).
+    """
     classes = ["cat", "dog"]
     image_paths: list[str] = []
     annotations: dict[str, Detections] = {}
@@ -1897,9 +1898,13 @@ def test_coco_round_trip_preserves_class_ids_and_writes_one_indexed_categories(
 def _tiny_detection_dataset(
     tmp_path, prefix: str, num_images: int, dets_per_image: int
 ) -> DetectionDataset:
-    """Build a DetectionDataset of ``num_images`` 10x10 RGB images on disk,
-    each holding ``dets_per_image`` 1x1 detections of class 0. Image content
-    is irrelevant; only the per-image Detections drive the COCO write path."""
+    """
+    Build a DetectionDataset of ``num_images`` 10x10 RGB images on disk, each holding
+    ``dets_per_image`` 1x1 detections of class 0.
+
+    Image content is irrelevant; only the per-image Detections drive the COCO write
+    path.
+    """
     classes = ["object"]
     image_paths: list[str] = []
     annotations: dict[str, Detections] = {}
@@ -1990,8 +1995,9 @@ def test_save_coco_annotations_respects_starting_ids(tmp_path):
 
 
 def test_as_coco_chains_ids_across_splits_without_collision(tmp_path):
-    """Regression for #768: exporting train/valid/test splits with the
-    returned ids fed forward yields globally unique image and annotation ids."""
+    """Regression for #768: exporting train/valid/test splits with the returned ids fed
+    forward yields globally unique image and annotation ids.
+    """
     train = _tiny_detection_dataset(tmp_path, "train", num_images=3, dets_per_image=2)
     valid = _tiny_detection_dataset(tmp_path, "valid", num_images=2, dets_per_image=4)
     test = _tiny_detection_dataset(tmp_path, "test", num_images=1, dets_per_image=5)
@@ -2031,8 +2037,9 @@ def test_as_coco_chains_ids_across_splits_without_collision(tmp_path):
 
 
 def test_save_coco_annotations_empty_dataset_returns_starting_ids(tmp_path):
-    """An empty dataset writes a valid (but empty) COCO file and returns
-    the starting ids unchanged so chaining still composes around it."""
+    """An empty dataset writes a valid (but empty) COCO file and returns the starting
+    ids unchanged so chaining still composes around it.
+    """
     dataset = DetectionDataset(classes=["object"], images=[], annotations={})
     annotation_path = tmp_path / "annotations.json"
 
@@ -2051,8 +2058,9 @@ def test_save_coco_annotations_empty_dataset_returns_starting_ids(tmp_path):
 
 
 def test_as_coco_without_annotations_path_returns_starting_ids(tmp_path):
-    """When only writing images, the starting ids round-trip unchanged so
-    chaining still works in the images-only branch."""
+    """When only writing images, the starting ids round-trip unchanged so chaining still
+    works in the images-only branch.
+    """
     dataset = _tiny_detection_dataset(tmp_path, "img", num_images=2, dets_per_image=1)
     next_image_id, next_annotation_id = dataset.as_coco(
         images_directory_path=str(tmp_path / "imgs"),
@@ -2064,8 +2072,9 @@ def test_as_coco_without_annotations_path_returns_starting_ids(tmp_path):
 
 
 def test_save_coco_annotations_annotation_image_id_references_correct_image(tmp_path):
-    """Every annotation's image_id must reference an image id present in the
-    same file, even when a non-default starting_image_id is used."""
+    """Every annotation's image_id must reference an image id present in the same file,
+    even when a non-default starting_image_id is used.
+    """
     dataset = _tiny_detection_dataset(tmp_path, "img", num_images=3, dets_per_image=2)
     annotation_path = tmp_path / "annotations.json"
 
@@ -2086,8 +2095,9 @@ def test_save_coco_annotations_annotation_image_id_references_correct_image(tmp_
 
 
 def test_save_coco_annotations_zero_annotation_images(tmp_path):
-    """Dataset with images but zero detections per image: image ids are
-    assigned sequentially but annotation list stays empty."""
+    """Dataset with images but zero detections per image: image ids are assigned
+    sequentially but annotation list stays empty.
+    """
     dataset = _tiny_detection_dataset(tmp_path, "img", num_images=2, dets_per_image=0)
     annotation_path = tmp_path / "annotations.json"
 
@@ -2169,8 +2179,9 @@ class TestSaveCocoAnnotationsHeaderSizeReads:
 
 
 def test_from_coco_loads_legacy_zero_indexed_category_ids(tmp_path) -> None:
-    """COCO files with 0-indexed category ids (written by supervision <=0.28.x)
-    must still load and produce correct internal 0-indexed class_ids."""
+    """COCO files with 0-indexed category ids (written by supervision <=0.28.x) must
+    still load and produce correct internal 0-indexed class_ids.
+    """
     images_dir = tmp_path / "images"
     images_dir.mkdir()
     img_path = images_dir / "img.jpg"
@@ -2372,7 +2383,8 @@ def test_coco_polygon_segmentation_survives_roundtrip(
     area: float,
     expected_min_polygon_count: int,
 ) -> None:
-    """COCO polygon segmentation survives the load/export sequence.
+    """
+    COCO polygon segmentation survives the load/export sequence.
 
     1. Write source COCO JSON with polygon segmentation.
     2. Load it through DetectionDataset.from_coco().
@@ -2420,8 +2432,9 @@ def test_coco_polygon_segmentation_survives_roundtrip(
 
 def test_coco_raw_segmentation_preserved_when_masks_not_decoded() -> None:
     """When masks are NOT decoded (with_masks=False), raw polygon data stored in
-    data['segmentation'] is used as a lossless fallback so as_coco() still emits
-    non-empty segmentation."""
+    data['segmentation'] is used as a lossless fallback so as_coco() still emits non-
+    empty segmentation.
+    """
     image_annotations = [
         _coco_annotation_with_segmentation(segmentation=[[0, 0, 4, 0, 4, 4, 0, 4]])
     ]

--- a/tests/dataset/formats/test_pascal_voc.py
+++ b/tests/dataset/formats/test_pascal_voc.py
@@ -31,6 +31,8 @@ def are_xml_elements_equal(elem1, elem2) -> bool:
         if not are_xml_elements_equal(child1, child2):
             return False
     return True
+
+
 @pytest.mark.parametrize(
     ("xyxy", "name", "polygon", "expected_result", "exception"),
     [
@@ -111,6 +113,8 @@ def test_detections_to_pascal_voc_does_not_mutate_detections():
     )
     assert np.array_equal(detections.xyxy, expected_xyxy)
     assert first == second
+
+
 @pytest.mark.parametrize(
     ("polygon_element", "expected_result", "exception"),
     [

--- a/tests/dataset/formats/test_pascal_voc.py
+++ b/tests/dataset/formats/test_pascal_voc.py
@@ -40,8 +40,7 @@ def are_xml_elements_equal(elem1, elem2) -> bool:
             None,
             ElementTree.fromstring(
                 """<object><name>test</name><bndbox><xmin>1</xmin><ymin>1</ymin>
-                <xmax>11</xmax><ymax>11</ymax></bndbox></object>
-                """
+                <xmax>11</xmax><ymax>11</ymax></bndbox></object>"""
             ),
             DoesNotRaise(),
             id="bbox_only",
@@ -55,8 +54,7 @@ def are_xml_elements_equal(elem1, elem2) -> bool:
                 <xmax>11</xmax><ymax>11</ymax>
                 </bndbox><polygon><x1>1</x1><y1>1</y1><x2>11</x2>
                 <y2>1</y2><x3>11</x3><y3>11</y3><x4>1</x4><y4>11</y4>
-                </polygon></object>
-                """
+                </polygon></object>"""
             ),
             DoesNotRaise(),
             id="bbox_and_polygon",
@@ -119,8 +117,7 @@ def test_detections_to_pascal_voc_does_not_mutate_detections():
         pytest.param(
             ElementTree.fromstring(
                 """<polygon><x1>0</x1><y1>0</y1><x2>10</x2><y2>0</y2><x3>10</x3>
-                <y3>10</y3><x4>0</x4><y4>10</y4></polygon>
-                """
+                <y3>10</y3><x4>0</x4><y4>10</y4></polygon>"""
             ),
             np.array([[0, 0], [10, 0], [10, 10], [0, 10]]),
             DoesNotRaise(),

--- a/tests/dataset/formats/test_pascal_voc.py
+++ b/tests/dataset/formats/test_pascal_voc.py
@@ -30,10 +30,7 @@ def are_xml_elements_equal(elem1, elem2) -> bool:
     for child1, child2 in zip(elem1, elem2):
         if not are_xml_elements_equal(child1, child2):
             return False
-
     return True
-
-
 @pytest.mark.parametrize(
     ("xyxy", "name", "polygon", "expected_result", "exception"),
     [
@@ -43,7 +40,8 @@ def are_xml_elements_equal(elem1, elem2) -> bool:
             None,
             ElementTree.fromstring(
                 """<object><name>test</name><bndbox><xmin>1</xmin><ymin>1</ymin>
-                <xmax>11</xmax><ymax>11</ymax></bndbox></object>"""
+                <xmax>11</xmax><ymax>11</ymax></bndbox></object>
+                """
             ),
             DoesNotRaise(),
             id="bbox_only",
@@ -57,7 +55,8 @@ def are_xml_elements_equal(elem1, elem2) -> bool:
                 <xmax>11</xmax><ymax>11</ymax>
                 </bndbox><polygon><x1>1</x1><y1>1</y1><x2>11</x2>
                 <y2>1</y2><x3>11</x3><y3>11</y3><x4>1</x4><y4>11</y4>
-                </polygon></object>"""
+                </polygon></object>
+                """
             ),
             DoesNotRaise(),
             id="bbox_and_polygon",
@@ -112,18 +111,16 @@ def test_detections_to_pascal_voc_does_not_mutate_detections():
     second = detections_to_pascal_voc(
         detections, classes=["test"], filename="image.jpg", image_shape=(100, 100, 3)
     )
-
     assert np.array_equal(detections.xyxy, expected_xyxy)
     assert first == second
-
-
 @pytest.mark.parametrize(
     ("polygon_element", "expected_result", "exception"),
     [
         pytest.param(
             ElementTree.fromstring(
                 """<polygon><x1>0</x1><y1>0</y1><x2>10</x2><y2>0</y2><x3>10</x3>
-                    <y3>10</y3><x4>0</x4><y4>10</y4></polygon>"""
+                <y3>10</y3><x4>0</x4><y4>10</y4></polygon>
+                """
             ),
             np.array([[0, 0], [10, 0], [10, 10], [0, 10]]),
             DoesNotRaise(),

--- a/tests/dataset/formats/test_yolo.py
+++ b/tests/dataset/formats/test_yolo.py
@@ -442,8 +442,8 @@ def test_load_yolo_annotations_accepts_pil_readable_image_modes(
 def test_polygons_to_masks_multiple_polygons_shape() -> None:
     """Regression test for #1746: _polygons_to_masks must return shape (N, H, W).
 
-    The original PR rewrite processed only a single polygon and always returned
-    shape (1, H, W), breaking multi-polygon detections.
+    The original PR rewrite processed only a single polygon and always returned shape
+    (1, H, W), breaking multi-polygon detections.
     """
     from supervision.dataset.formats.yolo import _polygons_to_masks
 

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -190,8 +190,7 @@ def test_dataset_merge(
     expected_result: DetectionDataset | None,
     exception: Exception,
 ) -> None:
-    """
-    Verify that multiple DetectionDataset objects can be successfully merged.
+    """Verify that multiple DetectionDataset objects can be successfully merged.
 
     Ensures that multiple `DetectionDataset` objects can be merged into single dataset.
     This is vital for users who need to combine data from different sources or augment

--- a/tests/dataset/test_core.py
+++ b/tests/dataset/test_core.py
@@ -194,8 +194,8 @@ def test_dataset_merge(
     Verify that multiple DetectionDataset objects can be successfully merged.
 
     Ensures that multiple `DetectionDataset` objects can be merged into single dataset.
-    This is vital for users who need to combine data from different sources or
-    augment their datasets with additional labeled examples.
+    This is vital for users who need to combine data from different sources or augment
+    their datasets with additional labeled examples.
     """
     with exception:
         result = DetectionDataset.merge(dataset_list=dataset_list)

--- a/tests/dataset/test_utils.py
+++ b/tests/dataset/test_utils.py
@@ -259,14 +259,14 @@ class TestTrainTestSplitRngIsolation:
     """Regression tests for train_test_split RNG isolation (DAT-02)."""
 
     def test_does_not_mutate_input_list(self) -> None:
-        """split() must not reorder the caller's list in place."""
+        """Split() must not reorder the caller's list in place."""
         data = list(range(10))
         original = data.copy()
         train_test_split(data=data, train_ratio=0.5, random_state=42, shuffle=True)
         assert data == original
 
     def test_does_not_pollute_global_rng(self) -> None:
-        """split() must not disturb the process-global random state."""
+        """Split() must not disturb the process-global random state."""
         state_before = random.getstate()
         train_test_split(
             data=list(range(10)), train_ratio=0.5, random_state=42, shuffle=True

--- a/tests/detection/test_compact_mask.py
+++ b/tests/detection/test_compact_mask.py
@@ -1383,10 +1383,10 @@ class TestRleSplitCols:
     def test_join_true_true_junction_no_zero_run(self) -> None:
         """_rle_join_cols merges True/True boundary; no zero-length False run inserted.
 
-        When column A ends True and column B starts True (leading False count = 0),
-        the junction must produce a single merged True run, not a zero-length False
-        run between two True runs.  A zero-length run would inflate len(rle) and
-        misroute density-based dispatch in _resize_crop.
+        When column A ends True and column B starts True (leading False count = 0), the
+        junction must produce a single merged True run, not a zero-length False run
+        between two True runs.  A zero-length run would inflate len(rle) and misroute
+        density-based dispatch in _resize_crop.
         """
         from supervision.detection.compact_mask import _rle_join_cols
 

--- a/tests/detection/test_compact_mask.py
+++ b/tests/detection/test_compact_mask.py
@@ -33,12 +33,12 @@ def _make_cm(masks: np.ndarray, image_shape: tuple[int, int]) -> CompactMask:
 
 
 class TestRleHelpers:
-    """Tests for _mask_to_rle_counts, _rle_counts_to_mask, and _rle_area.
+    """
+    Tests for _mask_to_rle_counts, _rle_counts_to_mask, and _rle_area.
 
-    Verifies that the private RLE encoding round-trips correctly for a range
-    of mask shapes (all-False, all-True, diagonal, L-shape, checkerboard,
-    single-pixel, and empty), and that _rle_area matches np.sum on the
-    original boolean array.
+    Verifies that the private RLE encoding round-trips correctly for a range of mask
+    shapes (all-False, all-True, diagonal, L-shape, checkerboard, single-pixel, and
+    empty), and that _rle_area matches np.sum on the original boolean array.
     """
 
     @pytest.mark.parametrize(
@@ -145,11 +145,12 @@ class TestRleHelpers:
 
 
 class TestFromDenseToDense:
-    """Tests for CompactMask.from_dense and to_dense.
+    """
+    Tests for CompactMask.from_dense and to_dense.
 
-    Verifies that the from_dense → to_dense round-trip is lossless when the
-    bounding boxes span the full image (no True pixels fall outside the crop).
-    Covers N=0 (empty), N=1 (single mask), and N=5 (several random masks).
+    Verifies that the from_dense → to_dense round-trip is lossless when the bounding
+    boxes span the full image (no True pixels fall outside the crop). Covers N=0
+    (empty), N=1 (single mask), and N=5 (several random masks).
     """
 
     @pytest.mark.parametrize(
@@ -437,7 +438,7 @@ class TestCocoRleCountsToArray:
         ],
     )
     def test_str_and_bytes_decode_identically(self, counts: object) -> None:
-        """str and bytes inputs decode to the same run-length array."""
+        """Str and bytes inputs decode to the same run-length array."""
         from supervision.detection.compact_mask import _coco_rle_counts_to_array
 
         result = _coco_rle_counts_to_array(counts)
@@ -501,7 +502,8 @@ class TestRleTrimColRuns:
 
 
 class TestGetItem:
-    """Tests for CompactMask.__getitem__.
+    """
+    Tests for CompactMask.__getitem__.
 
     Covers four indexing modes:
     - Integer index → dense (H, W) np.ndarray with correct shape and dtype.
@@ -580,27 +582,28 @@ class TestGetItem:
 
 
 class TestProperties:
-    """Tests for len, shape, dtype, and area properties.
+    """
+    Tests for len, shape, dtype, and area properties.
 
-    Verifies that the shape tuple follows the (N, H, W) dense convention,
-    dtype is always bool, and area returns per-mask True-pixel counts that
-    match np.sum on the corresponding dense masks.
+    Verifies that the shape tuple follows the (N, H, W) dense convention, dtype is
+    always bool, and area returns per-mask True-pixel counts that match np.sum on the
+    corresponding dense masks.
     """
 
     def test_len(self) -> None:
-        """len() returns the number of masks in the collection."""
+        """Len() returns the number of masks in the collection."""
         masks = np.zeros((3, 10, 10), dtype=bool)
         cm = _make_cm(masks, (10, 10))
         assert len(cm) == 3
 
     def test_shape(self) -> None:
-        """shape follows the (N, H, W) dense array convention."""
+        """Shape follows the (N, H, W) dense array convention."""
         masks = np.zeros((3, 10, 10), dtype=bool)
         cm = _make_cm(masks, (10, 10))
         assert cm.shape == (3, 10, 10)
 
     def test_shape_empty(self) -> None:
-        """shape reports N=0 for an empty CompactMask while keeping (H, W)."""
+        """Shape reports N=0 for an empty CompactMask while keeping (H, W)."""
         cm = CompactMask(
             [],
             np.empty((0, 2), dtype=np.int32),
@@ -610,12 +613,12 @@ class TestProperties:
         assert cm.shape == (0, 480, 640)
 
     def test_dtype(self) -> None:
-        """dtype is always bool regardless of the input mask dtype."""
+        """Dtype is always bool regardless of the input mask dtype."""
         cm = _make_cm(np.zeros((1, 5, 5), dtype=bool), (5, 5))
         assert cm.dtype == np.dtype(bool)
 
     def test_area_matches_dense(self) -> None:
-        """area returns per-mask True-pixel counts matching np.sum on dense masks."""
+        """Area returns per-mask True-pixel counts matching np.sum on dense masks."""
         img_h, img_w = 20, 20
         rng = np.random.default_rng(3)
         masks = rng.integers(0, 2, size=(4, img_h, img_w)).astype(bool)
@@ -625,7 +628,7 @@ class TestProperties:
         np.testing.assert_array_equal(cm.area, expected)
 
     def test_area_empty(self) -> None:
-        """area is an empty (0,) array for an empty CompactMask."""
+        """Area is an empty (0,) array for an empty CompactMask."""
         cm = CompactMask(
             [],
             np.empty((0, 2), dtype=np.int32),
@@ -636,11 +639,11 @@ class TestProperties:
 
 
 class TestCrop:
-    """Tests for CompactMask.crop.
+    """
+    Tests for CompactMask.crop.
 
-    Verifies that crop(index) returns an array shaped (crop_h, crop_w)
-    containing only the pixels within the bounding box, without allocating
-    the full (H, W) image.
+    Verifies that crop(index) returns an array shaped (crop_h, crop_w) containing only
+    the pixels within the bounding box, without allocating the full (H, W) image.
     """
 
     def test_returns_crop_shape(self) -> None:
@@ -656,10 +659,11 @@ class TestCrop:
 
 
 class TestArrayProtocol:
-    """Tests for the __array__ protocol.
+    """
+    Tests for the __array__ protocol.
 
-    Verifies that np.asarray(cm) materialises the full (N, H, W) dense array
-    and that optional dtype casting (e.g. to uint8) is correctly applied.
+    Verifies that np.asarray(cm) materialises the full (N, H, W) dense array and that
+    optional dtype casting (e.g. to uint8) is correctly applied.
     """
 
     def test_array_protocol(self) -> None:
@@ -681,12 +685,13 @@ class TestArrayProtocol:
 
 
 class TestMerge:
-    """Tests for CompactMask.merge.
+    """
+    Tests for CompactMask.merge.
 
-    Verifies that multiple CompactMask instances with the same image_shape
-    can be concatenated into a single CompactMask, that merging with an empty
-    instance works, that an empty input list raises ValueError, and that
-    mismatched image shapes raise ValueError.
+    Verifies that multiple CompactMask instances with the same image_shape can be
+    concatenated into a single CompactMask, that merging with an empty instance works,
+    that an empty input list raises ValueError, and that mismatched image shapes raise
+    ValueError.
     """
 
     def test_merge(self) -> None:
@@ -739,10 +744,11 @@ class TestMerge:
 
 
 class TestEquality:
-    """Tests for CompactMask.__eq__.
+    """
+    Tests for CompactMask.__eq__.
 
-    Verifies element-wise equality between two CompactMask instances and
-    between a CompactMask and an equivalent dense (N, H, W) boolean array.
+    Verifies element-wise equality between two CompactMask instances and between a
+    CompactMask and an equivalent dense (N, H, W) boolean array.
     """
 
     def test_eq_identical(self) -> None:
@@ -769,7 +775,8 @@ class TestEquality:
 
 
 class TestEdgeCases:
-    """Tests for boundary conditions and unusual inputs.
+    """
+    Tests for boundary conditions and unusual inputs.
 
     Covers: zero-area bounding box (x1 == x2), masks that reach the image
     edge, xyxy values beyond image dimensions (clamped silently), empty
@@ -794,7 +801,7 @@ class TestEdgeCases:
         np.testing.assert_array_equal(cm.to_dense(), masks)
 
     def test_xyxy_beyond_image_clipped(self) -> None:
-        """xyxy values beyond the image boundary should be clipped silently."""
+        """Xyxy values beyond the image boundary should be clipped silently."""
         img_h, img_w = 10, 10
         masks = np.zeros((1, img_h, img_w), dtype=bool)
         masks[0, 5:10, 5:10] = True
@@ -869,7 +876,7 @@ class TestEdgeCases:
         np.testing.assert_array_equal(cm_shifted.to_dense(), expected)
 
     def test_repack_tightens_loose_bbox(self) -> None:
-        """repack() shrinks the crop to the minimal True-pixel rectangle."""
+        """Repack() shrinks the crop to the minimal True-pixel rectangle."""
         img_h, img_w = 20, 20
         masks = np.zeros((1, img_h, img_w), dtype=bool)
         masks[0, 5:10, 6:12] = True  # True block at (5,6)-(9,11)
@@ -890,7 +897,7 @@ class TestEdgeCases:
         np.testing.assert_array_equal(repacked.to_dense(), masks)
 
     def test_repack_preserves_all_false_mask(self) -> None:
-        """repack() normalises an all-False mask to a 1x1 crop."""
+        """Repack() normalises an all-False mask to a 1x1 crop."""
         img_h, img_w = 10, 10
         masks = np.zeros((2, img_h, img_w), dtype=bool)
         masks[1, 3:6, 3:6] = True  # only mask 1 is non-empty
@@ -904,7 +911,7 @@ class TestEdgeCases:
         np.testing.assert_array_equal(repacked.to_dense(), masks)
 
     def test_repack_empty_collection(self) -> None:
-        """repack() on an empty CompactMask returns another empty CompactMask."""
+        """Repack() on an empty CompactMask returns another empty CompactMask."""
         cm = CompactMask(
             [],
             np.empty((0, 2), dtype=np.int32),
@@ -916,7 +923,7 @@ class TestEdgeCases:
         assert repacked._image_shape == (10, 10)
 
     def test_repack_already_tight(self) -> None:
-        """repack() is a no-op when bboxes are already tight."""
+        """Repack() is a no-op when bboxes are already tight."""
         img_h, img_w = 15, 15
         masks = np.zeros((1, img_h, img_w), dtype=bool)
         masks[0, 4:9, 3:8] = True
@@ -932,10 +939,11 @@ class TestEdgeCases:
 
 
 class TestCalculateMasksCentroidsCompact:
-    """Verify calculate_masks_centroids gives identical results for CompactMask.
+    """
+    Verify calculate_masks_centroids gives identical results for CompactMask.
 
-    The function has a dedicated CompactMask branch that computes centroids
-    per-crop.  Results must match the dense path to within integer rounding.
+    The function has a dedicated CompactMask branch that computes centroids per-crop.
+    Results must match the dense path to within integer rounding.
     """
 
     def test_centroids_compact_matches_dense(self) -> None:
@@ -990,11 +998,12 @@ class TestCalculateMasksCentroidsCompact:
 
 
 class TestContainsHolesCompact:
-    """Verify contains_holes result is unchanged after CompactMask roundtrip.
+    """
+    Verify contains_holes result is unchanged after CompactMask roundtrip.
 
-    contains_holes works on a 2D boolean mask.  Encoding then decoding via
-    CompactMask must preserve pixel topology so that the function returns
-    the same result as on the original array.
+    contains_holes works on a 2D boolean mask.  Encoding then decoding via CompactMask
+    must preserve pixel topology so that the function returns the same result as on the
+    original array.
     """
 
     @pytest.mark.parametrize(
@@ -1036,10 +1045,11 @@ class TestContainsHolesCompact:
 
 
 class TestContainsMultipleSegmentsCompact:
-    """Verify contains_multiple_segments result survives CompactMask roundtrip.
+    """
+    Verify contains_multiple_segments result survives CompactMask roundtrip.
 
-    Encoding and decoding must preserve connected-component topology so
-    that the multi-segment predicate returns the same value.
+    Encoding and decoding must preserve connected-component topology so that the multi-
+    segment predicate returns the same value.
     """
 
     @pytest.mark.parametrize(
@@ -1116,12 +1126,13 @@ def _random_masks_and_xyxy(
     img_w: int,
     fill_prob: float = 0.3,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Generate *num_masks* random boolean masks with matching tight xyxy boxes.
+    """
+    Generate *num_masks* random boolean masks with matching tight xyxy boxes.
 
     Each mask is built by filling a random sub-rectangle with Bernoulli noise at
-    ``fill_prob``, then computing tight bounding boxes via ``mask_to_xyxy``.
-    This guarantees every mask has at least one True pixel (for non-degenerate
-    bounding boxes).
+    ``fill_prob``, then computing tight bounding boxes via ``mask_to_xyxy``. This
+    guarantees every mask has at least one True pixel (for non-degenerate bounding
+    boxes).
     """
     masks = np.zeros((num_masks, img_h, img_w), dtype=bool)
     for mask_idx in range(num_masks):
@@ -1140,10 +1151,11 @@ def _random_masks_and_xyxy(
 
 
 class TestCompactMaskRoundtripRandom:
-    """from_dense -> to_dense pixel equality across 10 random seeds.
+    """
+    from_dense -> to_dense pixel equality across 10 random seeds.
 
-    Uses tight bounding boxes so the round-trip must be lossless (all True
-    pixels lie strictly within the crop).
+    Uses tight bounding boxes so the round-trip must be lossless (all True pixels lie
+    strictly within the crop).
     """
 
     @pytest.mark.parametrize("seed", list(range(10)))
@@ -1163,7 +1175,7 @@ class TestCompactMaskRoundtripRandom:
 
     @pytest.mark.parametrize("seed", list(range(10)))
     def test_shape_and_len(self, seed: int) -> None:
-        """len() and .shape must agree with the dense array."""
+        """Len() and .shape must agree with the dense array."""
         rng = np.random.default_rng(seed)
         num_masks, img_h, img_w = _RANDOM_CONFIGS[seed]
         masks, xyxy = _random_masks_and_xyxy(rng, num_masks, img_h, img_w)
@@ -1173,7 +1185,7 @@ class TestCompactMaskRoundtripRandom:
 
     @pytest.mark.parametrize("seed", list(range(10)))
     def test_individual_mask_access(self, seed: int) -> None:
-        """cm[i] must equal masks[i] for every index."""
+        """Cm[i] must equal masks[i] for every index."""
         rng = np.random.default_rng(seed)
         num_masks, img_h, img_w = _RANDOM_CONFIGS[seed]
         masks, xyxy = _random_masks_and_xyxy(rng, num_masks, img_h, img_w)
@@ -1187,7 +1199,7 @@ class TestCompactMaskRoundtripRandom:
 
 
 class TestCompactMaskAreaRandom:
-    """area from CompactMask equals dense .sum(axis=(1,2)) across 10 seeds."""
+    """Area from CompactMask equals dense .sum(axis=(1,2)) across 10 seeds."""
 
     @pytest.mark.parametrize("seed", list(range(10)))
     def test_parity_seed(self, seed: int) -> None:
@@ -1405,10 +1417,11 @@ class TestRleSplitCols:
 
 
 class TestCompactMaskResize:
-    """Tests for CompactMask.resize method.
+    """
+    Tests for CompactMask.resize method.
 
-    Verifies scaling behaviour, coordinate arithmetic, identity resize,
-    empty collections, invalid dimensions, and dense parity with cv2.
+    Verifies scaling behaviour, coordinate arithmetic, identity resize, empty
+    collections, invalid dimensions, and dense parity with cv2.
     """
 
     @pytest.mark.parametrize(
@@ -1572,11 +1585,12 @@ class TestCompactMaskResize:
 
 
 class TestRleResize:
-    """Tests for _rle_resize direct F-order RLE resizing.
+    """
+    Tests for _rle_resize direct F-order RLE resizing.
 
     Verifies that _rle_resize produces identical results to the decode ->
-    cv2.resize(INTER_NEAREST) -> encode path for identity, upscale, downscale,
-    non-square, all-False, all-True, single-pixel, and random masks.
+    cv2.resize(INTER_NEAREST) -> encode path for identity, upscale, downscale, non-
+    square, all-False, all-True, single-pixel, and random masks.
     """
 
     def test_identity_4x4(self) -> None:
@@ -1823,7 +1837,7 @@ class TestRleResize:
             assert not result.any(), "1x1 False -> large shape must be all False"
 
     def test_resize_dispatch_uses_l3_for_sparse(self) -> None:
-        """resize() dispatches to _rle_resize for sparse masks."""
+        """Resize() dispatches to _rle_resize for sparse masks."""
         img_h, img_w = 100, 100
         masks = np.zeros((1, img_h, img_w), dtype=bool)
         masks[0, 50, 50] = True
@@ -1837,10 +1851,11 @@ class TestRleResize:
         assert dense.sum() > 0
 
     def test_resize_dispatch_uses_cv2_for_dense(self) -> None:
-        """_resize_crop falls back to cv2 for dense masks (above _L3_DENSITY_THRESHOLD).
+        """
+        _resize_crop falls back to cv2 for dense masks (above _L3_DENSITY_THRESHOLD).
 
-        Checkerboard yields ~1 run per pixel, far above the 0.25 threshold.
-        Result must match cv2.resize(INTER_NEAREST) within 1 pixel.
+        Checkerboard yields ~1 run per pixel, far above the 0.25 threshold. Result must
+        match cv2.resize(INTER_NEAREST) within 1 pixel.
         """
         from supervision.detection.compact_mask import (
             _L3_DENSITY_THRESHOLD,
@@ -1872,7 +1887,7 @@ class TestResizeParallelPath:
     """Tests for CompactMask.resize() thread-pool code path (N >= 8 masks)."""
 
     def test_parallel_resize_correctness(self) -> None:
-        """resize() with N=10 masks exercises ThreadPoolExecutor; output is correct."""
+        """Resize() with N=10 masks exercises ThreadPoolExecutor; output is correct."""
         img_h, img_w = 80, 80
         n = 10  # above _PARALLEL_THRESHOLD = 8
         masks = np.zeros((n, img_h, img_w), dtype=bool)

--- a/tests/detection/test_compact_mask.py
+++ b/tests/detection/test_compact_mask.py
@@ -33,8 +33,7 @@ def _make_cm(masks: np.ndarray, image_shape: tuple[int, int]) -> CompactMask:
 
 
 class TestRleHelpers:
-    """
-    Tests for _mask_to_rle_counts, _rle_counts_to_mask, and _rle_area.
+    """Tests for _mask_to_rle_counts, _rle_counts_to_mask, and _rle_area.
 
     Verifies that the private RLE encoding round-trips correctly for a range of mask
     shapes (all-False, all-True, diagonal, L-shape, checkerboard, single-pixel, and
@@ -145,8 +144,7 @@ class TestRleHelpers:
 
 
 class TestFromDenseToDense:
-    """
-    Tests for CompactMask.from_dense and to_dense.
+    """Tests for CompactMask.from_dense and to_dense.
 
     Verifies that the from_dense → to_dense round-trip is lossless when the bounding
     boxes span the full image (no True pixels fall outside the crop). Covers N=0
@@ -502,8 +500,7 @@ class TestRleTrimColRuns:
 
 
 class TestGetItem:
-    """
-    Tests for CompactMask.__getitem__.
+    """Tests for CompactMask.__getitem__.
 
     Covers four indexing modes:
     - Integer index → dense (H, W) np.ndarray with correct shape and dtype.
@@ -582,8 +579,7 @@ class TestGetItem:
 
 
 class TestProperties:
-    """
-    Tests for len, shape, dtype, and area properties.
+    """Tests for len, shape, dtype, and area properties.
 
     Verifies that the shape tuple follows the (N, H, W) dense convention, dtype is
     always bool, and area returns per-mask True-pixel counts that match np.sum on the
@@ -639,8 +635,7 @@ class TestProperties:
 
 
 class TestCrop:
-    """
-    Tests for CompactMask.crop.
+    """Tests for CompactMask.crop.
 
     Verifies that crop(index) returns an array shaped (crop_h, crop_w) containing only
     the pixels within the bounding box, without allocating the full (H, W) image.
@@ -659,8 +654,7 @@ class TestCrop:
 
 
 class TestArrayProtocol:
-    """
-    Tests for the __array__ protocol.
+    """Tests for the __array__ protocol.
 
     Verifies that np.asarray(cm) materialises the full (N, H, W) dense array and that
     optional dtype casting (e.g. to uint8) is correctly applied.
@@ -685,8 +679,7 @@ class TestArrayProtocol:
 
 
 class TestMerge:
-    """
-    Tests for CompactMask.merge.
+    """Tests for CompactMask.merge.
 
     Verifies that multiple CompactMask instances with the same image_shape can be
     concatenated into a single CompactMask, that merging with an empty instance works,
@@ -744,8 +737,7 @@ class TestMerge:
 
 
 class TestEquality:
-    """
-    Tests for CompactMask.__eq__.
+    """Tests for CompactMask.__eq__.
 
     Verifies element-wise equality between two CompactMask instances and between a
     CompactMask and an equivalent dense (N, H, W) boolean array.
@@ -775,8 +767,7 @@ class TestEquality:
 
 
 class TestEdgeCases:
-    """
-    Tests for boundary conditions and unusual inputs.
+    """Tests for boundary conditions and unusual inputs.
 
     Covers: zero-area bounding box (x1 == x2), masks that reach the image
     edge, xyxy values beyond image dimensions (clamped silently), empty
@@ -939,8 +930,7 @@ class TestEdgeCases:
 
 
 class TestCalculateMasksCentroidsCompact:
-    """
-    Verify calculate_masks_centroids gives identical results for CompactMask.
+    """Verify calculate_masks_centroids gives identical results for CompactMask.
 
     The function has a dedicated CompactMask branch that computes centroids per-crop.
     Results must match the dense path to within integer rounding.
@@ -998,8 +988,7 @@ class TestCalculateMasksCentroidsCompact:
 
 
 class TestContainsHolesCompact:
-    """
-    Verify contains_holes result is unchanged after CompactMask roundtrip.
+    """Verify contains_holes result is unchanged after CompactMask roundtrip.
 
     contains_holes works on a 2D boolean mask.  Encoding then decoding via CompactMask
     must preserve pixel topology so that the function returns the same result as on the
@@ -1045,8 +1034,7 @@ class TestContainsHolesCompact:
 
 
 class TestContainsMultipleSegmentsCompact:
-    """
-    Verify contains_multiple_segments result survives CompactMask roundtrip.
+    """Verify contains_multiple_segments result survives CompactMask roundtrip.
 
     Encoding and decoding must preserve connected-component topology so that the multi-
     segment predicate returns the same value.
@@ -1126,8 +1114,7 @@ def _random_masks_and_xyxy(
     img_w: int,
     fill_prob: float = 0.3,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Generate *num_masks* random boolean masks with matching tight xyxy boxes.
+    """Generate *num_masks* random boolean masks with matching tight xyxy boxes.
 
     Each mask is built by filling a random sub-rectangle with Bernoulli noise at
     ``fill_prob``, then computing tight bounding boxes via ``mask_to_xyxy``. This
@@ -1151,8 +1138,7 @@ def _random_masks_and_xyxy(
 
 
 class TestCompactMaskRoundtripRandom:
-    """
-    from_dense -> to_dense pixel equality across 10 random seeds.
+    """from_dense -> to_dense pixel equality across 10 random seeds.
 
     Uses tight bounding boxes so the round-trip must be lossless (all True pixels lie
     strictly within the crop).
@@ -1417,8 +1403,7 @@ class TestRleSplitCols:
 
 
 class TestCompactMaskResize:
-    """
-    Tests for CompactMask.resize method.
+    """Tests for CompactMask.resize method.
 
     Verifies scaling behaviour, coordinate arithmetic, identity resize, empty
     collections, invalid dimensions, and dense parity with cv2.
@@ -1585,8 +1570,7 @@ class TestCompactMaskResize:
 
 
 class TestRleResize:
-    """
-    Tests for _rle_resize direct F-order RLE resizing.
+    """Tests for _rle_resize direct F-order RLE resizing.
 
     Verifies that _rle_resize produces identical results to the decode ->
     cv2.resize(INTER_NEAREST) -> encode path for identity, upscale, downscale, non-
@@ -1851,8 +1835,7 @@ class TestRleResize:
         assert dense.sum() > 0
 
     def test_resize_dispatch_uses_cv2_for_dense(self) -> None:
-        """
-        _resize_crop falls back to cv2 for dense masks (above _L3_DENSITY_THRESHOLD).
+        """_resize_crop falls back to cv2 for dense masks (above _L3_DENSITY_THRESHOLD).
 
         Checkerboard yields ~1 run per pixel, far above the 0.25 threshold. Result must
         match cv2.resize(INTER_NEAREST) within 1 pixel.

--- a/tests/detection/test_compact_mask_integration.py
+++ b/tests/detection/test_compact_mask_integration.py
@@ -18,10 +18,11 @@ def _full_xyxy(n: int, h: int, w: int) -> np.ndarray:
 def _make_compact_detections(
     n: int, h: int = 40, w: int = 40
 ) -> tuple[Detections, np.ndarray]:
-    """Detections with a CompactMask backed by full-image bounding boxes.
+    """
+    Detections with a CompactMask backed by full-image bounding boxes.
 
-    Using full-image xyxy means all True pixels are within the crop region,
-    so from_dense -> to_dense is lossless.
+    Using full-image xyxy means all True pixels are within the crop region, so
+    from_dense -> to_dense is lossless.
     """
     rng = np.random.default_rng(42)
     masks = rng.integers(0, 2, size=(n, h, w)).astype(bool)
@@ -37,11 +38,12 @@ def _make_compact_detections(
 
 
 class TestConstruction:
-    """Tests for building Detections with a CompactMask.
+    """
+    Tests for building Detections with a CompactMask.
 
-    Verifies that a CompactMask is accepted as a valid mask argument and that
-    the validator raises ValueError when the mask length does not match the
-    number of bounding boxes.
+    Verifies that a CompactMask is accepted as a valid mask argument and that the
+    validator raises ValueError when the mask length does not match the number of
+    bounding boxes.
     """
 
     def test_detections_construction_with_compact_mask(self) -> None:
@@ -60,7 +62,8 @@ class TestConstruction:
 
 
 class TestFiltering:
-    """Tests for Detections.__getitem__ with a CompactMask.
+    """
+    Tests for Detections.__getitem__ with a CompactMask.
 
     Verifies that integer, slice, and boolean-array indexing all preserve the
     CompactMask type and return the correct subset of masks.
@@ -90,11 +93,12 @@ class TestFiltering:
 
 
 class TestIteration:
-    """Tests for iterating over Detections with a CompactMask.
+    """
+    Tests for iterating over Detections with a CompactMask.
 
-    Verifies that each iteration step yields a 2-D boolean (H, W) array
-    identical to the corresponding dense mask, so downstream code that
-    iterates over detections needs no changes.
+    Verifies that each iteration step yields a 2-D boolean (H, W) array identical to the
+    corresponding dense mask, so downstream code that iterates over detections needs no
+    changes.
     """
 
     def test_iter_yields_2d_dense(self) -> None:
@@ -109,10 +113,11 @@ class TestIteration:
 
 
 class TestEquality:
-    """Tests for Detections.__eq__ mixing CompactMask and dense arrays.
+    """
+    Tests for Detections.__eq__ mixing CompactMask and dense arrays.
 
-    Verifies that a Detections object backed by a CompactMask compares equal
-    to an otherwise identical Detections object backed by a dense ndarray.
+    Verifies that a Detections object backed by a CompactMask compares equal to an
+    otherwise identical Detections object backed by a dense ndarray.
     """
 
     def test_compact_vs_dense(self) -> None:
@@ -129,10 +134,11 @@ class TestEquality:
 
 
 class TestArea:
-    """Tests for the Detections.area property with a CompactMask.
+    """
+    Tests for the Detections.area property with a CompactMask.
 
-    Verifies that the fast CompactMask path in Detections.area returns the
-    same per-detection pixel counts as summing the equivalent dense array.
+    Verifies that the fast CompactMask path in Detections.area returns the same per-
+    detection pixel counts as summing the equivalent dense array.
     """
 
     def test_compact_matches_dense(self) -> None:
@@ -142,7 +148,8 @@ class TestArea:
 
 
 class TestMerge:
-    """Tests for merging Detections objects that contain CompactMask instances.
+    """
+    Tests for merging Detections objects that contain CompactMask instances.
 
     Covers three scenarios:
     - All-compact merge: result is a CompactMask.
@@ -225,12 +232,12 @@ class TestMerge:
 
 
 class TestAnnotators:
-    """Tests for annotators that consume CompactMask via Detections.
+    """
+    Tests for annotators that consume CompactMask via Detections.
 
-    Verifies that MaskAnnotator and PolygonAnnotator produce pixel-identical
-    output when given Detections backed by a CompactMask versus the equivalent
-    dense ndarray, confirming that the annotators are transparent to the mask
-    representation.
+    Verifies that MaskAnnotator and PolygonAnnotator produce pixel-identical output when
+    given Detections backed by a CompactMask versus the equivalent dense ndarray,
+    confirming that the annotators are transparent to the mask representation.
     """
 
     def test_mask_annotator(self) -> None:

--- a/tests/detection/test_compact_mask_integration.py
+++ b/tests/detection/test_compact_mask_integration.py
@@ -18,8 +18,7 @@ def _full_xyxy(n: int, h: int, w: int) -> np.ndarray:
 def _make_compact_detections(
     n: int, h: int = 40, w: int = 40
 ) -> tuple[Detections, np.ndarray]:
-    """
-    Detections with a CompactMask backed by full-image bounding boxes.
+    """Detections with a CompactMask backed by full-image bounding boxes.
 
     Using full-image xyxy means all True pixels are within the crop region, so
     from_dense -> to_dense is lossless.
@@ -38,8 +37,7 @@ def _make_compact_detections(
 
 
 class TestConstruction:
-    """
-    Tests for building Detections with a CompactMask.
+    """Tests for building Detections with a CompactMask.
 
     Verifies that a CompactMask is accepted as a valid mask argument and that the
     validator raises ValueError when the mask length does not match the number of
@@ -62,8 +60,7 @@ class TestConstruction:
 
 
 class TestFiltering:
-    """
-    Tests for Detections.__getitem__ with a CompactMask.
+    """Tests for Detections.__getitem__ with a CompactMask.
 
     Verifies that integer, slice, and boolean-array indexing all preserve the
     CompactMask type and return the correct subset of masks.
@@ -93,8 +90,7 @@ class TestFiltering:
 
 
 class TestIteration:
-    """
-    Tests for iterating over Detections with a CompactMask.
+    """Tests for iterating over Detections with a CompactMask.
 
     Verifies that each iteration step yields a 2-D boolean (H, W) array identical to the
     corresponding dense mask, so downstream code that iterates over detections needs no
@@ -113,8 +109,7 @@ class TestIteration:
 
 
 class TestEquality:
-    """
-    Tests for Detections.__eq__ mixing CompactMask and dense arrays.
+    """Tests for Detections.__eq__ mixing CompactMask and dense arrays.
 
     Verifies that a Detections object backed by a CompactMask compares equal to an
     otherwise identical Detections object backed by a dense ndarray.
@@ -134,8 +129,7 @@ class TestEquality:
 
 
 class TestArea:
-    """
-    Tests for the Detections.area property with a CompactMask.
+    """Tests for the Detections.area property with a CompactMask.
 
     Verifies that the fast CompactMask path in Detections.area returns the same per-
     detection pixel counts as summing the equivalent dense array.
@@ -148,8 +142,7 @@ class TestArea:
 
 
 class TestMerge:
-    """
-    Tests for merging Detections objects that contain CompactMask instances.
+    """Tests for merging Detections objects that contain CompactMask instances.
 
     Covers three scenarios:
     - All-compact merge: result is a CompactMask.
@@ -232,8 +225,7 @@ class TestMerge:
 
 
 class TestAnnotators:
-    """
-    Tests for annotators that consume CompactMask via Detections.
+    """Tests for annotators that consume CompactMask via Detections.
 
     Verifies that MaskAnnotator and PolygonAnnotator produce pixel-identical output when
     given Detections backed by a CompactMask versus the equivalent dense ndarray,

--- a/tests/detection/test_compact_mask_iou.py
+++ b/tests/detection/test_compact_mask_iou.py
@@ -55,9 +55,9 @@ def _dense_iou(
 class TestCompactMaskIouBatch:
     """Verify that compact_mask_iou_batch matches dense raster IoU exactly.
 
-    Every test builds a pair of CompactMask collections from known boolean
-    arrays, runs compact_mask_iou_batch, and compares the result to the dense
-    reference computed by mask_iou_batch on the raw numpy arrays.
+    Every test builds a pair of CompactMask collections from known boolean arrays, runs
+    compact_mask_iou_batch, and compares the result to the dense reference computed by
+    mask_iou_batch on the raw numpy arrays.
     """
 
     def test_no_overlap_gives_zero(self) -> None:
@@ -205,10 +205,10 @@ class TestCompactMaskIouBatch:
 class TestMaskIouBatchDispatch:
     """Verify mask_iou_batch dispatches correctly for CompactMask inputs.
 
-    When both arguments are CompactMask, the function must route to the
-    efficient RLE implementation and produce identical results to the dense
-    path.  When one argument is dense and the other is CompactMask, the
-    CompactMask must be materialised transparently before computation.
+    When both arguments are CompactMask, the function must route to the efficient RLE
+    implementation and produce identical results to the dense path.  When one argument
+    is dense and the other is CompactMask, the CompactMask must be materialised
+    transparently before computation.
     """
 
     def test_both_compact_dispatches_to_rle(self) -> None:
@@ -242,9 +242,9 @@ class TestMaskIouBatchDispatch:
 class TestNmsWithCompactMask:
     """Verify mask NMS produces identical keep-sets for CompactMask and dense inputs.
 
-    Both paths now use exact full-resolution IoU — no resize approximation.
-    Tests use images larger than 640 px to ensure the old resize-to-640 path
-    would have introduced lossy approximation (catching the regression).
+    Both paths now use exact full-resolution IoU — no resize approximation. Tests use
+    images larger than 640 px to ensure the old resize-to-640 path would have introduced
+    lossy approximation (catching the regression).
     """
 
     def test_nms_compact_matches_dense(self) -> None:
@@ -271,9 +271,9 @@ class TestNmsWithCompactMask:
     def test_nms_compact_matches_dense_borderline(self) -> None:
         """Borderline IoU pair (≈ threshold) must agree — catches the resize bug.
 
-        With resize-to-640, sub-pixel rounding on a pair whose true IoU is very
-        close to the threshold flips the keep/suppress decision.  Both paths now
-        compute exact pixel-level IoU so results are identical.
+        With resize-to-640, sub-pixel rounding on a pair whose true IoU is very close to
+        the threshold flips the keep/suppress decision.  Both paths now compute exact
+        pixel-level IoU so results are identical.
         """
         img_h, img_w = 1080, 1920
         masks = np.zeros((2, img_h, img_w), dtype=bool)
@@ -324,8 +324,8 @@ class TestNmsWithCompactMask:
 class TestNmmWithCompactMask:
     """Verify mask_non_max_merge produces the same groups for CompactMask and dense.
 
-    NMM materialises CompactMask to a downscaled dense array internally, so
-    results must be numerically identical to the dense path.
+    NMM materialises CompactMask to a downscaled dense array internally, so results must
+    be numerically identical to the dense path.
     """
 
     def test_nmm_compact_matches_dense(self) -> None:
@@ -423,8 +423,8 @@ def _random_masks(
 class TestCompactMaskIouRandom:
     """compact_mask_iou_batch matches dense mask_iou_batch across 10 random seeds.
 
-    Uses small mask counts (5-15) and image sizes (20x20 to 60x60) to keep
-    individual test runs under 1 second.
+    Uses small mask counts (5-15) and image sizes (20x20 to 60x60) to keep individual
+    test runs under 1 second.
     """
 
     @pytest.mark.parametrize("seed", list(range(10)))

--- a/tests/detection/test_core.py
+++ b/tests/detection/test_core.py
@@ -316,10 +316,11 @@ def test_getitem(
     expected_result: Detections | None,
     exception: Exception,
 ) -> None:
-    """
-    Ensures that `Detections.__getitem__` (indexing/slicing) works correctly for various
-    input types. This is a core feature that allows users to filter and manipulate
-    detection results easily.
+    """Ensures that `Detections.__getitem__` (indexing/slicing) works correctly for
+    various input types.
+
+    This is a core feature that allows users to filter and manipulate detection results
+    easily.
     """
     with exception:
         result = detections[index]
@@ -736,14 +737,14 @@ class TestMergeMixedMasks:
         return dense_det
 
     def test_mixed_result_is_compact_mask(self) -> None:
-        """merge([dense, compact]) returns a CompactMask, not ndarray."""
+        """Merge([dense, compact]) returns a CompactMask, not ndarray."""
         det_dense = self._make_dense_det([[5, 5, 15, 15]])
         det_compact = self._make_compact_det([[20, 20, 35, 35]])
         result = Detections.merge([det_dense, det_compact])
         assert isinstance(result.mask, CompactMask)
 
     def test_mixed_pixel_parity_with_all_dense(self) -> None:
-        """merge([dense, compact]) produces the same pixels as merge([dense, dense])."""
+        """Merge([dense, compact]) produces the same pixels as merge([dense, dense])."""
         xyxy_a = [[5, 5, 15, 15]]
         xyxy_b = [[20, 20, 35, 35]]
         det_dense_a = self._make_dense_det(xyxy_a)
@@ -758,7 +759,7 @@ class TestMergeMixedMasks:
         assert mixed.mask.image_shape == self.IMG_SHAPE
 
     def test_mixed_compact_first_pixel_parity(self) -> None:
-        """merge([compact, dense]) order: compact input first still gives parity."""
+        """Merge([compact, dense]) order: compact input first still gives parity."""
         xyxy_a = [[5, 5, 15, 15]]
         xyxy_b = [[20, 20, 35, 35]]
         det_compact_a = self._make_compact_det(xyxy_a)
@@ -774,7 +775,7 @@ class TestMergeMixedMasks:
         assert mixed.mask.image_shape == self.IMG_SHAPE
 
     def test_mixed_fields_remain_aligned(self) -> None:
-        """confidence, class_id, xyxy stay in order after mixed merge."""
+        """Confidence, class_id, xyxy stay in order after mixed merge."""
         det_dense = self._make_dense_det([[1, 1, 10, 10]])
         det_compact = self._make_compact_det([[30, 30, 40, 40]])
         det_dense.confidence = np.array([0.1])
@@ -805,7 +806,7 @@ class TestMergeMixedMasks:
         )
 
     def test_mixed_compact_image_shape_mismatch_raises(self) -> None:
-        """merge with CompactMasks of different image_shapes raises ValueError."""
+        """Merge with CompactMasks of different image_shapes raises ValueError."""
         h, w = self.IMG_SHAPE
         masks_a = np.zeros((1, h, w), dtype=bool)
         masks_b = np.zeros((1, h + 10, w + 10), dtype=bool)
@@ -849,9 +850,8 @@ class TestMergeMixedMasks:
     def test_mixed_dense_out_of_box_pixels_dropped(self) -> None:
         """Dense True pixels outside xyxy box are dropped after mixed merge.
 
-        from_dense crops each dense mask to its xyxy bounding box — a documented
-        lossy conversion. This test asserts the drop rather than treating it as a
-        regression.
+        from_dense crops each dense mask to its xyxy bounding box — a documented lossy
+        conversion. This test asserts the drop rather than treating it as a regression.
         """
         h, w = self.IMG_SHAPE
         xyxy = [[5, 5, 15, 15]]
@@ -875,7 +875,7 @@ class TestMergeMixedMasks:
         assert not result_dense[0, 0, 0], "out-of-box pixel dropped"
 
     def test_empty_compact_mask_detections_merge_returns_no_mask(self) -> None:
-        """merge on empty CompactMask-carrying Detections returns mask=None."""
+        """Merge on empty CompactMask-carrying Detections returns mask=None."""
         h, w = self.IMG_SHAPE
         cm_empty = CompactMask(
             [],
@@ -1432,9 +1432,9 @@ def test_from_inference_compact_masks_matches_dense_default() -> None:
 def test_from_inference_compact_masks_crops_to_detector_bbox() -> None:
     """compact_masks=True crops masks to the detector bbox; pixels outside are dropped.
 
-    This is the documented behaviour (see Warning in Detections.from_inference):
-    each mask is cropped to its detector bbox, so True pixels outside that box
-    are not stored.  Dense masks are unaffected and preserve the full mask.
+    This is the documented behaviour (see Warning in Detections.from_inference): each
+    mask is cropped to its detector bbox, so True pixels outside that box are not
+    stored.  Dense masks are unaffected and preserve the full mask.
     """
     # Mask has True at (row=0,col=0) [inside bbox] and (row=3,col=3) [outside bbox].
     # counts=[0,1,14,1,0]: 0 False, 1 True (pos 0), 14 False, 1 True (pos 15), 0 False.
@@ -1888,7 +1888,7 @@ class TestGetAnchorsObbDispatch:
 
 
 class TestMergeObbCorners:
-    """_merge_obb_corners"""
+    """_merge_obb_corners."""
 
     @pytest.mark.parametrize(
         ("corners_list", "expected"),
@@ -1987,7 +1987,7 @@ class TestMergeObbCorners:
 
 
 class TestMergeDetectionGroup:
-    """_merge_detection_group"""
+    """_merge_detection_group."""
 
     @pytest.mark.parametrize(
         ("detections", "expected_detections"),
@@ -2690,8 +2690,8 @@ class TestDetectionsArea:
         assert np.allclose(detections.area, detections.box_area)
 
     def test_mask_takes_precedence_over_oriented_box(self) -> None:
-        """When both `mask` and `ORIENTED_BOX_COORDINATES` are present, area is
-        computed from the mask."""
+        """When both `mask` and `ORIENTED_BOX_COORDINATES` are present, area is computed
+        from the mask."""
         mask = np.zeros((40, 40), dtype=bool)
         mask[10:30, 10:25] = True  # 20 rows x 15 cols = 300 pixels
         quad = _rotated_rect(20, 20, 20, 10, 0)  # OBB area = 200
@@ -2705,8 +2705,8 @@ class TestDetectionsArea:
         assert np.allclose(detections.area, [300.0])
 
     def test_empty_detections_with_obb_data_returns_empty_array(self) -> None:
-        """Boundary case: empty Detections carrying an OBB data field must
-        return an empty area array (matches the mask / box_area branches)."""
+        """Boundary case: empty Detections carrying an OBB data field must return an
+        empty area array (matches the mask / box_area branches)."""
         detections = Detections(
             xyxy=np.empty((0, 4), dtype=np.float32),
             class_id=np.array([], dtype=int),
@@ -2716,8 +2716,8 @@ class TestDetectionsArea:
         assert detections.area.shape == (0,)
 
     def test_degenerate_oriented_box_has_zero_area(self) -> None:
-        """An OBB whose four corners coincide has zero area — the shoelace
-        formula must not produce NaN or a negative value."""
+        """An OBB whose four corners coincide has zero area — the shoelace formula must
+        not produce NaN or a negative value."""
         quad = np.full((4, 2), 5.0, dtype=np.float32)
         detections = _make_obb_detections([quad], [0.9], [0])
 
@@ -2725,8 +2725,10 @@ class TestDetectionsArea:
 
     def test_handles_batched_oriented_boxes(self) -> None:
         """Multiple OBBs in one `Detections` each get their own correct area.
-        Guards against the shoelace reduction collapsing across boxes instead
-        of along the per-box corner axis."""
+
+        Guards against the shoelace reduction collapsing across boxes instead of along
+        the per-box corner axis.
+        """
         quads = [
             _rotated_rect(50, 50, 20, 10, 0),  # 200
             _rotated_rect(100, 100, 20, 10, 45),  # 200 (rotation must not change it)

--- a/tests/detection/test_csv.py
+++ b/tests/detection/test_csv.py
@@ -619,10 +619,11 @@ class TestCSVSinkLifecycle:
 
 
 class TestCSVSinkEmptyBatches:
-    """Tests for appending batches that contain no detections.
+    """
+    Tests for appending batches that contain no detections.
 
-    Also covers close() idempotency for the deferred-header path, since that
-    behavior is only reachable through an empty-batch-only session.
+    Also covers close() idempotency for the deferred-header path, since that behavior is
+    only reachable through an empty-batch-only session.
     """
 
     def test_empty_first_batch_does_not_drop_later_columns(self, tmp_path: Any) -> None:
@@ -657,7 +658,8 @@ class TestCSVSinkEmptyBatches:
     def test_empty_batch_does_not_warn_about_field_names(
         self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A detection-free frame is not a header mismatch worth reporting.
+        """
+        A detection-free frame is not a header mismatch worth reporting.
 
         The trailing empty batch must also contribute zero data rows: it is
         not just silent about the field-name mismatch, it writes nothing at
@@ -737,13 +739,14 @@ class TestCSVSinkEmptyBatches:
     def test_differing_schema_empty_batches_use_first_batch_header(
         self, tmp_path: Any
     ) -> None:
-        """Empty batches with differing custom_data keys resolve via first-wins.
+        """
+        Empty batches with differing custom_data keys resolve via first-wins.
 
-        No batch in this run ever carries a detection, so the deferred header
-        is built entirely from empty-batch schemas. When those empty batches
-        disagree on their custom_data keys, the file must keep the schema
-        remembered from the first empty batch, not silently overwrite it with
-        the schema of a later, equally empty batch.
+        No batch in this run ever carries a detection, so the deferred header is built
+        entirely from empty-batch schemas. When those empty batches disagree on their
+        custom_data keys, the file must keep the schema remembered from the first empty
+        batch, not silently overwrite it with the schema of a later, equally empty
+        batch.
         """
         path = tmp_path / "differing_empty_schema.csv"
 
@@ -788,11 +791,12 @@ class TestCSVSinkEmptyBatches:
     def test_reopening_after_all_empty_session_resets_deferred_schema(
         self, tmp_path: Any
     ) -> None:
-        """Reopening after an all-empty session drops the stale deferred schema.
+        """
+        Reopening after an all-empty session drops the stale deferred schema.
 
         Session 1 never appends a real detection, so ``open()`` resetting
-        ``deferred_field_names`` is the only thing standing between session 2
-        and a header still carrying columns from a run that detected nothing.
+        ``deferred_field_names`` is the only thing standing between session 2 and a
+        header still carrying columns from a run that detected nothing.
         """
         path = tmp_path / "reopen_after_empty.csv"
         populated_detections = sv.Detections(

--- a/tests/detection/test_csv.py
+++ b/tests/detection/test_csv.py
@@ -619,8 +619,7 @@ class TestCSVSinkLifecycle:
 
 
 class TestCSVSinkEmptyBatches:
-    """
-    Tests for appending batches that contain no detections.
+    """Tests for appending batches that contain no detections.
 
     Also covers close() idempotency for the deferred-header path, since that behavior is
     only reachable through an empty-batch-only session.
@@ -658,8 +657,7 @@ class TestCSVSinkEmptyBatches:
     def test_empty_batch_does_not_warn_about_field_names(
         self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """
-        A detection-free frame is not a header mismatch worth reporting.
+        """A detection-free frame is not a header mismatch worth reporting.
 
         The trailing empty batch must also contribute zero data rows: it is
         not just silent about the field-name mismatch, it writes nothing at
@@ -739,8 +737,7 @@ class TestCSVSinkEmptyBatches:
     def test_differing_schema_empty_batches_use_first_batch_header(
         self, tmp_path: Any
     ) -> None:
-        """
-        Empty batches with differing custom_data keys resolve via first-wins.
+        """Empty batches with differing custom_data keys resolve via first-wins.
 
         No batch in this run ever carries a detection, so the deferred header is built
         entirely from empty-batch schemas. When those empty batches disagree on their
@@ -791,8 +788,7 @@ class TestCSVSinkEmptyBatches:
     def test_reopening_after_all_empty_session_resets_deferred_schema(
         self, tmp_path: Any
     ) -> None:
-        """
-        Reopening after an all-empty session drops the stale deferred schema.
+        """Reopening after an all-empty session drops the stale deferred schema.
 
         Session 1 never appends a real detection, so ``open()`` resetting
         ``deferred_field_names`` is the only thing standing between session 2 and a

--- a/tests/detection/test_from_adapters.py
+++ b/tests/detection/test_from_adapters.py
@@ -236,7 +236,7 @@ class TestFromTransformers:
         assert len(det) == 0
 
     def test_detection_path_with_id2label_populates_class_names(self) -> None:
-        """id2label mapping adds class name strings to data dict."""
+        """Id2label mapping adds class name strings to data dict."""
         labels = np.array([0, 1], dtype=np.int64)
         result = {
             "boxes": _FakeDetachTensor(np.zeros((2, 4), dtype=np.float32)),
@@ -523,7 +523,7 @@ class TestFromDeepSparse:
         labels: np.ndarray,
         expected_len: int,
     ) -> None:
-        """boxes[0], scores[0], labels[0] are extracted into Detections fields."""
+        """Boxes[0], scores[0], labels[0] are extracted into Detections fields."""
         result = _FakeDeepSparseResults(boxes=[boxes], scores=[scores], labels=[labels])
 
         det = Detections.from_deepsparse(result)
@@ -594,7 +594,7 @@ class TestFromEasyOCR:
         np.testing.assert_allclose(det.data[ORIENTED_BOX_COORDINATES], np.array([bbox]))
 
     def test_detail_zero_results_raise_clear_error(self) -> None:
-        """detail=0 EasyOCR results must fail with a descriptive ValueError."""
+        """Detail=0 EasyOCR results must fail with a descriptive ValueError."""
         with pytest.raises(ValueError, match="detail=1"):
             Detections.from_easyocr(["text"])
 
@@ -739,7 +739,7 @@ class TestFromNCNN:
         ],
     )
     def test_maps_xywh_rect_to_xyxy(self, objects: list, expected_len: int) -> None:
-        """rect xywh converts to xyxy; prob and label map to confidence/class_id."""
+        """Rect xywh converts to xyxy; prob and label map to confidence/class_id."""
         det = Detections.from_ncnn(objects)
 
         assert len(det) == expected_len

--- a/tests/detection/test_polygonzone.py
+++ b/tests/detection/test_polygonzone.py
@@ -49,8 +49,7 @@ class TestPolygonZoneInit:
 
         Calls trigger() twice on the same zone: a materialized list keeps returning
         results on repeated calls, whereas an un-materialized generator would be
-        exhausted after the first trigger() and silently yield no anchors on the
-        second.
+        exhausted after the first trigger() and silently yield no anchors on the second.
         """
         zone = sv.PolygonZone(
             POLYGON, triggering_anchors=(p for p in [sv.Position.CENTER])
@@ -184,8 +183,8 @@ class TestPolygonZoneTrigger:
 
     def test_anchor_on_polygon_boundary_included_any_mode(self) -> None:
         """With require_all_anchors=False and multiple anchors, an anchor landing
-        exactly on the polygon boundary is enough to trigger, even though the
-        other anchors of the same detection fall outside the polygon."""
+        exactly on the polygon boundary is enough to trigger, even though the other
+        anchors of the same detection fall outside the polygon."""
         polygon = np.array([[0, 0], [100, 0], [100, 100], [0, 100]])
         anchors = [sv.Position.TOP_LEFT, sv.Position.BOTTOM_RIGHT]
         # TOP_LEFT = (-50, -50) is outside; BOTTOM_RIGHT = (100, 100) is exactly
@@ -243,9 +242,9 @@ class TestPolygonZoneTrigger:
         assert any_anchor.current_count == 0
 
     def test_require_all_anchors_default_matches_explicit_true(self) -> None:
-        """Omitting require_all_anchors and passing require_all_anchors=True
-        explicitly must produce identical trigger() results, pinning the
-        documented default (True)."""
+        """Omitting require_all_anchors and passing require_all_anchors=True explicitly
+        must produce identical trigger() results, pinning the documented default
+        (True)."""
         anchors = (
             sv.Position.TOP_LEFT,
             sv.Position.TOP_RIGHT,
@@ -263,7 +262,9 @@ class TestPolygonZoneTrigger:
     def test_require_all_anchors_has_no_effect_with_single_anchor(self) -> None:
         """With a single triggering anchor, require_all_anchors is a no-op: both
         settings must produce identical trigger() results (per the docstring:
-        "Has no effect when triggering_anchors has a single entry")."""
+
+        "Has no effect when triggering_anchors has a single entry").
+        """
         # Box [140, 140, 160, 160] has its BOTTOM_CENTER inside POLYGON.
         detections = _create_detections(
             xyxy=[[140.0, 140.0, 160.0, 160.0]], class_id=[0]

--- a/tests/detection/test_vlm.py
+++ b/tests/detection/test_vlm.py
@@ -293,8 +293,7 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [10, 10, 100, 100]}, {"label": "missing box"},
-            {"bbox_2d": [50, 60, 110, 120], "unused": "something"} ] ```"""
-               ,
+            {"bbox_2d": [50, 60, 110, 120], "unused": "something"} ] ```""",
             (640, 640),
             (1280, 720),
             None,
@@ -302,8 +301,7 @@ def test_from_paligemma(
         ),  # missing keys
         (
             does_not_raise(),
-            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                                                                                 ,
+            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"} ] ```""",
             (640, 640),
             (1280, 720),
             None,
@@ -316,8 +314,7 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [0, 0, 64, 64], "label": "dog"}, {"bbox_2d": [100,
-            200, 300, 400], "label": "cat"} ] ```"""
-               ,
+            200, 300, 400], "label": "cat"} ] ```""",
             (640, 640),
             (640, 640),
             None,
@@ -329,8 +326,7 @@ def test_from_paligemma(
         ),  # multiple no classes
         (
             does_not_raise(),
-            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "bird"} ] ```"""
-                                                                                  ,
+            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "bird"} ] ```""",
             (640, 640),
             (1280, 720),
             ["cat", "dog"],
@@ -341,8 +337,7 @@ def test_from_paligemma(
             """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"}, {"bbox_2d":
 
             [50, 100, 150, 200], "label": "dog"} ] ```
-            """
-               ,
+            """,
             (640, 640),
             (640, 480),
             ["cat", "dog"],
@@ -354,8 +349,7 @@ def test_from_paligemma(
         ),  # partial filtering
         (
             does_not_raise(),
-            """```json [ {"bbox_2d": [-10, 0, 700, 700], "label": "dog"} ] ```"""
-                                                                                 ,
+            """```json [ {"bbox_2d": [-10, 0, 700, 700], "label": "dog"} ] ```""",
             (640, 640),
             (1280, 720),
             None,
@@ -367,8 +361,7 @@ def test_from_paligemma(
         ),  # out-of-bounds box
         (
             does_not_raise(),
-            """[ {'bbox_2d': [10, 20, 110, 120], 'label': 'cat'} ]"""
-                                                                     ,
+            """[ {'bbox_2d': [10, 20, 110, 120], 'label': 'cat'} ]""",
             (640, 640),
             (1280, 720),
             None,
@@ -381,8 +374,7 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [0, 0, 64, 64], "label": "dog"}, {"bbox_2d": [10,
-            20, 110, 120], "label": "cat"}, {"bbox_2d": [30, 40, 130, 140], "label":"""
-               ,
+            20, 110, 120], "label": "cat"}, {"bbox_2d": [30, 40, 130, 140], "label":""",
             (640, 640),
             (640, 640),
             None,
@@ -406,8 +398,7 @@ def test_from_paligemma(
                     r"Got \(0, 640\)"
                 ),
             ),
-            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                                                                                 ,
+            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"} ] ```""",
             (0, 640),
             (1280, 720),
             None,
@@ -421,8 +412,7 @@ def test_from_paligemma(
                     r"Got \(1280, -100\)"
                 ),
             ),
-            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "dog"} ] ```"""
-                                                                                 ,
+            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "dog"} ] ```""",
             (640, 640),
             (1280, -100),
             None,
@@ -477,8 +467,7 @@ def test_from_qwen_2_5_vl(
         ),  # empty JSON array
         (
             does_not_raise(),
-            """```json [ {"box_2d": [100, 200, 300, 400], "label": "cat"} ] ```"""
-                                                                                  ,
+            """```json [ {"box_2d": [100, 200, 300, 400], "label": "cat"} ] ```""",
             (1000, 500),
             None,
             (
@@ -490,8 +479,7 @@ def test_from_qwen_2_5_vl(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"}, {"box_2d": [50,
-            100, 150, 200], "label": "dog"} ] ```"""
-               ,
+            100, 150, 200], "label": "dog"} ] ```""",
             (640, 480),
             None,
             (
@@ -502,8 +490,7 @@ def test_from_qwen_2_5_vl(
         ),  # multiple valid boxes without class filtering
         (
             does_not_raise(),
-            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                                                                                ,
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```""",
             (640, 480),
             ["dog", "person"],
             (np.empty((0, 4)), np.empty(0, dtype=int), np.empty(0, dtype=str)),
@@ -511,8 +498,7 @@ def test_from_qwen_2_5_vl(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"}, {"box_2d": [50,
-            100, 150, 200], "label": "dog"} ] ```"""
-               ,
+            100, 150, 200], "label": "dog"} ] ```""",
             (640, 480),
             ["person", "dog"],
             (
@@ -524,8 +510,7 @@ def test_from_qwen_2_5_vl(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"}, {"box_2d": [50,
-            100, 150, 200], "label": "dog"} ] ```"""
-               ,
+            100, 150, 200], "label": "dog"} ] ```""",
             (640, 480),
             ["cat", "dog"],
             (
@@ -542,8 +527,7 @@ def test_from_qwen_2_5_vl(
                     r"Got \(0, 480\)"
                 ),
             ),
-            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                                                                                ,
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```""",
             (0, 480),
             None,
             None,
@@ -556,8 +540,7 @@ def test_from_qwen_2_5_vl(
                     r"Got \(640, -100\)"
                 ),
             ),
-            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                                                                                ,
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```""",
             (640, -100),
             None,
             None,
@@ -1025,8 +1008,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
             """```json [ {"box_2d": [100, 200, 300, 400], "label": "cat", "confidence":
 
             0.8} ] ```
-            """
-               ,
+            """,
             (1000, 500),
             None,
             (
@@ -1043,8 +1025,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
 
             0.8}, {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9} ]
             ```
-            """
-               ,
+            """,
             (640, 480),
             None,
             (
@@ -1060,8 +1041,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence":
 
             0.8} ] ```
-            """
-               ,
+            """,
             (640, 480),
             ["dog", "person"],
             (
@@ -1078,8 +1058,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
 
             0.8}, {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9} ]
             ```
-            """
-               ,
+            """,
             (640, 480),
             ["person", "dog"],
             (
@@ -1096,8 +1075,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
 
             0.8}, {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9} ]
             ```
-            """
-               ,
+            """,
             (640, 480),
             ["cat", "dog"],
             (
@@ -1116,8 +1094,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
                     r"Got \(0, 480\)"
                 ),
             ),
-            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                                                                                ,
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```""",
             (0, 480),
             None,
             None,
@@ -1130,8 +1107,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
                     r"Got \(640, -100\)"
                 ),
             ),
-            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                                                                                ,
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```""",
             (640, -100),
             None,
             None,
@@ -1140,8 +1116,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "mask": "data:image/png;base64,i
             VBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjA
-            AAAAElFTkSuQmCC", "label": "cat"} ] ```"""
-               ,
+            AAAAElFTkSuQmCC", "label": "cat"} ] ```""",
             (10, 10),
             ["cat"],
             (
@@ -1161,8 +1136,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
             AAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjAAAAAElFTkSuQmCC", "label":
 
             "dog", "confidence": 0.9} ] ```
-            """
-               ,
+            """,
             (10, 10),
             ["cat", "dog"],
             (

--- a/tests/detection/test_vlm.py
+++ b/tests/detection/test_vlm.py
@@ -1114,9 +1114,12 @@ def test_florence_2_invalid_payloads_raise_value_error(
         ),
         (
             does_not_raise(),
-            """```json [ {"box_2d": [10, 20, 110, 120], "mask": "data:image/png;base64,i
-            VBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjA
-            AAAAElFTkSuQmCC", "label": "cat"} ] ```""",
+            (
+                '```json [ {"box_2d": [10, 20, 110, 120], "mask": '
+                '"data:image/png;base64,'
+                "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjA"
+                'AAAAElFTkSuQmCC", "label": "cat"} ] ```'
+            ),
             (10, 10),
             ["cat"],
             (
@@ -1129,14 +1132,16 @@ def test_florence_2_invalid_payloads_raise_value_error(
         ),
         (
             does_not_raise(),
-            """```json [ {"box_2d": [100, 100, 200, 200], "mask": "data:image/png;base64
-            ,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXp
-            jAAAAAElFTkSuQmCC", "label": "cat", "confidence": 0.8}, {"box_2d": [300,
-            300, 400, 400], "mask": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAA
-            AAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjAAAAAElFTkSuQmCC", "label":
-
-            "dog", "confidence": 0.9} ] ```
-            """,
+            (
+                '```json [ {"box_2d": [100, 100, 200, 200], "mask": '
+                '"data:image/png;base64,'
+                "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXp"
+                'jAAAAAElFTkSuQmCC", "label": "cat", "confidence": 0.8}, '
+                '{"box_2d": [300, 300, 400, 400], "mask": '
+                '"data:image/png;base64,'
+                "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpj"
+                'AAAAAElFTkSuQmCC", "label": "dog", "confidence": 0.9} ] ```'
+            ),
             (10, 10),
             ["cat", "dog"],
             (

--- a/tests/detection/test_vlm.py
+++ b/tests/detection/test_vlm.py
@@ -292,13 +292,10 @@ def test_from_paligemma(
         ),  # empty list
         (
             does_not_raise(),
-            """```json
-            [
-                {"bbox_2d": [10, 10, 100, 100]},
-                {"label": "missing box"},
-                {"bbox_2d": [50, 60, 110, 120], "unused": "something"}
-            ]
-            ```""",
+            """```json [ {"bbox_2d": [10, 10, 100, 100]}, {"label": "missing box"},
+            {"bbox_2d": [50, 60, 110, 120], "unused": "something"} ] ```
+            """
+                  ,
             (640, 640),
             (1280, 720),
             None,
@@ -306,11 +303,8 @@ def test_from_paligemma(
         ),  # missing keys
         (
             does_not_raise(),
-            """```json
-            [
-                {"bbox_2d": [10, 20, 110, 120], "label": "cat"}
-            ]
-            ```""",
+            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
+                  ,
             (640, 640),
             (1280, 720),
             None,
@@ -322,12 +316,10 @@ def test_from_paligemma(
         ),  # single box no classes
         (
             does_not_raise(),
-            """```json
-            [
-                {"bbox_2d": [0, 0, 64, 64], "label": "dog"},
-                {"bbox_2d": [100, 200, 300, 400], "label": "cat"}
-            ]
-            ```""",
+            """```json [ {"bbox_2d": [0, 0, 64, 64], "label": "dog"}, {"bbox_2d": [100,
+            200, 300, 400], "label": "cat"} ] ```
+            """
+                  ,
             (640, 640),
             (640, 640),
             None,
@@ -339,11 +331,8 @@ def test_from_paligemma(
         ),  # multiple no classes
         (
             does_not_raise(),
-            """```json
-            [
-                {"bbox_2d": [10, 20, 110, 120], "label": "bird"}
-            ]
-            ```""",
+            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "bird"} ] ```"""
+                  ,
             (640, 640),
             (1280, 720),
             ["cat", "dog"],
@@ -351,12 +340,10 @@ def test_from_paligemma(
         ),  # class mismatch
         (
             does_not_raise(),
-            """```json
-            [
-                {"bbox_2d": [10, 20, 110, 120], "label": "cat"},
-                {"bbox_2d": [50, 100, 150, 200], "label": "dog"}
-            ]
-            ```""",
+            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"}, {"bbox_2d":
+            [50, 100, 150, 200], "label": "dog"} ] ```
+            """
+                  ,
             (640, 640),
             (640, 480),
             ["cat", "dog"],
@@ -368,11 +355,8 @@ def test_from_paligemma(
         ),  # partial filtering
         (
             does_not_raise(),
-            """```json
-            [
-                {"bbox_2d": [-10, 0, 700, 700], "label": "dog"}
-            ]
-            ```""",
+            """```json [ {"bbox_2d": [-10, 0, 700, 700], "label": "dog"} ] ```"""
+                  ,
             (640, 640),
             (1280, 720),
             None,
@@ -384,9 +368,8 @@ def test_from_paligemma(
         ),  # out-of-bounds box
         (
             does_not_raise(),
-            """[
-                {'bbox_2d': [10, 20, 110, 120], 'label': 'cat'}
-            ]""",
+            """[ {'bbox_2d': [10, 20, 110, 120], 'label': 'cat'} ]"""
+                ,
             (640, 640),
             (1280, 720),
             None,
@@ -398,12 +381,10 @@ def test_from_paligemma(
         ),  # python-style list, single quotes, no fences
         (
             does_not_raise(),
-            """```json
-            [
-                {"bbox_2d": [0, 0, 64, 64], "label": "dog"},
-                {"bbox_2d": [10, 20, 110, 120], "label": "cat"},
-                {"bbox_2d": [30, 40, 130, 140], "label":
-            """,
+            """```json [ {"bbox_2d": [0, 0, 64, 64], "label": "dog"}, {"bbox_2d": [10,
+            20, 110, 120], "label": "cat"}, {"bbox_2d": [30, 40, 130, 140], "label":
+            """
+               ,
             (640, 640),
             (640, 640),
             None,
@@ -427,11 +408,8 @@ def test_from_paligemma(
                     r"Got \(0, 640\)"
                 ),
             ),
-            """```json
-            [
-                {"bbox_2d": [10, 20, 110, 120], "label": "cat"}
-            ]
-            ```""",
+            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
+                  ,
             (0, 640),
             (1280, 720),
             None,
@@ -445,11 +423,8 @@ def test_from_paligemma(
                     r"Got \(1280, -100\)"
                 ),
             ),
-            """```json
-            [
-                {"bbox_2d": [10, 20, 110, 120], "label": "dog"}
-            ]
-            ```""",
+            """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "dog"} ] ```"""
+                  ,
             (640, 640),
             (1280, -100),
             None,
@@ -504,11 +479,8 @@ def test_from_qwen_2_5_vl(
         ),  # empty JSON array
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [100, 200, 300, 400], "label": "cat"}
-            ]
-            ```""",
+            """```json [ {"box_2d": [100, 200, 300, 400], "label": "cat"} ] ```"""
+                  ,
             (1000, 500),
             None,
             (
@@ -519,12 +491,10 @@ def test_from_qwen_2_5_vl(
         ),  # single valid box with coordinate scaling
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat"},
-                {"box_2d": [50, 100, 150, 200], "label": "dog"}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"}, {"box_2d": [50,
+            100, 150, 200], "label": "dog"} ] ```
+            """
+                  ,
             (640, 480),
             None,
             (
@@ -535,23 +505,18 @@ def test_from_qwen_2_5_vl(
         ),  # multiple valid boxes without class filtering
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat"}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
+                  ,
             (640, 480),
             ["dog", "person"],
             (np.empty((0, 4)), np.empty(0, dtype=int), np.empty(0, dtype=str)),
         ),  # class mismatch with filter
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat"},
-                {"box_2d": [50, 100, 150, 200], "label": "dog"}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"}, {"box_2d": [50,
+            100, 150, 200], "label": "dog"} ] ```
+            """
+                  ,
             (640, 480),
             ["person", "dog"],
             (
@@ -562,12 +527,10 @@ def test_from_qwen_2_5_vl(
         ),  # partial class filtering
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat"},
-                {"box_2d": [50, 100, 150, 200], "label": "dog"}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"}, {"box_2d": [50,
+            100, 150, 200], "label": "dog"} ] ```
+            """
+                  ,
             (640, 480),
             ["cat", "dog"],
             (
@@ -584,11 +547,8 @@ def test_from_qwen_2_5_vl(
                     r"Got \(0, 480\)"
                 ),
             ),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat"}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
+                  ,
             (0, 480),
             None,
             None,
@@ -601,11 +561,8 @@ def test_from_qwen_2_5_vl(
                     r"Got \(640, -100\)"
                 ),
             ),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat"}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
+                  ,
             (640, -100),
             None,
             None,
@@ -1070,11 +1027,10 @@ def test_florence_2_invalid_payloads_raise_value_error(
         ),
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [100, 200, 300, 400], "label": "cat", "confidence": 0.8}
-            ]
-            ```""",
+            """```json [ {"box_2d": [100, 200, 300, 400], "label": "cat", "confidence":
+            0.8} ] ```
+            """
+                  ,
             (1000, 500),
             None,
             (
@@ -1087,12 +1043,11 @@ def test_florence_2_invalid_payloads_raise_value_error(
         ),
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence": 0.8},
-                {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence":
+            0.8}, {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9} ]
+            ```
+            """
+                  ,
             (640, 480),
             None,
             (
@@ -1105,11 +1060,10 @@ def test_florence_2_invalid_payloads_raise_value_error(
         ),
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence": 0.8}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence":
+            0.8} ] ```
+            """
+                  ,
             (640, 480),
             ["dog", "person"],
             (
@@ -1122,12 +1076,11 @@ def test_florence_2_invalid_payloads_raise_value_error(
         ),
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence": 0.8},
-                {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence":
+            0.8}, {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9} ]
+            ```
+            """
+                  ,
             (640, 480),
             ["person", "dog"],
             (
@@ -1140,12 +1093,11 @@ def test_florence_2_invalid_payloads_raise_value_error(
         ),
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence": 0.8},
-                {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence":
+            0.8}, {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9} ]
+            ```
+            """
+                  ,
             (640, 480),
             ["cat", "dog"],
             (
@@ -1164,11 +1116,8 @@ def test_florence_2_invalid_payloads_raise_value_error(
                     r"Got \(0, 480\)"
                 ),
             ),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat"}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
+                  ,
             (0, 480),
             None,
             None,
@@ -1181,22 +1130,19 @@ def test_florence_2_invalid_payloads_raise_value_error(
                     r"Got \(640, -100\)"
                 ),
             ),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "label": "cat"}
-            ]
-            ```""",
+            """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
+                  ,
             (640, -100),
             None,
             None,
         ),
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [10, 20, 110, 120], "mask": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjAAAAAElFTkSuQmCC", "label": "cat"}
-            ]
-            ```""",  # noqa E501 // docs
+            """```json [ {"box_2d": [10, 20, 110, 120], "mask": "data:image/png;base64,i
+            VBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjA
+            AAAAElFTkSuQmCC", "label": "cat"} ] ```
+            """
+                  ,  # noqa E501 // docs
             (10, 10),
             ["cat"],
             (
@@ -1209,12 +1155,14 @@ def test_florence_2_invalid_payloads_raise_value_error(
         ),
         (
             does_not_raise(),
-            """```json
-            [
-                {"box_2d": [100, 100, 200, 200], "mask": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjAAAAAElFTkSuQmCC", "label": "cat", "confidence": 0.8},
-                {"box_2d": [300, 300, 400, 400], "mask": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjAAAAAElFTkSuQmCC", "label": "dog", "confidence": 0.9}
-            ]
-            ```""",  # noqa E501 // docs
+            """```json [ {"box_2d": [100, 100, 200, 200], "mask": "data:image/png;base64
+            ,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXp
+            jAAAAAElFTkSuQmCC", "label": "cat", "confidence": 0.8}, {"box_2d": [300,
+            300, 400, 400], "mask": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAA
+            AAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjAAAAAElFTkSuQmCC", "label":
+            "dog", "confidence": 0.9} ] ```
+            """
+                  ,  # noqa E501 // docs
             (10, 10),
             ["cat", "dog"],
             (
@@ -1400,7 +1348,6 @@ def test_from_deepseek_vl_2_empty_parse_returns_empty_detections(
         resolution_wh=(1000, 1000),
         classes=classes,
     )
-
     assert len(detections) == 0
     assert detections.xyxy.shape == (0, 4)
 
@@ -1416,7 +1363,6 @@ def test_from_google_gemini_2_5_malformed_mask_keeps_confidence_aligned():
     xyxy, _, _, confidence, masks = from_google_gemini_2_5(
         result=result, resolution_wh=(640, 480)
     )
-
     assert xyxy.shape == (2, 4)
     assert confidence is not None
     assert confidence.shape == (2,)
@@ -1498,7 +1444,6 @@ def test_from_google_gemini_2_5_recovers_malformed_array():
     xyxy, _, class_name, _, _ = from_google_gemini_2_5(
         result=result, resolution_wh=(640, 480)
     )
-
     assert xyxy.shape == (2, 4)
     assert list(class_name) == ["cat", "dog"]
 
@@ -1518,7 +1463,6 @@ def test_from_google_gemini_2_0_recovers_malformed_array():
     xyxy, _, class_name = from_google_gemini_2_0(
         result=result, resolution_wh=(640, 480)
     )
-
     assert xyxy.shape == (2, 4)
     assert list(class_name) == ["cat", "dog"]
 
@@ -1537,7 +1481,6 @@ def test_from_google_gemini_3_5_parses_detections():
     xyxy, _, class_name, _, _ = from_google_gemini_3_5(
         result=result, resolution_wh=(640, 480)
     )
-
     assert xyxy.shape == (2, 4)
     assert list(class_name) == ["cat", "dog"]
 

--- a/tests/detection/test_vlm.py
+++ b/tests/detection/test_vlm.py
@@ -293,9 +293,8 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [10, 10, 100, 100]}, {"label": "missing box"},
-            {"bbox_2d": [50, 60, 110, 120], "unused": "something"} ] ```
-            """
-                  ,
+            {"bbox_2d": [50, 60, 110, 120], "unused": "something"} ] ```"""
+               ,
             (640, 640),
             (1280, 720),
             None,
@@ -304,7 +303,7 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                  ,
+                                                                                 ,
             (640, 640),
             (1280, 720),
             None,
@@ -317,9 +316,8 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [0, 0, 64, 64], "label": "dog"}, {"bbox_2d": [100,
-            200, 300, 400], "label": "cat"} ] ```
-            """
-                  ,
+            200, 300, 400], "label": "cat"} ] ```"""
+               ,
             (640, 640),
             (640, 640),
             None,
@@ -332,7 +330,7 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "bird"} ] ```"""
-                  ,
+                                                                                  ,
             (640, 640),
             (1280, 720),
             ["cat", "dog"],
@@ -341,9 +339,10 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"}, {"bbox_2d":
+
             [50, 100, 150, 200], "label": "dog"} ] ```
             """
-                  ,
+               ,
             (640, 640),
             (640, 480),
             ["cat", "dog"],
@@ -356,7 +355,7 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [-10, 0, 700, 700], "label": "dog"} ] ```"""
-                  ,
+                                                                                 ,
             (640, 640),
             (1280, 720),
             None,
@@ -369,7 +368,7 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """[ {'bbox_2d': [10, 20, 110, 120], 'label': 'cat'} ]"""
-                ,
+                                                                     ,
             (640, 640),
             (1280, 720),
             None,
@@ -382,8 +381,7 @@ def test_from_paligemma(
         (
             does_not_raise(),
             """```json [ {"bbox_2d": [0, 0, 64, 64], "label": "dog"}, {"bbox_2d": [10,
-            20, 110, 120], "label": "cat"}, {"bbox_2d": [30, 40, 130, 140], "label":
-            """
+            20, 110, 120], "label": "cat"}, {"bbox_2d": [30, 40, 130, 140], "label":"""
                ,
             (640, 640),
             (640, 640),
@@ -409,7 +407,7 @@ def test_from_paligemma(
                 ),
             ),
             """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                  ,
+                                                                                 ,
             (0, 640),
             (1280, 720),
             None,
@@ -424,7 +422,7 @@ def test_from_paligemma(
                 ),
             ),
             """```json [ {"bbox_2d": [10, 20, 110, 120], "label": "dog"} ] ```"""
-                  ,
+                                                                                 ,
             (640, 640),
             (1280, -100),
             None,
@@ -480,7 +478,7 @@ def test_from_qwen_2_5_vl(
         (
             does_not_raise(),
             """```json [ {"box_2d": [100, 200, 300, 400], "label": "cat"} ] ```"""
-                  ,
+                                                                                  ,
             (1000, 500),
             None,
             (
@@ -492,9 +490,8 @@ def test_from_qwen_2_5_vl(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"}, {"box_2d": [50,
-            100, 150, 200], "label": "dog"} ] ```
-            """
-                  ,
+            100, 150, 200], "label": "dog"} ] ```"""
+               ,
             (640, 480),
             None,
             (
@@ -506,7 +503,7 @@ def test_from_qwen_2_5_vl(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                  ,
+                                                                                ,
             (640, 480),
             ["dog", "person"],
             (np.empty((0, 4)), np.empty(0, dtype=int), np.empty(0, dtype=str)),
@@ -514,9 +511,8 @@ def test_from_qwen_2_5_vl(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"}, {"box_2d": [50,
-            100, 150, 200], "label": "dog"} ] ```
-            """
-                  ,
+            100, 150, 200], "label": "dog"} ] ```"""
+               ,
             (640, 480),
             ["person", "dog"],
             (
@@ -528,9 +524,8 @@ def test_from_qwen_2_5_vl(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"}, {"box_2d": [50,
-            100, 150, 200], "label": "dog"} ] ```
-            """
-                  ,
+            100, 150, 200], "label": "dog"} ] ```"""
+               ,
             (640, 480),
             ["cat", "dog"],
             (
@@ -548,7 +543,7 @@ def test_from_qwen_2_5_vl(
                 ),
             ),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                  ,
+                                                                                ,
             (0, 480),
             None,
             None,
@@ -562,7 +557,7 @@ def test_from_qwen_2_5_vl(
                 ),
             ),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                  ,
+                                                                                ,
             (640, -100),
             None,
             None,
@@ -1028,9 +1023,10 @@ def test_florence_2_invalid_payloads_raise_value_error(
         (
             does_not_raise(),
             """```json [ {"box_2d": [100, 200, 300, 400], "label": "cat", "confidence":
+
             0.8} ] ```
             """
-                  ,
+               ,
             (1000, 500),
             None,
             (
@@ -1044,10 +1040,11 @@ def test_florence_2_invalid_payloads_raise_value_error(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence":
+
             0.8}, {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9} ]
             ```
             """
-                  ,
+               ,
             (640, 480),
             None,
             (
@@ -1061,9 +1058,10 @@ def test_florence_2_invalid_payloads_raise_value_error(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence":
+
             0.8} ] ```
             """
-                  ,
+               ,
             (640, 480),
             ["dog", "person"],
             (
@@ -1077,10 +1075,11 @@ def test_florence_2_invalid_payloads_raise_value_error(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence":
+
             0.8}, {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9} ]
             ```
             """
-                  ,
+               ,
             (640, 480),
             ["person", "dog"],
             (
@@ -1094,10 +1093,11 @@ def test_florence_2_invalid_payloads_raise_value_error(
         (
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat", "confidence":
+
             0.8}, {"box_2d": [50, 100, 150, 200], "label": "dog", "confidence": 0.9} ]
             ```
             """
-                  ,
+               ,
             (640, 480),
             ["cat", "dog"],
             (
@@ -1117,7 +1117,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
                 ),
             ),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                  ,
+                                                                                ,
             (0, 480),
             None,
             None,
@@ -1131,7 +1131,7 @@ def test_florence_2_invalid_payloads_raise_value_error(
                 ),
             ),
             """```json [ {"box_2d": [10, 20, 110, 120], "label": "cat"} ] ```"""
-                  ,
+                                                                                ,
             (640, -100),
             None,
             None,
@@ -1140,9 +1140,8 @@ def test_florence_2_invalid_payloads_raise_value_error(
             does_not_raise(),
             """```json [ {"box_2d": [10, 20, 110, 120], "mask": "data:image/png;base64,i
             VBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjA
-            AAAAElFTkSuQmCC", "label": "cat"} ] ```
-            """
-                  ,  # noqa E501 // docs
+            AAAAElFTkSuQmCC", "label": "cat"} ] ```"""
+               ,
             (10, 10),
             ["cat"],
             (
@@ -1160,9 +1159,10 @@ def test_florence_2_invalid_payloads_raise_value_error(
             jAAAAAElFTkSuQmCC", "label": "cat", "confidence": 0.8}, {"box_2d": [300,
             300, 400, 400], "mask": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAA
             AAKCAAAAACoWZBhAAAADElEQVR4nGNgoCcAAABuAAFIXXpjAAAAAElFTkSuQmCC", "label":
+
             "dog", "confidence": 0.9} ] ```
             """
-                  ,  # noqa E501 // docs
+               ,
             (10, 10),
             ["cat", "dog"],
             (

--- a/tests/detection/tools/test_inference_slicer.py
+++ b/tests/detection/tools/test_inference_slicer.py
@@ -209,8 +209,7 @@ def test_generate_offset(
 
 def test_run_callback_warns_when_detections_outside_slice_bounds() -> None:
     """Test that a warning is emitted when callback returns detections with coordinates
-    outside the slice bounds.
-    """
+    outside the slice bounds."""
 
     def out_of_bounds_callback(_: np.ndarray) -> Detections:
         # Return detections with coordinates exceeding the 64x64 slice size
@@ -229,8 +228,7 @@ def test_run_callback_warns_when_detections_outside_slice_bounds() -> None:
 
 def test_run_callback_warns_only_once_for_out_of_bounds_detections() -> None:
     """Test that the out-of-bounds warning is only emitted once even across multiple
-    slices.
-    """
+    slices."""
 
     def out_of_bounds_callback(_: np.ndarray) -> Detections:
         return Detections(
@@ -257,8 +255,7 @@ def test_run_callback_warns_only_once_for_out_of_bounds_detections() -> None:
 
 def test_run_callback_no_warning_when_detections_inside_slice_bounds() -> None:
     """Test that no warning is emitted when callback returns detections within the slice
-    bounds.
-    """
+    bounds."""
 
     def in_bounds_callback(_: np.ndarray) -> Detections:
         return Detections(
@@ -285,8 +282,7 @@ def test_run_callback_no_warning_when_detections_inside_slice_bounds() -> None:
 
 def test_run_callback_warns_when_detections_have_negative_coordinates() -> None:
     """Test that a warning is emitted when callback returns detections with negative
-    coordinates, indicating wrong reference frame.
-    """
+    coordinates, indicating wrong reference frame."""
 
     def negative_coords_callback(_: np.ndarray) -> Detections:
         # Return detections with negative coordinates (e.g., returned in full-image
@@ -308,8 +304,7 @@ def test_run_callback_warns_when_detections_have_negative_coordinates() -> None:
 
 def test_run_callback_warns_only_once_with_multiple_threads() -> None:
     """Test that exactly one warning fires even with thread_workers > 1, validating that
-    the threading.Lock makes the check-and-set atomic.
-    """
+    the threading.Lock makes the check-and-set atomic."""
 
     def out_of_bounds_callback(_: np.ndarray) -> Detections:
         return Detections(
@@ -342,8 +337,7 @@ def test_run_callback_warns_only_once_with_multiple_threads() -> None:
 
 def test_run_callback_no_warning_for_detection_exactly_at_slice_boundary() -> None:
     """Test that a detection whose coordinates exactly equal the slice dimensions does
-    not trigger the warning (boundary is exclusive: > not >=).
-    """
+    not trigger the warning (boundary is exclusive: > not >=)."""
 
     def at_boundary_callback(_: np.ndarray) -> Detections:
         # x2=64, y2=64 on a 64x64 slice — touching the edge but not exceeding it
@@ -371,8 +365,7 @@ def test_run_callback_no_warning_for_detection_exactly_at_slice_boundary() -> No
 
 def test_run_callback_does_not_rewarn_on_second_call() -> None:
     """Test that a second call to the same slicer instance does not re-emit the out-of-
-    bounds warning even when detections are still out of bounds.
-    """
+    bounds warning even when detections are still out of bounds."""
 
     def out_of_bounds_callback(_: np.ndarray) -> Detections:
         return Detections(
@@ -463,8 +456,7 @@ def _rotated_rect(
 def test_inference_slicer_keeps_crossed_obb_detections(
     overlap_filter: OverlapFilter,
 ) -> None:
-    """
-    Regression for issue #1679: the SAHI workflow with OBB detections dropped valid
+    """Regression for issue #1679: the SAHI workflow with OBB detections dropped valid
     detections at the merge step because `with_nms`/`with_nmm` historically used axis-
     aligned IoU. For crossed thin rectangles the AABBs are nearly identical (IoU ≈ 1.0)
     while the OBBs barely overlap (IoU ≈ 0.06) — so AABB-NMS suppressed one of them.

--- a/tests/detection/tools/test_inference_slicer.py
+++ b/tests/detection/tools/test_inference_slicer.py
@@ -208,8 +208,9 @@ def test_generate_offset(
 
 
 def test_run_callback_warns_when_detections_outside_slice_bounds() -> None:
-    """Test that a warning is emitted when callback returns detections with
-    coordinates outside the slice bounds."""
+    """Test that a warning is emitted when callback returns detections with coordinates
+    outside the slice bounds.
+    """
 
     def out_of_bounds_callback(_: np.ndarray) -> Detections:
         # Return detections with coordinates exceeding the 64x64 slice size
@@ -227,8 +228,9 @@ def test_run_callback_warns_when_detections_outside_slice_bounds() -> None:
 
 
 def test_run_callback_warns_only_once_for_out_of_bounds_detections() -> None:
-    """Test that the out-of-bounds warning is only emitted once even across
-    multiple slices."""
+    """Test that the out-of-bounds warning is only emitted once even across multiple
+    slices.
+    """
 
     def out_of_bounds_callback(_: np.ndarray) -> Detections:
         return Detections(
@@ -254,8 +256,9 @@ def test_run_callback_warns_only_once_for_out_of_bounds_detections() -> None:
 
 
 def test_run_callback_no_warning_when_detections_inside_slice_bounds() -> None:
-    """Test that no warning is emitted when callback returns detections within
-    the slice bounds."""
+    """Test that no warning is emitted when callback returns detections within the slice
+    bounds.
+    """
 
     def in_bounds_callback(_: np.ndarray) -> Detections:
         return Detections(
@@ -281,8 +284,9 @@ def test_run_callback_no_warning_when_detections_inside_slice_bounds() -> None:
 
 
 def test_run_callback_warns_when_detections_have_negative_coordinates() -> None:
-    """Test that a warning is emitted when callback returns detections with
-    negative coordinates, indicating wrong reference frame."""
+    """Test that a warning is emitted when callback returns detections with negative
+    coordinates, indicating wrong reference frame.
+    """
 
     def negative_coords_callback(_: np.ndarray) -> Detections:
         # Return detections with negative coordinates (e.g., returned in full-image
@@ -303,8 +307,9 @@ def test_run_callback_warns_when_detections_have_negative_coordinates() -> None:
 
 
 def test_run_callback_warns_only_once_with_multiple_threads() -> None:
-    """Test that exactly one warning fires even with thread_workers > 1, validating
-    that the threading.Lock makes the check-and-set atomic."""
+    """Test that exactly one warning fires even with thread_workers > 1, validating that
+    the threading.Lock makes the check-and-set atomic.
+    """
 
     def out_of_bounds_callback(_: np.ndarray) -> Detections:
         return Detections(
@@ -336,8 +341,9 @@ def test_run_callback_warns_only_once_with_multiple_threads() -> None:
 
 
 def test_run_callback_no_warning_for_detection_exactly_at_slice_boundary() -> None:
-    """Test that a detection whose coordinates exactly equal the slice dimensions
-    does not trigger the warning (boundary is exclusive: > not >=)."""
+    """Test that a detection whose coordinates exactly equal the slice dimensions does
+    not trigger the warning (boundary is exclusive: > not >=).
+    """
 
     def at_boundary_callback(_: np.ndarray) -> Detections:
         # x2=64, y2=64 on a 64x64 slice — touching the edge but not exceeding it
@@ -364,8 +370,9 @@ def test_run_callback_no_warning_for_detection_exactly_at_slice_boundary() -> No
 
 
 def test_run_callback_does_not_rewarn_on_second_call() -> None:
-    """Test that a second call to the same slicer instance does not re-emit
-    the out-of-bounds warning even when detections are still out of bounds."""
+    """Test that a second call to the same slicer instance does not re-emit the out-of-
+    bounds warning even when detections are still out of bounds.
+    """
 
     def out_of_bounds_callback(_: np.ndarray) -> Detections:
         return Detections(
@@ -393,7 +400,6 @@ def test_run_callback_does_not_rewarn_on_second_call() -> None:
 
 def test_obb_callbacks_run_sequentially_even_with_multiple_workers() -> None:
     """Test that OBB callbacks are serialized even when thread_workers > 1."""
-
     active_calls = 0
     max_active_calls = 0
     concurrent_callbacks = 0
@@ -457,11 +463,11 @@ def _rotated_rect(
 def test_inference_slicer_keeps_crossed_obb_detections(
     overlap_filter: OverlapFilter,
 ) -> None:
-    """Regression for issue #1679: the SAHI workflow with OBB detections
-    dropped valid detections at the merge step because `with_nms`/`with_nmm`
-    historically used axis-aligned IoU. For crossed thin rectangles the AABBs
-    are nearly identical (IoU ≈ 1.0) while the OBBs barely overlap (IoU ≈ 0.06)
-    — so AABB-NMS suppressed one of them.
+    """
+    Regression for issue #1679: the SAHI workflow with OBB detections dropped valid
+    detections at the merge step because `with_nms`/`with_nmm` historically used axis-
+    aligned IoU. For crossed thin rectangles the AABBs are nearly identical (IoU ≈ 1.0)
+    while the OBBs barely overlap (IoU ≈ 0.06) — so AABB-NMS suppressed one of them.
 
     Both crossed OBBs must survive end-to-end through `InferenceSlicer`.
     """

--- a/tests/detection/tools/test_inference_slicer_geotiff.py
+++ b/tests/detection/tools/test_inference_slicer_geotiff.py
@@ -23,8 +23,7 @@ class _FakeCRS:
 
 
 class _FakeRasterDataset:
-    """
-    Lightweight rasterio-style dataset supporting windowed reads.
+    """Lightweight rasterio-style dataset supporting windowed reads.
 
     Mimics the duck-typed interface that ``InferenceSlicer`` relies on without requiring
     ``rasterio`` to be installed.

--- a/tests/detection/tools/test_inference_slicer_geotiff.py
+++ b/tests/detection/tools/test_inference_slicer_geotiff.py
@@ -23,10 +23,11 @@ class _FakeCRS:
 
 
 class _FakeRasterDataset:
-    """Lightweight rasterio-style dataset supporting windowed reads.
+    """
+    Lightweight rasterio-style dataset supporting windowed reads.
 
-    Mimics the duck-typed interface that ``InferenceSlicer`` relies on without
-    requiring ``rasterio`` to be installed.
+    Mimics the duck-typed interface that ``InferenceSlicer`` relies on without requiring
+    ``rasterio`` to be installed.
     """
 
     def __init__(self, image_hwc: np.ndarray, crs: object | None = None):

--- a/tests/detection/tools/test_smoother.py
+++ b/tests/detection/tools/test_smoother.py
@@ -161,7 +161,7 @@ class TestDetectionsSmoother:
         assert_allclose(smoothed_returned.xyxy, np.array([[1, 1, 11, 11]]), atol=1e-5)
 
     def test_reset_clears_track_history(self) -> None:
-        """reset() must drop cached frames so post-reset output ignores prior boxes."""
+        """Reset() must drop cached frames so post-reset output ignores prior boxes."""
         smoother = DetectionsSmoother(length=3)
         smoother.update_with_detections(
             Detections(
@@ -184,7 +184,7 @@ class TestDetectionsSmoother:
         assert_allclose(smoothed.xyxy, np.array([[2, 2, 12, 12]]), atol=1e-5)
 
     def test_reset_preserves_window_length(self) -> None:
-        """reset() must keep the configured window so maxlen still bounds new tracks."""
+        """Reset() must keep the configured window so maxlen still bounds new tracks."""
         smoother = DetectionsSmoother(length=2)
         smoother.update_with_detections(
             Detections(
@@ -207,10 +207,10 @@ class TestDetectionsSmoother:
 class TestDetectionsSmootherOrientedBoxes:
     """Oriented corners must be smoothed alongside `xyxy` (issue #2318).
 
-    Everything on the returned detection other than `xyxy` and `confidence` is
-    copied from the oldest frame in the window, so the oriented corners used to
-    describe a different position from the smoothed axis-aligned box beside
-    them. The geometry helpers that read `xyxyxyxy` then disagree with `xyxy`.
+    Everything on the returned detection other than `xyxy` and `confidence` is copied
+    from the oldest frame in the window, so the oriented corners used to describe a
+    different position from the smoothed axis-aligned box beside them. The geometry
+    helpers that read `xyxyxyxy` then disagree with `xyxy`.
     """
 
     @staticmethod

--- a/tests/detection/tools/test_transformers.py
+++ b/tests/detection/tools/test_transformers.py
@@ -282,7 +282,7 @@ class TestProcessTransformersV5PanopticSegmentationResult:
         np.testing.assert_array_equal(out["class_id"], expected_class_ids)
 
     def test_with_id2label_sets_class_names(self) -> None:
-        """id2label maps unique IDs to class name strings in output data."""
+        """Id2label maps unique IDs to class name strings in output data."""
         seg_array = np.array([[3, 3], [5, 5]], dtype=np.int64)
 
         out = process_transformers_v5_panoptic_segmentation_result(
@@ -294,7 +294,7 @@ class TestProcessTransformersV5PanopticSegmentationResult:
         )
 
     def test_with_id2label_preserves_zero_class_name(self) -> None:
-        """id2label maps class id zero when it appears in a tensor map."""
+        """Id2label maps class id zero when it appears in a tensor map."""
         seg_array = np.array([[0, 0], [1, 1]], dtype=np.int64)
 
         out = process_transformers_v5_panoptic_segmentation_result(

--- a/tests/detection/utils/test_boxes.py
+++ b/tests/detection/utils/test_boxes.py
@@ -625,7 +625,8 @@ def test_pad_boxes(
     ],
 )
 def test_obb_polygon_area_is_invariant_to_large_origins(origin: int) -> None:
-    """Area is exact for boxes at large coordinate origins.
+    """
+    Area is exact for boxes at large coordinate origins.
 
     Regression: the shoelace formula was evaluated on absolute coordinates, so
     large cross-products rounded once the origin grew. A 100x50 box at origin

--- a/tests/detection/utils/test_boxes.py
+++ b/tests/detection/utils/test_boxes.py
@@ -625,8 +625,7 @@ def test_pad_boxes(
     ],
 )
 def test_obb_polygon_area_is_invariant_to_large_origins(origin: int) -> None:
-    """
-    Area is exact for boxes at large coordinate origins.
+    """Area is exact for boxes at large coordinate origins.
 
     Regression: the shoelace formula was evaluated on absolute coordinates, so
     large cross-products rounded once the origin grew. A 100x50 box at origin

--- a/tests/detection/utils/test_internal.py
+++ b/tests/detection/utils/test_internal.py
@@ -549,7 +549,7 @@ def test_process_roboflow_result_invalid_polygon_is_box_only(
 
 
 def test_polygon_prediction_compact_masks_true() -> None:
-    """polygon prediction with compact_masks=True returns a CompactMask."""
+    """Polygon prediction with compact_masks=True returns a CompactMask."""
     roboflow_result = _result(
         _pred(
             yx=(2.5, 2.5),
@@ -573,7 +573,7 @@ def test_polygon_prediction_compact_masks_true() -> None:
 
 
 def test_box_only_compact_masks_true_returns_none_mask() -> None:
-    """box-only predictions with compact_masks=True yield None mask."""
+    """Box-only predictions with compact_masks=True yield None mask."""
     roboflow_result = _result(
         _pred(yx=(2.0, 2.0), size=(3.0, 3.0), class_name="cat"),
         img_w=5,

--- a/tests/detection/utils/test_iou_and_nms.py
+++ b/tests/detection/utils/test_iou_and_nms.py
@@ -1577,11 +1577,11 @@ def test_box_iou_batch_float64_input_precision_at_2pow24_boundary(
 ) -> None:
     """`float64`/`int64` inputs keep full precision at the `2**24` boundary.
 
-    `float64` accumulation is exact for these integer-valued coordinates, so the
-    result must match the analytic value. Two 50x50 boxes shifted by 25 in x give
-    intersection 25*50=1250 and union 2*2500-1250=3750, so IoU=1/3 and IoS=0.5.
-    This does not exercise the `float32`-storage case, which cannot be recovered
-    inside this function; it guards the `float64`/`int64` accumulation path only.
+    `float64` accumulation is exact for these integer-valued coordinates, so the result
+    must match the analytic value. Two 50x50 boxes shifted by 25 in x give intersection
+    25*50=1250 and union 2*2500-1250=3750, so IoU=1/3 and IoS=0.5. This does not
+    exercise the `float32`-storage case, which cannot be recovered inside this function;
+    it guards the `float64`/`int64` accumulation path only.
     """
     box_a, box_b = _boundary_box_pair(origin, dtype=np.float64)
 
@@ -1595,9 +1595,9 @@ def test_box_iou_batch_float64_input_precision_at_2pow24_boundary(
 def test_box_iou_batch_int32_input_does_not_overflow() -> None:
     """`int32` coordinates with large areas must not overflow to a wrong IoU.
 
-    A 60000x60000 box has area 3.6e9, which wraps to a negative value in `int32`.
-    Before upcasting the corners to `float64`, this made the union non-positive
-    and the function returned `0.0`; it must now return the analytic IoU of 1/3.
+    A 60000x60000 box has area 3.6e9, which wraps to a negative value in `int32`. Before
+    upcasting the corners to `float64`, this made the union non-positive and the
+    function returned `0.0`; it must now return the analytic IoU of 1/3.
     """
     side, shift = 60000, 30000
     box_a, box_b = _boundary_box_pair(0, side=side, shift=shift, dtype=np.int32)
@@ -1706,10 +1706,9 @@ def test_oriented_box_iou_batch_is_invariant_to_non_square_scaling(
 ) -> None:
     """IoU is invariant under per-axis (anisotropic) scaling.
 
-    An affine map multiplies every area — intersection and union alike — by the
-    same determinant, so exact polygon IoU is unchanged. Equality is exact
-    because the computation is rasterization-free; the analytic IoU of these two
-    rectangles is 0.25.
+    An affine map multiplies every area — intersection and union alike — by the same
+    determinant, so exact polygon IoU is unchanged. Equality is exact because the
+    computation is rasterization-free; the analytic IoU of these two rectangles is 0.25.
     """
     boxes_true = np.array([[[1, 0], [0, 1], [3, 4], [4, 3]]], dtype=np.float32)
     boxes_detection = np.array([[[1, 1], [2, 0], [4, 2], [3, 3]]], dtype=np.float32)
@@ -1739,9 +1738,10 @@ class TestOrientedBoxIouBatch:
     ) -> None:
         """IoU is invariant under uniform scaling and translation.
 
-        Both are affine maps, so exact polygon IoU matches the small-coordinate
-        baseline exactly — free of the pixel-quantization error that the prior
-        rasterization-based implementation exhibited."""
+        Both are affine maps, so exact polygon IoU matches the small-coordinate baseline
+        exactly — free of the pixel-quantization error that the prior rasterization-
+        based implementation exhibited.
+        """
         boxes_true = _rotated_rect(50, 50, 40, 20, 30)[None]
         boxes_detection = _rotated_rect(52, 48, 40, 20, 35)[None]
         baseline = oriented_box_iou_batch(boxes_true, boxes_detection)
@@ -1852,8 +1852,8 @@ class TestOrientedBoxIouBatch:
     def test_envelope_overlap_without_polygon_overlap_scores_zero(self) -> None:
         """Parallel rotated bars share an envelope but not a body, so they score 0.
 
-        Exercises the path where a pair passes the axis-aligned gate yet has no
-        exact polygon intersection.
+        Exercises the path where a pair passes the axis-aligned gate yet has no exact
+        polygon intersection.
         """
         boxes_true = _rotated_rect(50, 50, 100, 4, 45)[None]
         boxes_detection = _rotated_rect(72, 28, 100, 4, 45)[None]
@@ -1949,9 +1949,11 @@ class TestOrientedBoxNonMaxSuppression:
     """Tests for `oriented_box_non_max_suppression`."""
 
     def test_keeps_x_pattern(self) -> None:
-        """X-pattern: two thin rectangles crossing at +/-45° share an AABB but
-        barely overlap as OBBs. AABB-NMS would suppress one; OBB-NMS must keep
-        both."""
+        """X-pattern: two thin rectangles crossing at +/-45° share an AABB but barely
+        overlap as OBBs.
+
+        AABB-NMS would suppress one; OBB-NMS must keep both.
+        """
         quad_a = _rotated_rect(50, 50, 100, 10, +45)
         quad_b = _rotated_rect(50, 50, 100, 10, -45)
         oriented_boxes = np.stack([quad_a, quad_b])
@@ -1981,7 +1983,10 @@ class TestOrientedBoxNonMaxSuppression:
     def test_suppression_is_class_aware(
         self, class_id_b: int, expected_keep: list[bool]
     ) -> None:
-        """Same class: lower-score OBB suppressed. Different class: both kept."""
+        """Same class: lower-score OBB suppressed.
+
+        Different class: both kept.
+        """
         quad = _rotated_rect(50, 50, 100, 10, 45)
         shifted = _rotated_rect(51, 51, 100, 10, 45)
         oriented_boxes = np.stack([quad, shifted])
@@ -2001,8 +2006,8 @@ class TestOrientedBoxNonMaxSuppression:
         assert np.array_equal(keep, np.array(expected_keep))
 
     def test_length_mismatch_raises(self) -> None:
-        """Mismatched predictions and oriented_boxes must fail loudly, not
-        silently misalign rows."""
+        """Mismatched predictions and oriented_boxes must fail loudly, not silently
+        misalign rows."""
         predictions = np.zeros((3, 5), dtype=np.float32)
         oriented_boxes = np.zeros((2, 4, 2), dtype=np.float32)
         with pytest.raises(ValueError, match="same length"):
@@ -2130,8 +2135,8 @@ class TestOrientedBoxNonMaxMerge:
         assert groups == [[0]]
 
     def test_groups_overlapping_oriented_boxes(self) -> None:
-        """Two near-identical OBBs should be merged into one group; an X-pattern
-        pair should produce two separate groups."""
+        """Two near-identical OBBs should be merged into one group; an X-pattern pair
+        should produce two separate groups."""
         quad_dup_a = _rotated_rect(50, 50, 100, 10, 45)
         quad_dup_b = _rotated_rect(51, 51, 100, 10, 45)
         quad_x = _rotated_rect(50, 50, 100, 10, -45)
@@ -2375,7 +2380,7 @@ class TestMaskIouBatch:
         )
 
     def test_float64_promotion_for_large_float32_masks(self) -> None:
-        """float32 masks with pixel count > 2**24 must give exact IoU via float64."""
+        """Float32 masks with pixel count > 2**24 must give exact IoU via float64."""
         # 1x(2**24+1) pixels: float32 area sum rounds, float64 area sum is exact.
         # Without CRIT-2 fix, IoU would exceed 1.0 due to dtype mismatch.
         mask = np.ones((1, 1, 2**24 + 1), dtype=np.float32)
@@ -2397,7 +2402,7 @@ class TestMaskIouBatch:
         np.testing.assert_allclose(mask_iou_batch(masks, cm), dense_vs_dense, rtol=1e-5)
 
     def test_detection_exceeds_limit_warns_and_completes(self) -> None:
-        """detection > memory_limit emits UserWarning; result shape is still correct."""
+        """Detection > memory_limit emits UserWarning; result shape is still correct."""
         rng = np.random.default_rng(4)
         masks_true = rng.random((3, 32, 32)) > 0.5
         # 500 x 1024 px x 4 bytes ~2 MB > memory_limit=1 MB triggers OOM warning.

--- a/tests/draw/test_color.py
+++ b/tests/draw/test_color.py
@@ -58,8 +58,7 @@ from supervision.draw.color import Color, ColorPalette, unify_to_bgr
 def test_color_from_hex(
     color_hex, expected_result: Color | None, exception: Exception
 ) -> None:
-    """
-    Verify that Color.from_hex correctly parses various hex string formats.
+    """Verify that Color.from_hex correctly parses various hex string formats.
 
     Scenario: Creating a `Color` object from various hex string formats (3-, 4-, 6-,
     and 8-digit, with/without # prefix).
@@ -91,8 +90,7 @@ def test_color_from_hex(
 def test_color_as_hex(
     color: Color, expected_result: str | None, exception: Exception
 ) -> None:
-    """
-    Verify that Color.as_hex correctly converts Color objects to hex strings.
+    """Verify that Color.as_hex correctly converts Color objects to hex strings.
 
     Scenario: Converting a `Color` object back to a hex string.
     Expected: 6-digit hex (#RRGGBB) when alpha is 255, 8-digit hex (#RRGGBBAA)

--- a/tests/draw/test_utils.py
+++ b/tests/draw/test_utils.py
@@ -93,10 +93,11 @@ def test_draw_image_grayscale_array_raises_value_error() -> None:
 def test_draw_rounded_rectangle_square_matches_plain_rectangle(
     border_radius: int,
 ) -> None:
-    """Non-positive border_radius fills exactly the same pixels as a plain box.
+    """
+    Non-positive border_radius fills exactly the same pixels as a plain box.
 
-    For border_radius < 0: previously raised cv2.error: radius >= 0 in
-    function 'circle'; fast path now silently draws square corners instead.
+    For border_radius < 0: previously raised cv2.error: radius >= 0 in function
+    'circle'; fast path now silently draws square corners instead.
     """
     rect = Rect(x=20, y=30, width=120, height=80)
     scene = np.full((150, 200, 3), 17, dtype=np.uint8)
@@ -229,7 +230,7 @@ def test_draw_filled_rectangle_fills_interior() -> None:
 
 
 def test_draw_filled_rectangle_opacity_blends() -> None:
-    """opacity<1 blends the fill colour with the original background."""
+    """Opacity<1 blends the fill colour with the original background."""
     scene = np.zeros((50, 50, 3), dtype=np.uint8)
     draw_filled_rectangle(
         scene=scene,

--- a/tests/draw/test_utils.py
+++ b/tests/draw/test_utils.py
@@ -93,8 +93,7 @@ def test_draw_image_grayscale_array_raises_value_error() -> None:
 def test_draw_rounded_rectangle_square_matches_plain_rectangle(
     border_radius: int,
 ) -> None:
-    """
-    Non-positive border_radius fills exactly the same pixels as a plain box.
+    """Non-positive border_radius fills exactly the same pixels as a plain box.
 
     For border_radius < 0: previously raised cv2.error: radius >= 0 in function
     'circle'; fast path now silently draws square corners instead.

--- a/tests/geometry/test_core.py
+++ b/tests/geometry/test_core.py
@@ -34,8 +34,7 @@ def test_position_list_returns_enum_values_in_definition_order() -> None:
 def test_vector_cross_product(
     vector: Vector, point: Point, expected_result: float
 ) -> None:
-    """
-    Verify that Vector.cross_product correctly calculates the scalar value.
+    """Verify that Vector.cross_product correctly calculates the scalar value.
 
     Scenario: Computing the cross product between a vector and a point.
     Expected: Correct scalar value is returned, which is used to determine which side
@@ -67,8 +66,7 @@ def test_vector_cross_product(
     ],
 )
 def test_vector_magnitude(vector: Vector, expected_result: float) -> None:
-    """
-    Verify that Vector.magnitude correctly calculates Euclidean distance.
+    """Verify that Vector.magnitude correctly calculates Euclidean distance.
 
     Scenario: Calculating the magnitude (length) of a vector.
     Expected: Correct Euclidean distance between start and end points is returned,

--- a/tests/geometry/test_utils.py
+++ b/tests/geometry/test_utils.py
@@ -6,8 +6,7 @@ from supervision.geometry.utils import get_polygon_center
 
 
 def generate_test_polygon(n: int) -> np.ndarray:
-    """
-     Generate a semicircle with a given number of points.
+    """Generate a semicircle with a given number of points.
 
      Parameters:
          n (int): amount of points in polygon

--- a/tests/geometry/test_utils.py
+++ b/tests/geometry/test_utils.py
@@ -48,8 +48,7 @@ def generate_test_polygon(n: int) -> np.ndarray:
     ],
 )
 def test_get_polygon_center(polygon: np.ndarray, expected_result: Point) -> None:
-    """
-    Verify that get_polygon_center correctly calculates the centroid of a polygon.
+    """Verify that get_polygon_center correctly calculates the centroid of a polygon.
 
     Scenario: Calculating the center point (centroid) of various polygons.
     Expected: The returned `Point` correctly represents the average position of all

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,9 +1,8 @@
-"""
-Helper functions and utilities for testing the `supervision` library.
+"""Helper functions and utilities for testing the `supervision` library.
 
-This module provides convenient factory functions for creating `Detections`
-and `KeyPoints` objects from simple list-based inputs, as well as utilities
-for generating synthetic test data and performing custom assertions.
+This module provides convenient factory functions for creating `Detections` and
+`KeyPoints` objects from simple list-based inputs, as well as utilities for generating
+synthetic test data and performing custom assertions.
 """
 
 from __future__ import annotations
@@ -21,8 +20,8 @@ from supervision.key_points.core import KeyPoints
 def make_panoptic_png(segment_map: np.ndarray) -> bytes:
     """Encode a segment-ID array as a 24-bit RGBA PNG byte string.
 
-    Segment IDs are stored in RGB little-endian order so tests can cover
-    panoptic labels above 255 without collisions.
+    Segment IDs are stored in RGB little-endian order so tests can cover panoptic labels
+    above 255 without collisions.
     """
     segment_map_u32 = np.asarray(segment_map, dtype=np.uint32)
     arr = np.zeros((*segment_map_u32.shape, 4), dtype=np.uint8)
@@ -43,8 +42,7 @@ def _create_detections(
     tracker_id: list[int] | None = None,
     data: dict[str, list[Any]] | None = None,
 ) -> Detections:
-    """
-    Create a Detections object from list-based inputs.
+    """Create a Detections object from list-based inputs.
 
     This is a helper function primarily used for testing purposes to quickly
     instantiate a Detections object without manually converting lists to numpy arrays.
@@ -103,8 +101,7 @@ def _create_key_points(
     visible: list[list[bool]] | None = None,
     data: dict[str, list[Any]] | None = None,
 ) -> KeyPoints:
-    """
-    Create a KeyPoints object from list-based inputs.
+    """Create a KeyPoints object from list-based inputs.
 
     This is a helper function primarily used for testing purposes to quickly
     instantiate a KeyPoints object without manually converting lists to numpy arrays.
@@ -167,8 +164,8 @@ def _generate_random_boxes(
     max_box_size: int = 200,
     seed: int | None = None,
 ) -> np.ndarray:
-    """
-    Generate random bounding boxes within given image dimensions and size constraints.
+    """Generate random bounding boxes within given image dimensions and size
+    constraints.
 
     Creates `count` bounding boxes randomly positioned and sized, ensuring each
     stays within image bounds and has width and height in the specified range.
@@ -214,8 +211,7 @@ def _generate_random_boxes(
 
 
 def assert_almost_equal(actual, expected, tolerance=1e-5) -> None:
-    """
-    Assert that two values are equal within a specified tolerance.
+    """Assert that two values are equal within a specified tolerance.
 
     Args:
         actual: The value to check.
@@ -237,8 +233,7 @@ def assert_almost_equal(actual, expected, tolerance=1e-5) -> None:
 def assert_image_mostly_same(
     original: np.ndarray, annotated: np.ndarray, similarity_threshold: float = 0.9
 ) -> None:
-    """
-    Assert that the annotated image is mostly the same as the original.
+    """Assert that the annotated image is mostly the same as the original.
 
     Args:
         original: Original image
@@ -439,8 +434,7 @@ def create_yolo_dataset(
     objects_per_image_range: tuple[int, int] = (2, 4),
     seed: int = 42,
 ) -> dict[str, Any]:
-    """
-    Create a synthetic YOLO-format dataset on disk.
+    """Create a synthetic YOLO-format dataset on disk.
 
     Generates dummy images with YOLO-format annotations, `data.yaml` file,
     and directory structure suitable for testing dataset loading.
@@ -652,8 +646,7 @@ class _FakeNCNNObject:
 def create_predictions_with_class_iou_tests(
     gt_detections: Detections, num_classes: int
 ) -> Detections:
-    """
-    Create predictions that test IoU+class matching behavior.
+    """Create predictions that test IoU+class matching behavior.
 
     For each ground truth detection, creates predictions with different patterns:
     - Pattern 0 (i%3==0): Correct match (same bbox, correct class)

--- a/tests/key_points/test_annotators.py
+++ b/tests/key_points/test_annotators.py
@@ -207,14 +207,14 @@ class TestEdgeAnnotator:
 
 
 class TestVertexEllipseAnnotator:
-    """
-    Verify that VertexEllipseAnnotator draws filled semi-transparent
-    covariance ellipses around keypoints.
+    """Verify that VertexEllipseAnnotator draws filled semi-transparent covariance
+    ellipses around keypoints.
     """
 
     def test_annotate_with_covariance_data(self, scene, sample_key_points):
         """
         Scenario: Annotating keypoints with per-point covariance matrices.
+
         Expected: Scene is modified with filled ellipses at keypoint locations.
         """
         covariance = np.tile(
@@ -236,6 +236,7 @@ class TestVertexEllipseAnnotator:
     def test_annotate_empty_key_points(self, scene, empty_key_points):
         """
         Scenario: Annotating a scene with no keypoints.
+
         Expected: Original scene is returned untouched.
         """
         annotator = sv.VertexEllipseAnnotator()
@@ -246,6 +247,7 @@ class TestVertexEllipseAnnotator:
     def test_annotate_missing_covariance_data_raises(self, scene, sample_key_points):
         """
         Scenario: Annotating non-empty keypoints without covariance data.
+
         Expected: Clear error explaining the expected data field.
         """
         annotator = sv.VertexEllipseAnnotator()
@@ -256,6 +258,7 @@ class TestVertexEllipseAnnotator:
     def test_annotate_invalid_covariance_shape_raises(self, scene, sample_key_points):
         """
         Scenario: Covariance data does not match keypoint dimensions.
+
         Expected: Clear shape validation error.
         """
         sample_key_points.data["covariance"] = np.zeros((1, 1, 2, 2), dtype=np.float32)

--- a/tests/key_points/test_annotators.py
+++ b/tests/key_points/test_annotators.py
@@ -7,16 +7,15 @@ from tests.helpers import assert_image_mostly_same
 
 
 class TestVertexAnnotator:
-    """
-    Verify that VertexAnnotator correctly draws keypoints on an image.
+    """Verify that VertexAnnotator correctly draws keypoints on an image.
 
     Ensures that `VertexAnnotator` correctly draws keypoints (vertices) on an image,
     which is essential for human pose estimation or similar tasks.
     """
 
     def test_annotate_with_default_parameters(self, scene, sample_key_points):
-        """
-        Verify that VertexAnnotator correctly draws keypoints with default parameters.
+        """Verify that VertexAnnotator correctly draws keypoints with default
+        parameters.
 
         Scenario: Annotating a scene using default vertex parameters.
         Expected: Scene is modified, showing keypoints at their detected locations.
@@ -33,8 +32,7 @@ class TestVertexAnnotator:
         )
 
     def test_annotate_with_custom_color_and_radius(self, scene, sample_key_points):
-        """
-        Verify that VertexAnnotator respects custom color and radius settings.
+        """Verify that VertexAnnotator respects custom color and radius settings.
 
         Scenario: Annotating a scene with user-specified color and radius.
         Expected: Scene is modified according to custom style, allowing users to
@@ -54,8 +52,8 @@ class TestVertexAnnotator:
         )
 
     def test_annotate_empty_key_points(self, scene, empty_key_points):
-        """
-        Verify that VertexAnnotator handles empty keypoints without modifying the scene.
+        """Verify that VertexAnnotator handles empty keypoints without modifying the
+        scene.
 
         Scenario: Annotating a scene with no key points detected.
         Expected: Original scene is returned untouched, preventing phantom annotations.
@@ -97,16 +95,14 @@ class TestVertexAnnotator:
 
 
 class TestEdgeAnnotator:
-    """
-    Verify that EdgeAnnotator correctly draws skeleton edges between keypoints.
+    """Verify that EdgeAnnotator correctly draws skeleton edges between keypoints.
 
     Ensures that `EdgeAnnotator` correctly draws connections (edges) between keypoints,
     forming skeletons that help users interpret spatial relationships.
     """
 
     def test_annotate_with_default_parameters(self, scene, sample_key_points):
-        """
-        Verify correctly draw skeleton edges with default parameters.
+        """Verify correctly draw skeleton edges with default parameters.
 
         Scenario: Annotating a scene with default skeleton (e.g., COCO).
         Expected: Skeleton edges are drawn between corresponding keypoints.
@@ -120,8 +116,7 @@ class TestEdgeAnnotator:
         )
 
     def test_annotate_with_custom_edges(self, scene, sample_key_points):
-        """
-        Verify that EdgeAnnotator respects custom-defined skeleton structures.
+        """Verify that EdgeAnnotator respects custom-defined skeleton structures.
 
         Scenario: Annotating a scene with a custom-defined skeleton structure.
         Expected: Only the specified connections are drawn, giving users flexibility
@@ -137,8 +132,8 @@ class TestEdgeAnnotator:
         )
 
     def test_annotate_empty_key_points(self, scene, empty_key_points):
-        """
-        Verify that EdgeAnnotator handles empty keypoints without modifying the scene.
+        """Verify that EdgeAnnotator handles empty keypoints without modifying the
+        scene.
 
         Scenario: Annotating a scene with no key points for edge drawing.
         Expected: Original scene is returned untouched.
@@ -188,8 +183,7 @@ class TestEdgeAnnotator:
             annotator.annotate(scene=scene.copy(), key_points=key_points)
 
     def test_annotate_no_edges_found(self, scene):
-        """
-        Verify returning unmodified scene when no known skeleton matches.
+        """Verify returning unmodified scene when no known skeleton matches.
 
         Scenario: Key points provided don't match any known or provided skeleton.
         Expected: No edges are drawn, and the original scene is returned, avoiding
@@ -208,12 +202,10 @@ class TestEdgeAnnotator:
 
 class TestVertexEllipseAnnotator:
     """Verify that VertexEllipseAnnotator draws filled semi-transparent covariance
-    ellipses around keypoints.
-    """
+    ellipses around keypoints."""
 
     def test_annotate_with_covariance_data(self, scene, sample_key_points):
-        """
-        Scenario: Annotating keypoints with per-point covariance matrices.
+        """Scenario: Annotating keypoints with per-point covariance matrices.
 
         Expected: Scene is modified with filled ellipses at keypoint locations.
         """
@@ -234,8 +226,7 @@ class TestVertexEllipseAnnotator:
         assert not np.array_equal(result, scene)
 
     def test_annotate_empty_key_points(self, scene, empty_key_points):
-        """
-        Scenario: Annotating a scene with no keypoints.
+        """Scenario: Annotating a scene with no keypoints.
 
         Expected: Original scene is returned untouched.
         """
@@ -245,8 +236,7 @@ class TestVertexEllipseAnnotator:
         assert np.array_equal(result, scene)
 
     def test_annotate_missing_covariance_data_raises(self, scene, sample_key_points):
-        """
-        Scenario: Annotating non-empty keypoints without covariance data.
+        """Scenario: Annotating non-empty keypoints without covariance data.
 
         Expected: Clear error explaining the expected data field.
         """
@@ -256,8 +246,7 @@ class TestVertexEllipseAnnotator:
             annotator.annotate(scene=scene.copy(), key_points=sample_key_points)
 
     def test_annotate_invalid_covariance_shape_raises(self, scene, sample_key_points):
-        """
-        Scenario: Covariance data does not match keypoint dimensions.
+        """Scenario: Covariance data does not match keypoint dimensions.
 
         Expected: Clear shape validation error.
         """

--- a/tests/key_points/test_core.py
+++ b/tests/key_points/test_core.py
@@ -1954,8 +1954,8 @@ class TestFromMediapipeHandedness:
     def test_omits_handedness_when_absent(self):
         """Hand results without handedness keep `class_id` and `data` unset.
 
-        Older callers and partial mocks supply landmarks alone; reading handedness
-        must stay optional rather than raising on the missing attribute.
+        Older callers and partial mocks supply landmarks alone; reading handedness must
+        stay optional rather than raising on the missing attribute.
         """
         mediapipe_results = _FakeMediapipeResults(hand_landmarks=_hand_landmarks(1))
 
@@ -2001,8 +2001,8 @@ class TestFromMediapipeHandedness:
     def test_leaves_pose_results_untouched(self):
         """Pose results keep their existing `class_id`/`data` behaviour.
 
-        Handedness handling is additive for hand branches only; this pins that the
-        pose path did not inherit an empty-but-present data field or a class id.
+        Handedness handling is additive for hand branches only; this pins that the pose
+        path did not inherit an empty-but-present data field or a class id.
         """
         mediapipe_results = _FakeMediapipeResults(
             pose_landmarks=_FakeMediapipePose(

--- a/tests/key_points/test_skeletons.py
+++ b/tests/key_points/test_skeletons.py
@@ -102,9 +102,9 @@ class TestSkeletons:
         """Test MediaPipe hand skeleton follows expected palm and finger connections.
 
         The palm is the closing knuckle arch defined by MediaPipe's
-        `HAND_PALM_CONNECTIONS`, not a spoke-fan from the wrist: the wrist links
-        only to the thumb, index and pinky bases, and the knuckles chain across.
-        Asserted against the independently-transcribed `HAND` tuple above, not
-        imported from `skeletons.py`, so this fails loudly on a regression there.
+        `HAND_PALM_CONNECTIONS`, not a spoke-fan from the wrist: the wrist links only to
+        the thumb, index and pinky bases, and the knuckles chain across. Asserted
+        against the independently-transcribed `HAND` tuple above, not imported from
+        `skeletons.py`, so this fails loudly on a regression there.
         """
         assert Skeleton.HAND.value == HAND

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -146,8 +146,7 @@ def _yolo_dataset_factory(
     classes: list[str] | None = None,
     objects_per_image_range: tuple[int, int] = (1, 3),
 ):
-    """
-    Factory function to create synthetic YOLO-format datasets with custom parameters.
+    """Factory function to create synthetic YOLO-format datasets with custom parameters.
 
     Args:
         tmp_path: Pytest tmp_path fixture
@@ -175,8 +174,7 @@ def _yolo_dataset_factory(
 
 @pytest.fixture
 def yolo_dataset_structure(tmp_path):
-    """
-    Synthetic YOLO-format dataset for testing confusion matrix and detection metrics.
+    """Synthetic YOLO-format dataset for testing confusion matrix and detection metrics.
 
     Configuration:
     - 20 images
@@ -199,8 +197,7 @@ def yolo_dataset_structure(tmp_path):
 
 @pytest.fixture
 def yolo_dataset_two_classes(tmp_path):
-    """
-    Synthetic YOLO-format dataset for testing mAR and binary classification metrics.
+    """Synthetic YOLO-format dataset for testing mAR and binary classification metrics.
 
     Configuration:
     - 15 images

--- a/tests/metrics/test_detection.py
+++ b/tests/metrics/test_detection.py
@@ -64,8 +64,7 @@ def _call_confusion_matrix_evaluate_detection_batch_masks() -> None:
 
 
 class TestDetectionMetrics:
-    """
-    Verify that detection metrics are computed accurately.
+    """Verify that detection metrics are computed accurately.
 
     Ensures that detection metrics (mAP, Conf. Matrix, etc.) are computed accurately.
     These metrics are the primary way users evaluate the performance of their models
@@ -370,8 +369,7 @@ class TestDetectionMetrics:
         expected_result: np.ndarray | None,
         exception: Exception,
     ) -> None:
-        """
-        Verify that Detections objects are correctly converted to NumPy tensors.
+        """Verify that Detections objects are correctly converted to NumPy tensors.
 
         Scenario: Converting Detections objects to NumPy tensors.
         Expected: Tensors are correctly formatted for consumption by metric functions,
@@ -654,8 +652,7 @@ class TestDetectionMetrics:
         expected_result: float,
         exception: Exception,
     ) -> None:
-        """
-        Verify that Average Precision is correctly calculated from PR curve points.
+        """Verify that Average Precision is correctly calculated from PR curve points.
 
         Scenario: Computing Average Precision (AP) from PR curve points.
         Expected: AP is correctly calculated using the area under the curve, which is
@@ -1156,8 +1153,7 @@ class TestDetectionMetrics:
         np.testing.assert_array_equal(confusion_matrix.matrix, expected_result)
 
     def test_confusion_matrix_on_yolo_dataset(self, yolo_dataset_structure) -> None:
-        """
-        Test confusion matrix calculation on a YOLO-format dataset.
+        """Test confusion matrix calculation on a YOLO-format dataset.
 
         This test verifies that the confusion matrix fix (considering both IoU AND class
         agreement) works correctly when applied to a dataset loaded from roboflow-format
@@ -1346,8 +1342,7 @@ class TestDetectionMetrics:
             _validate_input_tensors(predictions, targets, metric_target=metric_target)
 
     def test_confusion_matrix_obb(self):
-        """
-        Verify OBB support in ConfusionMatrix.
+        """Verify OBB support in ConfusionMatrix.
 
         Test scenarios:
         1. Perfect OBB overlap (Rotation Match)

--- a/tests/metrics/test_detection.py
+++ b/tests/metrics/test_detection.py
@@ -1159,11 +1159,11 @@ class TestDetectionMetrics:
         """
         Test confusion matrix calculation on a YOLO-format dataset.
 
-        This test verifies that the confusion matrix fix (considering both IoU AND
-        class agreement) works correctly when applied to a dataset loaded from
-        roboflow-format YOLO data. It creates a synthetic dataset with specific
-        scenarios where predictions have high IoU but wrong class, ensuring only
-        predictions with correct class are matched.
+        This test verifies that the confusion matrix fix (considering both IoU AND class
+        agreement) works correctly when applied to a dataset loaded from roboflow-format
+        YOLO data. It creates a synthetic dataset with specific scenarios where
+        predictions have high IoU but wrong class, ensuring only predictions with
+        correct class are matched.
         """
         dataset_info = yolo_dataset_structure
         classes = ["dog", "cat", "person"]
@@ -1348,6 +1348,7 @@ class TestDetectionMetrics:
     def test_confusion_matrix_obb(self):
         """
         Verify OBB support in ConfusionMatrix.
+
         Test scenarios:
         1. Perfect OBB overlap (Rotation Match)
         2. Rotation Sensitivity (Same AABB, different rotation)
@@ -1891,7 +1892,7 @@ class TestConfusionMatrixPlot:
         ],
     )
     def test_plot_returns_figure(self, normalize: bool) -> None:
-        """plot() must not crash on the integer matrix produced by from_tensors."""
+        """Plot() must not crash on the integer matrix produced by from_tensors."""
         targets = [
             np.array(
                 [

--- a/tests/metrics/test_f1_score.py
+++ b/tests/metrics/test_f1_score.py
@@ -40,7 +40,7 @@ class TestF1Score:
         )
 
     def test_initialization_default(self):
-        """Test that F1Score can be initialized with default parameters"""
+        """Test that F1Score can be initialized with default parameters."""
         metric = F1Score()
         assert metric._metric_target == MetricTarget.BOXES
         assert metric.averaging_method == AveragingMethod.WEIGHTED
@@ -48,7 +48,7 @@ class TestF1Score:
         assert metric._targets_list == []
 
     def test_initialization_custom(self):
-        """Test that F1Score can be initialized with custom parameters"""
+        """Test that F1Score can be initialized with custom parameters."""
         metric = F1Score(
             metric_target=MetricTarget.MASKS,
             averaging_method=AveragingMethod.MACRO,
@@ -92,7 +92,7 @@ class TestF1Score:
         assert r_dense.f1_50 == pytest.approx(r_compact.f1_50)
 
     def test_reset(self, dummy_prediction):
-        """Test that reset() clears all stored data"""
+        """Test that reset() clears all stored data."""
         metric = F1Score()
 
         # Add some dummy data
@@ -108,7 +108,7 @@ class TestF1Score:
         assert metric._targets_list == []
 
     def test_perfect_match(self, detections_50_50, targets_50_50):
-        """Test F1 score with perfect matching predictions and targets"""
+        """Test F1 score with perfect matching predictions and targets."""
         metric = F1Score()
         result = metric.update(detections_50_50, targets_50_50).compute()
 
@@ -123,7 +123,7 @@ class TestF1Score:
         assert result.matched_classes[0] == 0
 
     def test_no_overlap(self, predictions_no_overlap, targets_no_overlap):
-        """Test F1 score with predictions that don't overlap with targets"""
+        """Test F1 score with predictions that don't overlap with targets."""
         metric = F1Score()
         result = metric.update(predictions_no_overlap, targets_no_overlap).compute()
 
@@ -135,7 +135,7 @@ class TestF1Score:
         assert result.f1_75 == 0.0
 
     def test_empty_predictions(self, targets_50_50):
-        """Test F1 score with empty predictions but existing targets"""
+        """Test F1 score with empty predictions but existing targets."""
         predictions = Detections.empty()
 
         metric = F1Score()
@@ -149,7 +149,7 @@ class TestF1Score:
         assert result.f1_75 == 0.0
 
     def test_empty_targets(self, detections_50_50):
-        """Test F1 score with predictions but no targets"""
+        """Test F1 score with predictions but no targets."""
         targets = Detections.empty()
 
         metric = F1Score()
@@ -223,8 +223,8 @@ class TestF1Score:
         ],
     )
     def test_false_positives_of_absent_class_counted(self, method, expected):
-        """Predictions of absent class count as FPs under MICRO/MACRO; WEIGHTED
-        excludes them by design (GT support=0 → weight=0, consistent with sklearn)."""
+        """Predictions of absent class count as FPs under MICRO/MACRO; WEIGHTED excludes
+        them by design (GT support=0 → weight=0, consistent with sklearn)."""
         predictions = Detections(
             xyxy=np.array(
                 [[0, 0, 10, 10], [100, 0, 110, 10], [120, 0, 130, 10]], np.float32
@@ -262,7 +262,7 @@ class TestF1Score:
     def test_single_class_mixed_results(
         self, predictions_confidence_ranking, targets_50_50
     ):
-        """Test F1 score calculation with mixed precision and recall"""
+        """Test F1 score calculation with mixed precision and recall."""
         metric = F1Score()
         result = metric.update(predictions_confidence_ranking, targets_50_50).compute()
 
@@ -277,7 +277,7 @@ class TestF1Score:
     def test_precision_recall_imbalance(
         self, detections_50_50, targets_two_objects_class_0
     ):
-        """Test F1 score with different precision and recall scenarios"""
+        """Test F1 score with different precision and recall scenarios."""
         metric = F1Score()
         result = metric.update(detections_50_50, targets_two_objects_class_0).compute()
 
@@ -292,7 +292,7 @@ class TestF1Score:
     def test_multiple_classes(
         self, predictions_multiple_classes, targets_multiple_classes
     ):
-        """Test F1 score calculation for multiple classes"""
+        """Test F1 score calculation for multiple classes."""
         metric = F1Score()
         result = metric.update(
             predictions_multiple_classes, targets_multiple_classes
@@ -308,7 +308,7 @@ class TestF1Score:
         assert 1 in result.matched_classes
 
     def test_different_iou_thresholds(self, predictions_iou_064, targets_iou_064):
-        """Test F1 score at different IoU thresholds"""
+        """Test F1 score at different IoU thresholds."""
         metric = F1Score()
         result = metric.update(predictions_iou_064, targets_iou_064).compute()
 
@@ -319,7 +319,7 @@ class TestF1Score:
         assert result.f1_75 == 0.0
 
     def test_confidence_ranking(self, predictions_confidence_ranking, targets_50_50):
-        """Test that F1 score respects confidence ranking"""
+        """Test that F1 score respects confidence ranking."""
         metric = F1Score()
         result = metric.update(predictions_confidence_ranking, targets_50_50).compute()
 
@@ -333,7 +333,7 @@ class TestF1Score:
     def test_list_inputs(
         self, detections_50_50, targets_50_50, prediction_class_1, target_class_1
     ):
-        """Test F1 score with list inputs"""
+        """Test F1 score with list inputs."""
         metric = F1Score()
         result = metric.update(
             [detections_50_50, prediction_class_1], [targets_50_50, target_class_1]
@@ -344,7 +344,7 @@ class TestF1Score:
         assert result.f1_75 == 1.0
 
     def test_mismatched_list_lengths(self, detections_50_50, targets_50_50):
-        """Test that mismatched prediction/target list lengths raise error"""
+        """Test that mismatched prediction/target list lengths raise error."""
         metric = F1Score()
 
         # Should raise ValueError for mismatched lengths
@@ -395,7 +395,7 @@ class TestF1Score:
         [AveragingMethod.MACRO, AveragingMethod.MICRO, AveragingMethod.WEIGHTED],
     )
     def test_averaging_methods(self, averaging_method, detections_50_50, targets_50_50):
-        """Test different averaging methods"""
+        """Test different averaging methods."""
         metric = F1Score(averaging_method=averaging_method)
         result = metric.update(detections_50_50, targets_50_50).compute()
 
@@ -406,7 +406,7 @@ class TestF1Score:
     def test_macro_averaging(
         self, predictions_multiple_classes, targets_multiple_classes
     ):
-        """Test MACRO averaging with specific example"""
+        """Test MACRO averaging with specific example."""
         metric = F1Score(averaging_method=AveragingMethod.MACRO)
         result = metric.update(
             predictions_multiple_classes, targets_multiple_classes
@@ -419,7 +419,7 @@ class TestF1Score:
     def test_micro_averaging(
         self, predictions_multiple_classes, targets_multiple_classes
     ):
-        """Test MICRO averaging with specific example"""
+        """Test MICRO averaging with specific example."""
         metric = F1Score(averaging_method=AveragingMethod.MICRO)
         result = metric.update(
             predictions_multiple_classes, targets_multiple_classes
@@ -432,7 +432,7 @@ class TestF1Score:
     def test_weighted_averaging(
         self, predictions_multiple_classes, targets_multiple_classes
     ):
-        """Test WEIGHTED averaging with specific example"""
+        """Test WEIGHTED averaging with specific example."""
         metric = F1Score(averaging_method=AveragingMethod.WEIGHTED)
         result = metric.update(
             predictions_multiple_classes, targets_multiple_classes
@@ -463,12 +463,12 @@ class TestF1Score:
         assert result.f1_50 == 1.0
 
     def test_compute_no_runtime_warning_for_zero_denominator_bucket(self) -> None:
-        """compute() must not emit RuntimeWarning when a size bucket has a
-        zero true-positive/false-positive/false-negative denominator.
+        """Compute() must not emit RuntimeWarning when a size bucket has a zero true-
+        positive/false-positive/false-negative denominator.
 
-        Regression test for #2434: a single medium-sized match leaves the
-        small-object bucket with an all-zero confusion-matrix row, which used
-        to trigger a spurious `invalid value encountered in divide` warning.
+        Regression test for #2434: a single medium-sized match leaves the small-object
+        bucket with an all-zero confusion-matrix row, which used to trigger a spurious
+        `invalid value encountered in divide` warning.
         """
         predictions = Detections(
             xyxy=np.array([[0, 0, 31, 31]], dtype=np.float32),
@@ -489,8 +489,8 @@ class TestF1Score:
 
 
 class TestComputeF1:
-    """Direct coverage of `F1Score._compute_f1`, the broadcastable helper that
-    turns a confusion matrix into per-element F1 scores."""
+    """Direct coverage of `F1Score._compute_f1`, the broadcastable helper that turns a
+    confusion matrix into per-element F1 scores."""
 
     @pytest.mark.parametrize(
         ("confusion_matrix", "expected_f1"),
@@ -520,10 +520,9 @@ class TestComputeF1:
     def test_compute_f1_matches_expected_score_without_warning(
         self, confusion_matrix, expected_f1
     ) -> None:
-        """_compute_f1 returns the expected score and never emits
-        RuntimeWarning, including for confusion matrix rows whose
-        true-positive/false-positive/false-negative denominator is zero.
-        """
+        """_compute_f1 returns the expected score and never emits RuntimeWarning,
+        including for confusion matrix rows whose true-positive/false-positive/false-
+        negative denominator is zero."""
         with warnings.catch_warnings():
             warnings.simplefilter("error", RuntimeWarning)
             f1_score = F1Score._compute_f1(confusion_matrix)
@@ -531,9 +530,8 @@ class TestComputeF1:
         assert f1_score == pytest.approx(expected_f1)
 
     def test_compute_f1_raises_value_error_for_wrong_last_dimension(self) -> None:
-        """_compute_f1 raises ValueError when the input's last axis isn't
-        length 3 (true positives, false positives, false negatives).
-        """
+        """_compute_f1 raises ValueError when the input's last axis isn't length 3 (true
+        positives, false positives, false negatives)."""
         confusion_matrix = np.zeros((2, 2))
 
         with pytest.raises(ValueError, match="Confusion matrix must have shape"):

--- a/tests/metrics/test_mean_average_precision.py
+++ b/tests/metrics/test_mean_average_precision.py
@@ -45,7 +45,7 @@ class TestMeanAveragePrecision:
         assert abs(result.map50_95 - 1.0) < 1e-6
 
     def test_multiple_perfect_detections(self):
-        """Test that multiple perfect detections get 1.0 mAP"""
+        """Test that multiple perfect detections get 1.0 mAP."""
         # Multiple perfect detections in one image
         detections = Detections(
             xyxy=np.array(
@@ -90,7 +90,7 @@ class TestMeanAveragePrecision:
         assert abs(result.map50_95 - 1.0) < 1e-6
 
     def test_batch_updates_perfect_detections(self, detections_50_50, targets_50_50):
-        """Test that batch updates with perfect detections get 1.0 mAP"""
+        """Test that batch updates with perfect detections get 1.0 mAP."""
         metric = MeanAveragePrecision()
         # Add 3 batch updates
         metric.update([detections_50_50], [targets_50_50])
@@ -102,7 +102,7 @@ class TestMeanAveragePrecision:
         assert abs(result.map50_95 - 1.0) < 1e-6
 
     def test_scenario_1_success_case_imperfect_match(self):
-        """Scenario 1: Success Case with imperfect match"""
+        """Scenario 1: Success Case with imperfect match."""
         # Small object (class 0) - area = 30*30 = 900 < 1024
         small_perfect = Detections(
             xyxy=np.array([[10, 10, 40, 40]], dtype=np.float64),
@@ -312,7 +312,7 @@ class TestMeanAveragePrecision:
     def test_mixed_classes_with_missing_detections(
         self, detections_50_50, targets_50_50
     ):
-        """Test mixed scenario with some classes having no detections"""
+        """Test mixed scenario with some classes having no detections."""
         # Class 1: GT exists but no prediction
         class_1_target = Detections(
             xyxy=np.array([[60, 60, 100, 100]], dtype=np.float64),
@@ -340,7 +340,7 @@ class TestMeanAveragePrecision:
         assert result.map50_95 < 1.0
 
     def test_empty_predictions_and_targets(self):
-        """Test completely empty predictions and targets"""
+        """Test completely empty predictions and targets."""
         metric = MeanAveragePrecision()
         metric.update([Detections.empty()], [Detections.empty()])
         result = metric.compute()
@@ -478,8 +478,8 @@ class TestMeanAveragePrecisionOrientedBoundingBoxes:
     def test_cross_matched_obb_orients_iou_correctly(self) -> None:
         """2x2 cross-match: pred0->target1, pred1->target0 must both score as TP.
 
-        A transposed (gt, dt) matrix would yield 0 IoU for every pair; map50=0.
-        Passing asserts the (dt, gt) orientation is correct end-to-end.
+        A transposed (gt, dt) matrix would yield 0 IoU for every pair; map50=0. Passing
+        asserts the (dt, gt) orientation is correct end-to-end.
         """
         box_tl = np.array([[0, 0], [10, 0], [10, 10], [0, 10]], dtype=np.float32)
         box_br = np.array([[20, 20], [30, 20], [30, 30], [20, 30]], dtype=np.float32)
@@ -599,8 +599,8 @@ class TestMeanAveragePrecisionMasksOrientation:
     def test_cross_matched_masks_orient_iou_correctly(self) -> None:
         """2x2 cross-match: pred0->target1, pred1->target0 must both score as TP.
 
-        A transposed (gt, dt) matrix would yield 0 IoU for every pair; map50=0.
-        Passing asserts the (dt, gt) orientation is correct end-to-end.
+        A transposed (gt, dt) matrix would yield 0 IoU for every pair; map50=0. Passing
+        asserts the (dt, gt) orientation is correct end-to-end.
         """
         top_mask = np.zeros((1, 32, 32), dtype=bool)
         top_mask[0, :16, :] = True

--- a/tests/metrics/test_mean_average_recall.py
+++ b/tests/metrics/test_mean_average_recall.py
@@ -8,8 +8,7 @@ from supervision.metrics import MeanAverageRecall, MetricTarget
 
 @pytest.fixture
 def complex_scenario_targets():
-    """
-    Ground truth for complex multi-image scenario.
+    """Ground truth for complex multi-image scenario.
 
     15 images with varying object counts and classes.
     Total: class_0=17, class_1=19 objects.
@@ -146,8 +145,7 @@ def complex_scenario_targets():
 
 @pytest.fixture
 def complex_scenario_predictions():
-    """
-    Predictions for complex multi-image scenario.
+    """Predictions for complex multi-image scenario.
 
     15 images with varying detection quality:
     - True positives, false positives, false negatives
@@ -285,8 +283,7 @@ def complex_scenario_predictions():
 
 @pytest.fixture
 def two_class_two_image_detections():
-    """
-    Scenario: 2 images with 2 classes with varying confidence levels.
+    """Scenario: 2 images with 2 classes with varying confidence levels.
 
     Tests that `mAR @ K` limits per image (not per class) by creating a case where
     the highest confidence detection differs between images.
@@ -700,8 +697,7 @@ def test_three_class_single_image_scenario(three_class_single_image_detections) 
 
 
 def test_dataset_split_integration(yolo_dataset_two_classes) -> None:
-    """
-    Test mAR with a roboflow-format dataset loaded from disk.
+    """Test mAR with a roboflow-format dataset loaded from disk.
 
     Uses a synthetic YOLO-format dataset loaded via DetectionDataset.from_yolo()
     to validate that the mAR metric works correctly with dataset splits - an
@@ -782,8 +778,7 @@ def test_dataset_split_integration(yolo_dataset_two_classes) -> None:
 
 
 def test_greedy_matching_two_valid_pairs():
-    """
-    Greedy matching finds both TPs; np.unique style missed the second pair.
+    """Greedy matching finds both TPs; np.unique style missed the second pair.
 
     IoU matrix: [[1.0, 0.667], [0.333, 0.538]]. At iou>=0.5 the optimal
     assignment is T0<->P0 and T1<->P1. mAR@100 at iou=0.5 is 1.0.

--- a/tests/metrics/test_mean_average_recall.py
+++ b/tests/metrics/test_mean_average_recall.py
@@ -595,8 +595,7 @@ def test_complex_integration_scenario(
 def test_mar_at_k_limits_per_image_not_per_class(
     two_class_two_image_detections,
 ) -> None:
-    """
-    Test that `mAR @ K` limits detections per image, not per class.
+    """Test that `mAR @ K` limits detections per image, not per class.
 
     BUG SCENARIO (what was wrong):
     The previous implementation would limit detections per CLASS per image,

--- a/tests/metrics/test_mean_average_recall.py
+++ b/tests/metrics/test_mean_average_recall.py
@@ -782,7 +782,8 @@ def test_dataset_split_integration(yolo_dataset_two_classes) -> None:
 
 
 def test_greedy_matching_two_valid_pairs():
-    """Greedy matching finds both TPs; np.unique style missed the second pair.
+    """
+    Greedy matching finds both TPs; np.unique style missed the second pair.
 
     IoU matrix: [[1.0, 0.667], [0.333, 0.538]]. At iou>=0.5 the optimal
     assignment is T0<->P0 and T1<->P1. mAR@100 at iou=0.5 is 1.0.

--- a/tests/metrics/test_oriented_bounding_box_metrics.py
+++ b/tests/metrics/test_oriented_bounding_box_metrics.py
@@ -49,7 +49,8 @@ def test_perfect_non_square_oriented_boxes_score_as_perfect(
 
 def test_mean_average_precision_accepts_obb_metric_target() -> None:
     """MeanAveragePrecision routes metric_target=ORIENTED_BOUNDING_BOXES through
-    oriented_box_iou_batch; perfect OBB predictions score 1.0."""
+    oriented_box_iou_batch; perfect OBB predictions score 1.0.
+    """
     predictions = _non_square_obb_detections(confidence=True)
     targets = _non_square_obb_detections()
 

--- a/tests/metrics/test_oriented_bounding_box_metrics.py
+++ b/tests/metrics/test_oriented_bounding_box_metrics.py
@@ -49,8 +49,7 @@ def test_perfect_non_square_oriented_boxes_score_as_perfect(
 
 def test_mean_average_precision_accepts_obb_metric_target() -> None:
     """MeanAveragePrecision routes metric_target=ORIENTED_BOUNDING_BOXES through
-    oriented_box_iou_batch; perfect OBB predictions score 1.0.
-    """
+    oriented_box_iou_batch; perfect OBB predictions score 1.0."""
     predictions = _non_square_obb_detections(confidence=True)
     targets = _non_square_obb_detections()
 

--- a/tests/metrics/test_precision.py
+++ b/tests/metrics/test_precision.py
@@ -37,7 +37,7 @@ class TestPrecision:
         )
 
     def test_initialization_default(self):
-        """Test that Precision can be initialized with default parameters"""
+        """Test that Precision can be initialized with default parameters."""
         metric = Precision()
         assert metric._metric_target == MetricTarget.BOXES
         assert metric.averaging_method == AveragingMethod.WEIGHTED
@@ -45,7 +45,7 @@ class TestPrecision:
         assert metric._targets_list == []
 
     def test_initialization_custom(self):
-        """Test that Precision can be initialized with custom parameters"""
+        """Test that Precision can be initialized with custom parameters."""
         metric = Precision(
             metric_target=MetricTarget.MASKS,
             averaging_method=AveragingMethod.MACRO,
@@ -54,7 +54,7 @@ class TestPrecision:
         assert metric.averaging_method == AveragingMethod.MACRO
 
     def test_reset(self, dummy_prediction):
-        """Test that reset() clears all stored data"""
+        """Test that reset() clears all stored data."""
         metric = Precision()
 
         # Add some dummy data
@@ -70,7 +70,7 @@ class TestPrecision:
         assert metric._targets_list == []
 
     def test_perfect_match(self, detections_50_50, targets_50_50):
-        """Test precision with perfect matching predictions and targets"""
+        """Test precision with perfect matching predictions and targets."""
         metric = Precision()
         result = metric.update(detections_50_50, targets_50_50).compute()
 
@@ -83,7 +83,7 @@ class TestPrecision:
         assert result.matched_classes[0] == 0
 
     def test_no_overlap(self, predictions_no_overlap, targets_no_overlap):
-        """Test precision with predictions that don't overlap with targets"""
+        """Test precision with predictions that don't overlap with targets."""
         metric = Precision()
         result = metric.update(predictions_no_overlap, targets_no_overlap).compute()
 
@@ -93,7 +93,7 @@ class TestPrecision:
         assert result.precision_at_75 == 0.0
 
     def test_empty_predictions(self, targets_50_50):
-        """Test precision with empty predictions but existing targets"""
+        """Test precision with empty predictions but existing targets."""
         predictions = Detections.empty()
 
         metric = Precision()
@@ -104,7 +104,7 @@ class TestPrecision:
         assert result.precision_at_75 == 0.0
 
     def test_empty_targets(self, detections_50_50):
-        """Test precision with predictions but no targets"""
+        """Test precision with predictions but no targets."""
         targets = Detections.empty()
 
         metric = Precision()
@@ -176,8 +176,8 @@ class TestPrecision:
         ],
     )
     def test_false_positives_of_absent_class_counted(self, method, expected):
-        """Predictions of absent class count as FPs under MICRO/MACRO; WEIGHTED
-        excludes them by design (GT support=0 → weight=0, consistent with sklearn)."""
+        """Predictions of absent class count as FPs under MICRO/MACRO; WEIGHTED excludes
+        them by design (GT support=0 → weight=0, consistent with sklearn)."""
         predictions = Detections(
             xyxy=np.array(
                 [[0, 0, 10, 10], [100, 0, 110, 10], [120, 0, 130, 10]], np.float32
@@ -213,7 +213,7 @@ class TestPrecision:
         assert result.precision_at_50 == 0.0
 
     def test_single_class(self, predictions_confidence_ranking, targets_50_50):
-        """Test precision calculation for single class with mixed results"""
+        """Test precision calculation for single class with mixed results."""
         metric = Precision()
         result = metric.update(predictions_confidence_ranking, targets_50_50).compute()
 
@@ -225,7 +225,7 @@ class TestPrecision:
     def test_multiple_classes(
         self, predictions_multiple_classes, targets_multiple_classes
     ):
-        """Test precision calculation for multiple classes"""
+        """Test precision calculation for multiple classes."""
         metric = Precision()
         result = metric.update(
             predictions_multiple_classes, targets_multiple_classes
@@ -242,7 +242,7 @@ class TestPrecision:
         assert 1 in result.matched_classes
 
     def test_different_iou_thresholds(self, predictions_iou_064, targets_iou_064):
-        """Test precision at different IoU thresholds"""
+        """Test precision at different IoU thresholds."""
         metric = Precision()
         result = metric.update(predictions_iou_064, targets_iou_064).compute()
 
@@ -252,7 +252,7 @@ class TestPrecision:
         assert result.precision_at_75 == 0.0  # TP=0, FP=1
 
     def test_confidence_ranking(self, predictions_confidence_ranking, targets_50_50):
-        """Test that predictions are ranked by confidence"""
+        """Test that predictions are ranked by confidence."""
         metric = Precision()
         result = metric.update(predictions_confidence_ranking, targets_50_50).compute()
 
@@ -263,7 +263,7 @@ class TestPrecision:
     def test_list_inputs(
         self, detections_50_50, targets_50_50, prediction_class_1, target_class_1
     ):
-        """Test precision with list inputs"""
+        """Test precision with list inputs."""
         metric = Precision()
         result = metric.update(
             [detections_50_50, prediction_class_1], [targets_50_50, target_class_1]
@@ -274,7 +274,7 @@ class TestPrecision:
         assert result.precision_at_75 == 1.0
 
     def test_mismatched_list_lengths(self, detections_50_50, targets_50_50):
-        """Test that mismatched prediction/target list lengths raise error"""
+        """Test that mismatched prediction/target list lengths raise error."""
         metric = Precision()
 
         # Should raise ValueError for mismatched lengths
@@ -325,7 +325,7 @@ class TestPrecision:
         [AveragingMethod.MACRO, AveragingMethod.MICRO, AveragingMethod.WEIGHTED],
     )
     def test_averaging_methods(self, averaging_method, detections_50_50, targets_50_50):
-        """Test different averaging methods"""
+        """Test different averaging methods."""
         metric = Precision(averaging_method=averaging_method)
         result = metric.update(detections_50_50, targets_50_50).compute()
 

--- a/tests/metrics/test_recall.py
+++ b/tests/metrics/test_recall.py
@@ -40,7 +40,7 @@ class TestRecall:
         )
 
     def test_initialization_default(self):
-        """Test that Recall can be initialized with default parameters"""
+        """Test that Recall can be initialized with default parameters."""
         metric = Recall()
         assert metric._metric_target == MetricTarget.BOXES
         assert metric.averaging_method == AveragingMethod.WEIGHTED
@@ -48,7 +48,7 @@ class TestRecall:
         assert metric._targets_list == []
 
     def test_initialization_custom(self):
-        """Test that Recall can be initialized with custom parameters"""
+        """Test that Recall can be initialized with custom parameters."""
         metric = Recall(
             metric_target=MetricTarget.MASKS,
             averaging_method=AveragingMethod.MACRO,
@@ -92,7 +92,7 @@ class TestRecall:
         assert r_dense.recall_at_50 == pytest.approx(r_compact.recall_at_50)
 
     def test_reset(self, dummy_prediction):
-        """Test that reset() clears all stored data"""
+        """Test that reset() clears all stored data."""
         metric = Recall()
 
         # Add some dummy data
@@ -108,7 +108,7 @@ class TestRecall:
         assert metric._targets_list == []
 
     def test_perfect_match(self, detections_50_50, targets_50_50):
-        """Test recall with perfect matching predictions and targets"""
+        """Test recall with perfect matching predictions and targets."""
         metric = Recall()
         result = metric.update(detections_50_50, targets_50_50).compute()
 
@@ -120,7 +120,7 @@ class TestRecall:
         assert result.matched_classes[0] == 0
 
     def test_no_overlap(self, predictions_no_overlap, targets_no_overlap):
-        """Test recall with predictions that don't overlap with targets"""
+        """Test recall with predictions that don't overlap with targets."""
         metric = Recall()
         result = metric.update(predictions_no_overlap, targets_no_overlap).compute()
 
@@ -146,7 +146,8 @@ class TestRecall:
         ],
     )
     def test_absent_class_predictions_are_tracked(self, method, expected):
-        """A class predicted but never present in the targets is still tracked.
+        """
+        A class predicted but never present in the targets is still tracked.
 
         Recall for such a class is 0.0 rather than undefined, which is what sklearn
         reports and what Precision and F1Score already do here. MICRO is unchanged
@@ -172,11 +173,12 @@ class TestRecall:
         assert list(result.matched_classes) == [0, 1]
 
     def test_tracked_classes_match_precision_and_f1(self):
-        """The three metrics must agree on which classes exist for the same data.
+        """
+        The three metrics must agree on which classes exist for the same data.
 
         They return `matched_classes` and a `*_per_class` array that read as parallel
-        outputs. When the class sets diverge, zipping them silently truncates instead
-        of raising.
+        outputs. When the class sets diverge, zipping them silently truncates instead of
+        raising.
         """
         predictions = Detections(
             xyxy=np.array([[0, 0, 10, 10], [100, 0, 110, 10]], dtype=np.float32),
@@ -221,14 +223,15 @@ class TestRecall:
     def test_tracked_classes_match_precision_and_f1_with_background_images(
         self, averaging_method: AveragingMethod, expected_recall_at_50: float
     ) -> None:
-        """The class sets must still agree when a sample has predictions and no targets.
+        """
+        The class sets must still agree when a sample has predictions and no targets.
 
-        A background image produces no false negatives, so no recall value changes
-        under WEIGHTED or MICRO, but its predicted classes still have to be tracked.
-        Building the class union only inside the targets-present path leaves them
-        out, and the three metrics disagree again for list inputs that contain one.
-        MACRO is where the background class's 0.0 recall placeholder visibly shifts
-        the aggregate, since it is averaged unweighted across classes.
+        A background image produces no false negatives, so no recall value changes under
+        WEIGHTED or MICRO, but its predicted classes still have to be tracked. Building
+        the class union only inside the targets-present path leaves them out, and the
+        three metrics disagree again for list inputs that contain one. MACRO is where
+        the background class's 0.0 recall placeholder visibly shifts the aggregate,
+        since it is averaged unweighted across classes.
         """
         with_targets_pred = Detections(
             xyxy=np.array([[0, 0, 10, 10]], dtype=np.float32),
@@ -261,10 +264,11 @@ class TestRecall:
         assert recall.recall_at_50 == pytest.approx(expected_recall_at_50)
 
     def test_background_image_size_bucket_filters_predictions_by_size(self) -> None:
-        """Size buckets restrict background-image prediction-only classes by size.
+        """
+        Size buckets restrict background-image prediction-only classes by size.
 
-        A background image (empty targets) with predictions of different sizes must
-        only surface in the size bucket matching that size; a bucket left with zero
+        A background image (empty targets) with predictions of different sizes must only
+        surface in the size bucket matching that size; a bucket left with zero
         predictions after size filtering must stay empty rather than error.
         """
         predictions = Detections(
@@ -297,7 +301,8 @@ class TestRecall:
         assert result.medium_objects.recall_per_class.shape == (0, 10)
 
     def test_multiple_background_image_samples_accumulate_classes(self) -> None:
-        """Two background-image samples in one list input union their classes.
+        """
+        Two background-image samples in one list input union their classes.
 
         Prediction-only classes from separate background-only samples must all be
         tracked together, not just the first sample's class.
@@ -339,7 +344,8 @@ class TestRecall:
         assert result.recall_at_50 == 0.0
 
     def test_non_contiguous_class_ids_align_by_value_not_index(self) -> None:
-        """`matched_classes` rows align to class-id values, not positional order.
+        """
+        `matched_classes` rows align to class-id values, not positional order.
 
         Large, non-contiguous class ids are sorted numerically by `np.unique` /
         `searchsorted`; a positional-index bug would misalign the prediction-only
@@ -376,7 +382,7 @@ class TestRecall:
         assert result.recall_at_50 == pytest.approx(0.5)
 
     def test_empty_predictions(self, targets_50_50):
-        """Test recall with empty predictions but existing targets"""
+        """Test recall with empty predictions but existing targets."""
         predictions = Detections.empty()
 
         metric = Recall()
@@ -387,7 +393,7 @@ class TestRecall:
         assert result.recall_at_75 == 0.0
 
     def test_empty_targets(self, detections_50_50):
-        """Test recall with predictions but no targets"""
+        """Test recall with predictions but no targets."""
         targets = Detections.empty()
 
         metric = Recall()
@@ -417,7 +423,7 @@ class TestRecall:
     def test_single_class_missed_detections(
         self, detections_50_50, targets_two_objects_class_0
     ):
-        """Test recall calculation with some missed detections"""
+        """Test recall calculation with some missed detections."""
         metric = Recall()
         result = metric.update(detections_50_50, targets_two_objects_class_0).compute()
 
@@ -429,7 +435,7 @@ class TestRecall:
     def test_multiple_classes(
         self, predictions_multiple_classes, targets_multiple_classes
     ):
-        """Test recall calculation for multiple classes"""
+        """Test recall calculation for multiple classes."""
         metric = Recall()
         result = metric.update(
             predictions_multiple_classes, targets_multiple_classes
@@ -446,7 +452,7 @@ class TestRecall:
         assert 1 in result.matched_classes
 
     def test_different_iou_thresholds(self, predictions_iou_064, targets_iou_064):
-        """Test recall at different IoU thresholds"""
+        """Test recall at different IoU thresholds."""
         metric = Recall()
         result = metric.update(predictions_iou_064, targets_iou_064).compute()
 
@@ -456,7 +462,7 @@ class TestRecall:
         assert result.recall_at_75 == 0.0  # TP=0, FN=1
 
     def test_confidence_ranking(self, predictions_confidence_ranking, targets_50_50):
-        """Test that higher confidence predictions are preferred for matching"""
+        """Test that higher confidence predictions are preferred for matching."""
         metric = Recall()
         result = metric.update(predictions_confidence_ranking, targets_50_50).compute()
 
@@ -467,7 +473,7 @@ class TestRecall:
     def test_multiple_predictions_one_target(
         self, predictions_confidence_ranking, targets_50_50
     ):
-        """Test recall when multiple predictions compete for one target"""
+        """Test recall when multiple predictions compete for one target."""
         metric = Recall()
         result = metric.update(predictions_confidence_ranking, targets_50_50).compute()
 
@@ -478,7 +484,7 @@ class TestRecall:
     def test_list_inputs(
         self, detections_50_50, targets_50_50, prediction_class_1, target_class_1
     ):
-        """Test recall with list inputs"""
+        """Test recall with list inputs."""
         metric = Recall()
         result = metric.update(
             [detections_50_50, prediction_class_1], [targets_50_50, target_class_1]
@@ -489,7 +495,7 @@ class TestRecall:
         assert result.recall_at_75 == 1.0
 
     def test_mismatched_list_lengths(self, detections_50_50, targets_50_50):
-        """Test that mismatched prediction/target list lengths raise error"""
+        """Test that mismatched prediction/target list lengths raise error."""
         metric = Recall()
 
         # Should raise ValueError for mismatched lengths
@@ -540,7 +546,7 @@ class TestRecall:
         [AveragingMethod.MACRO, AveragingMethod.MICRO, AveragingMethod.WEIGHTED],
     )
     def test_averaging_methods(self, averaging_method, detections_50_50, targets_50_50):
-        """Test different averaging methods"""
+        """Test different averaging methods."""
         metric = Recall(averaging_method=averaging_method)
         result = metric.update(detections_50_50, targets_50_50).compute()
 
@@ -549,7 +555,7 @@ class TestRecall:
         assert result.averaging_method == averaging_method
 
     def test_macro_averaging(self):
-        """Test MACRO averaging with specific example"""
+        """Test MACRO averaging with specific example."""
         # Class 0: 1/2 targets matched -> recall = 0.5
         # Class 1: 1/1 targets matched -> recall = 1.0
         # Macro average: (0.5 + 1.0) / 2 = 0.75
@@ -585,7 +591,8 @@ class TestRecall:
         assert result.recall_at_50 == 0.75
 
     def test_greedy_matching_two_valid_pairs(self):
-        """Greedy matching finds both TPs; np.unique style missed the second pair.
+        """
+        Greedy matching finds both TPs; np.unique style missed the second pair.
 
         IoU matrix: [[1.0, 0.667], [0.333, 0.538]]. At iou>=0.5 the optimal
         assignment is T0<->P0 and T1<->P1 (2 TPs, recall=1.0).

--- a/tests/metrics/test_recall.py
+++ b/tests/metrics/test_recall.py
@@ -146,8 +146,7 @@ class TestRecall:
         ],
     )
     def test_absent_class_predictions_are_tracked(self, method, expected):
-        """
-        A class predicted but never present in the targets is still tracked.
+        """A class predicted but never present in the targets is still tracked.
 
         Recall for such a class is 0.0 rather than undefined, which is what sklearn
         reports and what Precision and F1Score already do here. MICRO is unchanged
@@ -173,8 +172,7 @@ class TestRecall:
         assert list(result.matched_classes) == [0, 1]
 
     def test_tracked_classes_match_precision_and_f1(self):
-        """
-        The three metrics must agree on which classes exist for the same data.
+        """The three metrics must agree on which classes exist for the same data.
 
         They return `matched_classes` and a `*_per_class` array that read as parallel
         outputs. When the class sets diverge, zipping them silently truncates instead of
@@ -223,8 +221,7 @@ class TestRecall:
     def test_tracked_classes_match_precision_and_f1_with_background_images(
         self, averaging_method: AveragingMethod, expected_recall_at_50: float
     ) -> None:
-        """
-        The class sets must still agree when a sample has predictions and no targets.
+        """The class sets must still agree when a sample has predictions and no targets.
 
         A background image produces no false negatives, so no recall value changes under
         WEIGHTED or MICRO, but its predicted classes still have to be tracked. Building
@@ -264,8 +261,7 @@ class TestRecall:
         assert recall.recall_at_50 == pytest.approx(expected_recall_at_50)
 
     def test_background_image_size_bucket_filters_predictions_by_size(self) -> None:
-        """
-        Size buckets restrict background-image prediction-only classes by size.
+        """Size buckets restrict background-image prediction-only classes by size.
 
         A background image (empty targets) with predictions of different sizes must only
         surface in the size bucket matching that size; a bucket left with zero
@@ -301,8 +297,7 @@ class TestRecall:
         assert result.medium_objects.recall_per_class.shape == (0, 10)
 
     def test_multiple_background_image_samples_accumulate_classes(self) -> None:
-        """
-        Two background-image samples in one list input union their classes.
+        """Two background-image samples in one list input union their classes.
 
         Prediction-only classes from separate background-only samples must all be
         tracked together, not just the first sample's class.
@@ -344,8 +339,7 @@ class TestRecall:
         assert result.recall_at_50 == 0.0
 
     def test_non_contiguous_class_ids_align_by_value_not_index(self) -> None:
-        """
-        `matched_classes` rows align to class-id values, not positional order.
+        """`matched_classes` rows align to class-id values, not positional order.
 
         Large, non-contiguous class ids are sorted numerically by `np.unique` /
         `searchsorted`; a positional-index bug would misalign the prediction-only
@@ -591,8 +585,7 @@ class TestRecall:
         assert result.recall_at_50 == 0.75
 
     def test_greedy_matching_two_valid_pairs(self):
-        """
-        Greedy matching finds both TPs; np.unique style missed the second pair.
+        """Greedy matching finds both TPs; np.unique style missed the second pair.
 
         IoU matrix: [[1.0, 0.667], [0.333, 0.538]]. At iou>=0.5 the optimal
         assignment is T0<->P0 and T1<->P1 (2 TPs, recall=1.0).

--- a/tests/utils/test_image_window.py
+++ b/tests/utils/test_image_window.py
@@ -118,13 +118,13 @@ class TestImageWindowShow:
         ],
     )
     def test_show_raises_for_invalid_input(self, array, exc_type, match):
-        """show() rejects arrays with invalid dtype or shape."""
+        """Show() rejects arrays with invalid dtype or shape."""
         window = ImageWindow("test")
         with pytest.raises(exc_type, match=match):
             window.show(array)
 
     def test_show_creates_window_and_updates(self):
-        """show() creates a Tk window, sets the PhotoImage, and calls update."""
+        """Show() creates a Tk window, sets the PhotoImage, and calls update."""
         window = ImageWindow("preview")
         mock_root = MagicMock()
         mock_label = MagicMock()
@@ -373,7 +373,7 @@ class TestImageWindowClose:
         assert window.is_open is False
 
     def test_close_destroys_root(self):
-        """close() calls destroy() on the Tk root and nulls internal refs."""
+        """Close() calls destroy() on the Tk root and nulls internal refs."""
         window = ImageWindow()
         mock_root = MagicMock()
         window._root = mock_root
@@ -388,7 +388,7 @@ class TestImageWindowClose:
         assert window._photo is None
 
     def test_close_signals_waiters_and_clears_key_event(self):
-        """close() wakes wait_key() callers and clears stale Tk references."""
+        """Close() wakes wait_key() callers and clears stale Tk references."""
         window = ImageWindow()
         mock_root = MagicMock()
         mock_event = MagicMock()
@@ -404,13 +404,13 @@ class TestImageWindowClose:
         assert window._key_event is None
 
     def test_close_is_idempotent(self):
-        """close() on an already-closed window does not raise."""
+        """Close() on an already-closed window does not raise."""
         window = ImageWindow()
         window.close()  # no window created
         window.close()  # second call must not raise
 
     def test_close_clears_key_queue(self):
-        """close() discards stale keys so they don't fire on next open."""
+        """Close() discards stale keys so they don't fire on next open."""
         window = ImageWindow()
         window._root = MagicMock()
         window._key_queue = ["q", "Escape"]
@@ -436,7 +436,7 @@ class TestImageWindowContextManager:
             mock_close.assert_called_once()
 
     def test_context_manager_closes_on_exception(self):
-        """close() is called even when the body raises."""
+        """Close() is called even when the body raises."""
         with patch.object(ImageWindow, "close") as mock_close:
             with pytest.raises(RuntimeError):
                 with ImageWindow("ctx"):

--- a/tests/utils/test_sinks.py
+++ b/tests/utils/test_sinks.py
@@ -47,7 +47,7 @@ class TestImageSink:
         assert names == ["frame_000.jpg"]
 
     def test_overwrite_false_reuses_existing_dir(self, tmp_path: Path) -> None:
-        """overwrite=False keeps existing directory contents intact."""
+        """Overwrite=False keeps existing directory contents intact."""
         existing = tmp_path / "existing"
         existing.mkdir()
         sentinel = existing / "keep.txt"
@@ -61,7 +61,7 @@ class TestImageSink:
         assert len(list(existing.iterdir())) == 2
 
     def test_overwrite_true_clears_existing_dir(self, tmp_path: Path) -> None:
-        """overwrite=True removes pre-existing files before writing."""
+        """Overwrite=True removes pre-existing files before writing."""
         target = tmp_path / "target"
         target.mkdir()
         sentinel = target / "old.txt"

--- a/tests/utils/test_video.py
+++ b/tests/utils/test_video.py
@@ -32,8 +32,7 @@ def dummy_video_path(tmp_path):
 
 
 def test_process_video_exception_handling(dummy_video_path, tmp_path) -> None:
-    """
-    Verify that process_video correctly propagates exceptions from the callback.
+    """Verify that process_video correctly propagates exceptions from the callback.
 
     Scenario: Processing a video where the callback raises an exception.
     Expected: `process_video` should propagate the exception, allowing users to
@@ -55,8 +54,7 @@ def test_process_video_exception_handling(dummy_video_path, tmp_path) -> None:
 
 
 def test_process_video_success(dummy_video_path, tmp_path) -> None:
-    """
-    Verify successful video processing with a pass-through callback.
+    """Verify successful video processing with a pass-through callback.
 
     Scenario: Successfully processing a video with a simple pass-through callback.
     Expected: The video is processed without error and the target file is created,
@@ -76,8 +74,7 @@ def test_process_video_success(dummy_video_path, tmp_path) -> None:
 
 
 def test_process_video_exception_with_small_buffer(dummy_video_path, tmp_path) -> None:
-    """
-    Verify that process_video handles exceptions correctly even with small buffers.
+    """Verify that process_video handles exceptions correctly even with small buffers.
 
     Scenario: Processing a video with minimal buffering where an exception occurs.
     Expected: The exception is still correctly propagated even with low memory settings.
@@ -415,8 +412,7 @@ def test_process_video_waits_for_reader_timeout_when_queue_is_empty(
 
 
 def test_process_video_max_frames(dummy_video_path, tmp_path) -> None:
-    """
-    Verify that process_video respects the max_frames parameter.
+    """Verify that process_video respects the max_frames parameter.
 
     Scenario: Processing only a limited number of frames using `max_frames`.
     Expected: Only the specified number of frames are processed, which is useful for
@@ -443,9 +439,9 @@ def test_process_video_max_frames(dummy_video_path, tmp_path) -> None:
 def _run_process_video_with_deadline(deadline_seconds: float, **kwargs) -> None:
     """Run process_video in a daemon thread; fail on timeout, re-raise its error.
 
-    A hang must not block the whole test session, so the call runs in a daemon
-    thread with a deadline. Exceptions stay confined to that thread, so they are
-    captured and re-raised here to keep a crash from passing as a clean return.
+    A hang must not block the whole test session, so the call runs in a daemon thread
+    with a deadline. Exceptions stay confined to that thread, so they are captured and
+    re-raised here to keep a crash from passing as a clean return.
     """
     errors: list[BaseException] = []
     finished = threading.Event()
@@ -516,8 +512,7 @@ def test_process_video_propagates_reader_thread_errors(
 
 
 def test_process_video_custom_params(dummy_video_path, tmp_path) -> None:
-    """
-    Verify that process_video works correctly with custom performance parameters.
+    """Verify that process_video works correctly with custom performance parameters.
 
     Scenario: Processing video with custom prefetch and buffer parameters.
     Expected: Video is processed successfully, showing that these performance-tuning
@@ -541,8 +536,7 @@ def test_process_video_custom_params(dummy_video_path, tmp_path) -> None:
 
 
 def test_video_info(dummy_video_path) -> None:
-    """
-    Verify that VideoInfo correctly retrieves metadata from a video file.
+    """Verify that VideoInfo correctly retrieves metadata from a video file.
 
     Scenario: Retrieving metadata from a video file using `VideoInfo`.
     Expected: Correct width, height, fps, and frame count are returned, which is
@@ -558,8 +552,7 @@ def test_video_info(dummy_video_path) -> None:
 
 
 def test_video_info_float_fps(dummy_video_path, monkeypatch) -> None:
-    """
-    Verify that VideoInfo preserves non-integer FPS values as floats.
+    """Verify that VideoInfo preserves non-integer FPS values as floats.
 
     Scenario: Retrieving metadata from a video while OpenCV reports 23.976 fps.
     Expected: fps is returned as the original float value, not truncated to an
@@ -581,8 +574,7 @@ def test_video_info_float_fps(dummy_video_path, monkeypatch) -> None:
 
 
 def test_get_video_frames_generator(dummy_video_path) -> None:
-    """
-    Verify that get_video_frames_generator yields frames with correct shapes.
+    """Verify that get_video_frames_generator yields frames with correct shapes.
 
     Scenario: Iterating over video frames using a generator.
     Expected: All frames are yielded in order as NumPy arrays with correct shapes,
@@ -678,7 +670,7 @@ def test_get_video_frames_generator_prefetch_param_forwarding(
 
 
 def test_get_video_frames_generator_prefetch_minimum_queue(dummy_video_path) -> None:
-    """prefetch=1 creates maximum backpressure; all frames must be returned in order.
+    """Prefetch=1 creates maximum backpressure; all frames must be returned in order.
 
     Scenario: Using prefetch=1 forces the reader to block after every decoded
         frame, maximising producer-consumer synchronisation pressure.
@@ -692,8 +684,7 @@ def test_get_video_frames_generator_prefetch_minimum_queue(dummy_video_path) -> 
 
 
 def test_get_video_frames_generator_releases_on_early_break(monkeypatch) -> None:
-    """
-    Verify that the capture is released when a consumer breaks out early.
+    """Verify that the capture is released when a consumer breaks out early.
 
     Scenario: A consumer iterates one frame then abandons the generator, raising
     GeneratorExit at the yield point.
@@ -925,8 +916,7 @@ def test_get_video_frames_generator_prefetch_zero_frame_video(monkeypatch) -> No
 
 
 def test_get_video_frames_generator_with_stride(dummy_video_path) -> None:
-    """
-    Verify that get_video_frames_generator correctly handles the stride parameter.
+    """Verify that get_video_frames_generator correctly handles the stride parameter.
 
     Scenario: Iterating over video frames with specified stride (e.g., every 2nd frame).
     Expected: The generator correctly skips frames according to the stride, allowing
@@ -953,8 +943,7 @@ def test_fps_monitor_uses_frame_intervals(monkeypatch) -> None:
 
 
 def test_process_video_preserve_audio_calls_mux(dummy_video_path, tmp_path) -> None:
-    """
-    Verify that process_video calls _mux_audio when preserve_audio=True.
+    """Verify that process_video calls _mux_audio when preserve_audio=True.
 
     Scenario: Processing a video with preserve_audio=True and ffmpeg available.
     Expected: _mux_audio is called exactly once with the correct source and target
@@ -975,8 +964,7 @@ def test_process_video_preserve_audio_calls_mux(dummy_video_path, tmp_path) -> N
 
 
 def test_process_video_no_audio_by_default(dummy_video_path, tmp_path) -> None:
-    """
-    Verify that process_video does not call _mux_audio when preserve_audio=False.
+    """Verify that process_video does not call _mux_audio when preserve_audio=False.
 
     Scenario: Default process_video call without setting preserve_audio.
     Expected: _mux_audio is never called, preserving existing behavior for callers
@@ -994,8 +982,7 @@ def test_process_video_no_audio_by_default(dummy_video_path, tmp_path) -> None:
 
 
 def test_get_video_frames_generator_with_start_end(dummy_video_path) -> None:
-    """
-    Verify that get_video_frames_generator respects start and end frame indices.
+    """Verify that get_video_frames_generator respects start and end frame indices.
 
     Scenario: Iterating over a specific range of video frames using `start` and `end`.
     Expected: Only frames within the specified range are yielded, enabling targeted


### PR DESCRIPTION
This pull request introduces a new pre-commit hook and configuration for automatic formatting of Python docstrings using `docformatter`. The main changes are the addition of the `docformatter` tool to the pre-commit setup and its configuration in the project settings.

**Tooling and configuration updates:**

* Added the `docformatter` pre-commit hook to `.pre-commit-config.yaml` for automatic docstring formatting, along with a dependency on `tomli`.
* Added a `[tool.docformatter]` section to `pyproject.toml` with options for recursive formatting, summary and description wrapping at 88 characters, closing quotes on a new line, and enforcing a new line before summaries.