### PR TITLE
fix(detection): reject degenerate polygon zones and order VLM box corners

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,8 @@ date_modified: 2026-09-08
 
 - `sv.PolygonZone` now rejects a polygon with fewer than three vertices, or one that is not of shape `(N, 2)`, instead of building a zone that can never trigger. One or two vertices enclose no area, so the zone mask came out as a single pixel or a bare line and every detection tested against it read as outside — indistinguishable from a correctly configured zone that simply saw nothing. Zero vertices raised `zero-size array to reduction operation maximum` from NumPy rather than naming the problem. The three-vertex minimum matches `MIN_POLYGON_POINT_COUNT`, which `sv.mask_to_polygons` already enforces when producing polygons.
 
+- `sv.Detections.from_vlm` now orders each parsed box's corners, so a model that emits a corner pair backwards no longer produces an `xyxy` row with `x_min > x_max`. Every VLM parser passed such a row straight through, and nothing downstream caught it: `sv.box_iou_batch` clamps intersection widths at zero, so the box scored an IoU of `0.0` against itself — surviving NMS as a duplicate and counting as a total miss in mAP — while `sv.Detections.box_area` reported a plausible positive value, because negating both sides leaves their product positive. Correctly ordered boxes, their dtypes included, are unchanged.
+
 ### 0.30.2 <small>Sep 3, 2026</small>
 
 - `sv.xcycwh_to_xyxy` no longer truncates coordinates for integer input arrays. Half of an odd width or height is fractional, and the previous implementation wrote those values into a copy of the integer input, silently rounding them; the converted boxes are now exact.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,8 @@ date_modified: 2026-09-08
 
 - `sv.process_video` no longer hangs when `max_frames` exceeds the video's frame count. The reader thread used to fail on the out-of-range `end` before enqueuing its sentinel, blocking the main loop on the read queue. `max_frames` is now capped at the video length so the whole video processes, and any reader-thread error now surfaces as `RuntimeError("Reader thread raised: ...")` from the original exception instead of stalling the call ([#2545](https://github.com/roboflow/supervision/issues/2545)).
 
+- `sv.PolygonZone` now rejects a polygon with fewer than three vertices, or one that is not of shape `(N, 2)`, instead of building a zone that can never trigger. One or two vertices enclose no area, so the zone mask came out as a single pixel or a bare line and every detection tested against it read as outside — indistinguishable from a correctly configured zone that simply saw nothing. Zero vertices raised `zero-size array to reduction operation maximum` from NumPy rather than naming the problem. The three-vertex minimum matches `MIN_POLYGON_POINT_COUNT`, which `sv.mask_to_polygons` already enforces when producing polygons.
+
 ### 0.30.2 <small>Sep 3, 2026</small>
 
 - `sv.xcycwh_to_xyxy` no longer truncates coordinates for integer input arrays. Half of an odd width or height is fractional, and the previous implementation wrote those values into a copy of the integer input, silently rounding them; the converted boxes are now exact.

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -28,6 +28,7 @@ from supervision.detection.utils._typing import (
 )
 from supervision.detection.utils.boxes import (
     _oriented_box_anchors,
+    _sort_box_corners,
     xyxyxyxy_to_xyxy,
 )
 from supervision.detection.utils.converters import (
@@ -2037,6 +2038,7 @@ class Detections:
                     f"Invalid VLM result type: {type(result)}. Must be str."
                 )
             xyxy, class_id, class_name = from_paligemma(result, **kwargs)
+            xyxy = _sort_box_corners(xyxy)
             data: _DetectionDataType = {
                 CLASS_NAME_DATA_FIELD: class_name,
             }
@@ -2048,6 +2050,7 @@ class Detections:
                     f"Invalid VLM result type: {type(result)}. Must be str."
                 )
             xyxy, class_id, class_name = from_qwen_2_5_vl(result, **kwargs)
+            xyxy = _sort_box_corners(xyxy)
             data = {CLASS_NAME_DATA_FIELD: class_name}
             confidence_arr: npt.NDArray[np.floating[Any]] = np.ones(
                 len(xyxy), dtype=float
@@ -2062,6 +2065,7 @@ class Detections:
                     f"Invalid VLM result type: {type(result)}. Must be str."
                 )
             xyxy, class_id, class_name = from_qwen_3_vl(result, **kwargs)
+            xyxy = _sort_box_corners(xyxy)
             data = {CLASS_NAME_DATA_FIELD: class_name}
             confidence_arr = np.ones(len(xyxy), dtype=float)
             return cls(
@@ -2074,6 +2078,7 @@ class Detections:
                     f"Invalid VLM result type: {type(result)}. Must be str."
                 )
             xyxy, class_id, class_name = from_deepseek_vl_2(result, **kwargs)
+            xyxy = _sort_box_corners(xyxy)
             data = {CLASS_NAME_DATA_FIELD: class_name}
             return cls(xyxy=xyxy, class_id=class_id, data=data)
 
@@ -2083,6 +2088,7 @@ class Detections:
                     f"Invalid VLM result type: {type(result)}. Must be dict."
                 )
             xyxy, labels, mask, xyxyxyxy = from_florence_2(result, **kwargs)
+            xyxy = _sort_box_corners(xyxy)
             if len(xyxy) == 0:
                 empty = cls.empty()
                 empty.data = {CLASS_NAME_DATA_FIELD: np.empty(0, dtype=str)}
@@ -2102,6 +2108,7 @@ class Detections:
                     f"Invalid VLM result type: {type(result)}. Must be str."
                 )
             xyxy, class_id, class_name = from_google_gemini_2_0(result, **kwargs)
+            xyxy = _sort_box_corners(xyxy)
             data = {CLASS_NAME_DATA_FIELD: class_name}
             return cls(xyxy=xyxy, class_id=class_id, data=data)
 
@@ -2111,6 +2118,7 @@ class Detections:
                     f"Invalid VLM result type: {type(result)}. Must be dict."
                 )
             xyxy = from_moondream(result, **kwargs)
+            xyxy = _sort_box_corners(xyxy)
             return cls(xyxy=xyxy)
 
         if vlm == VLM.GOOGLE_GEMINI_2_5:
@@ -2119,9 +2127,10 @@ class Detections:
                     f"Invalid VLM result type: {type(result)}. Must be str."
                 )
             gemini_result = from_google_gemini_2_5(result, **kwargs)
+            gemini_xyxy = _sort_box_corners(gemini_result[0])
             data = {CLASS_NAME_DATA_FIELD: gemini_result[2]}
             return cls(
-                xyxy=gemini_result[0],
+                xyxy=gemini_xyxy,
                 class_id=gemini_result[1],
                 mask=gemini_result[4],
                 confidence=gemini_result[3],
@@ -2134,9 +2143,10 @@ class Detections:
                     f"Invalid VLM result type: {type(result)}. Must be str."
                 )
             gemini_result = from_google_gemini_3_5(result, **kwargs)
+            gemini_xyxy = _sort_box_corners(gemini_result[0])
             data = {CLASS_NAME_DATA_FIELD: gemini_result[2]}
             return cls(
-                xyxy=gemini_result[0],
+                xyxy=gemini_xyxy,
                 class_id=gemini_result[1],
                 mask=gemini_result[4],
                 confidence=gemini_result[3],

--- a/src/supervision/detection/tools/polygon_zone.py
+++ b/src/supervision/detection/tools/polygon_zone.py
@@ -6,7 +6,10 @@ import numpy.typing as npt
 
 from supervision import Detections
 from supervision import _cv2 as cv2
-from supervision.detection.utils.converters import polygon_to_mask
+from supervision.detection.utils.converters import (
+    MIN_POLYGON_POINT_COUNT,
+    polygon_to_mask,
+)
 from supervision.draw.color import Color
 from supervision.draw.utils import draw_filled_polygon, draw_polygon, draw_text
 from supervision.geometry.core import Position
@@ -77,6 +80,34 @@ class PolygonZone:
         triggering_anchors: Iterable[Position] = (Position.BOTTOM_CENTER,),
         require_all_anchors: bool = True,
     ) -> None:
+        """Build a zone from a polygon.
+
+        Args:
+            polygon: Zone boundary of shape `(N, 2)` holding the `x`, `y`
+                coordinates of its vertices.
+            triggering_anchors: Which anchors of a detection's bounding box
+                decide whether it falls inside the zone.
+            require_all_anchors: Whether every triggering anchor must be inside
+                for the detection to count, rather than any one of them.
+
+        Raises:
+            ValueError: If `polygon` is not of shape `(N, 2)`, has fewer than
+                `MIN_POLYGON_POINT_COUNT` vertices, or `triggering_anchors` is
+                empty.
+        """
+        polygon = np.asarray(polygon)
+        if polygon.ndim != 2 or polygon.shape[-1] != 2:
+            raise ValueError(f"Polygon must have shape (N, 2); got {polygon.shape}.")
+        # Fewer than three vertices enclose no area, so the mask below comes out
+        # empty or a bare line and the zone silently never triggers. Reject it
+        # here rather than let a zone that can never count look like a zone that
+        # simply saw nothing. Zero vertices additionally breaks `np.max`.
+        if len(polygon) < MIN_POLYGON_POINT_COUNT:
+            raise ValueError(
+                f"Polygon must have at least {MIN_POLYGON_POINT_COUNT} vertices "
+                f"to enclose an area; got {len(polygon)}."
+            )
+
         self.polygon = polygon.astype(int)
         # Materialize once so we can safely accept generators without exhausting them.
         self.triggering_anchors = list(triggering_anchors)

--- a/src/supervision/detection/utils/boxes.py
+++ b/src/supervision/detection/utils/boxes.py
@@ -166,6 +166,45 @@ def denormalize_boxes(
     return xyxy * scale
 
 
+def _sort_box_corners(
+    xyxy: npt.NDArray[np.number],
+) -> npt.NDArray[np.number]:
+    """Order each box's corners so that `x_min <= x_max` and `y_min <= y_max`.
+
+    `Detections.xyxy` is defined as `(x_min, y_min, x_max, y_max)`, and every
+    box operation in the library relies on that ordering: `box_iou_batch`
+    clamps its intersection widths at zero, so a box whose corners arrive
+    swapped scores an IoU of `0` even against itself. `box_area` hides the
+    problem rather than surfacing it, because negating both sides leaves their
+    product positive. Sorting the corner pairs restores the invariant without
+    moving the region a box describes; a correctly ordered box is unchanged.
+
+    Args:
+        xyxy: Boxes of shape `(N, 4)`, each row `(x_min, y_min, x_max, y_max)`,
+            possibly with either corner pair transposed.
+
+    Returns:
+        Boxes of shape `(N, 4)` with both corner pairs in ascending order.
+
+    Examples:
+        ```pycon
+        >>> import numpy as np
+        >>> from supervision.detection.utils.boxes import _sort_box_corners
+        >>> _sort_box_corners(np.array([[300.0, 320.0, 200.0, 80.0]]))
+        array([[200.,  80., 300., 320.]])
+
+        ```
+    """
+    xyxy = np.asarray(xyxy)
+    if xyxy.size == 0:
+        return xyxy
+    x_min = np.minimum(xyxy[:, 0], xyxy[:, 2])
+    x_max = np.maximum(xyxy[:, 0], xyxy[:, 2])
+    y_min = np.minimum(xyxy[:, 1], xyxy[:, 3])
+    y_max = np.maximum(xyxy[:, 1], xyxy[:, 3])
+    return cast(npt.NDArray[np.number], np.stack([x_min, y_min, x_max, y_max], axis=-1))
+
+
 def move_boxes(
     xyxy: npt.NDArray[np.number], offset: npt.NDArray[np.integer]
 ) -> npt.NDArray[np.number]:

--- a/tests/detection/test_polygonzone.py
+++ b/tests/detection/test_polygonzone.py
@@ -60,6 +60,34 @@ class TestPolygonZoneInit:
         assert zone.trigger(detections)[0]
         assert zone.trigger(detections)[0]
 
+    @pytest.mark.parametrize(
+        ("polygon", "expected_vertex_count"),
+        [
+            (np.empty((0, 2), dtype=int), 0),
+            (np.array([[20, 20]]), 1),
+            (np.array([[0, 0], [40, 40]]), 2),
+        ],
+    )
+    def test_degenerate_polygon_raises(
+        self, polygon: np.ndarray, expected_vertex_count: int
+    ) -> None:
+        """A polygon enclosing no area cannot be a zone and must not be accepted."""
+        with pytest.raises(
+            ValueError, match=f"at least 3 vertices.*got {expected_vertex_count}"
+        ):
+            sv.PolygonZone(polygon)
+
+    def test_triangle_is_accepted(self) -> None:
+        """Three vertices is the smallest polygon that encloses an area."""
+        zone = sv.PolygonZone(np.array([[0, 0], [100, 0], [100, 100]]))
+
+        assert zone.mask.sum() > 0
+
+    def test_wrongly_shaped_polygon_raises(self) -> None:
+        """A polygon must be (N, 2) coordinate pairs, not a flat or 3-D array."""
+        with pytest.raises(ValueError, match=r"shape \(N, 2\)"):
+            sv.PolygonZone(np.array([0, 0, 40, 0, 40, 40]))
+
 
 class TestPolygonZoneTrigger:
     @pytest.mark.parametrize(

--- a/tests/detection/test_vlm.py
+++ b/tests/detection/test_vlm.py
@@ -1482,3 +1482,97 @@ def test_from_google_gemini_3_5_recovers_malformed_array():
 
     assert xyxy.shape == (2, 4)
     assert list(class_name) == ["cat", "dog"]
+
+
+class TestFromVlmCornerOrdering:
+    """Tests that `from_vlm` returns boxes obeying the `xyxy` corner ordering."""
+
+    @pytest.mark.parametrize(
+        ("vlm", "result", "kwargs"),
+        [
+            pytest.param(
+                VLM.GOOGLE_GEMINI_2_0,
+                '[{"box_2d": [400, 300, 100, 200], "label": "cat"}]',
+                {},
+                id="gemini-2.0",
+            ),
+            pytest.param(
+                VLM.GOOGLE_GEMINI_2_5,
+                '[{"box_2d": [400, 300, 100, 200], "label": "cat"}]',
+                {},
+                id="gemini-2.5",
+            ),
+            pytest.param(
+                VLM.GOOGLE_GEMINI_3_5,
+                '[{"box_2d": [400, 300, 100, 200], "label": "cat"}]',
+                {},
+                id="gemini-3.5",
+            ),
+            pytest.param(
+                VLM.QWEN_2_5_VL,
+                '[{"bbox_2d": [300, 400, 200, 100], "label": "cat"}]',
+                {"input_wh": (1000, 800)},
+                id="qwen-2.5-vl",
+            ),
+            pytest.param(
+                VLM.FLORENCE_2,
+                {"<OD>": {"bboxes": [[300.0, 400.0, 200.0, 100.0]], "labels": ["cat"]}},
+                {},
+                id="florence-2",
+            ),
+            pytest.param(
+                VLM.PALIGEMMA,
+                "<loc0400><loc0300><loc0100><loc0200> cat",
+                {"classes": ["cat"]},
+                id="paligemma",
+            ),
+            pytest.param(
+                VLM.MOONDREAM,
+                {"objects": [{"x_min": 0.4, "y_min": 0.5, "x_max": 0.1, "y_max": 0.2}]},
+                {},
+                id="moondream",
+            ),
+            pytest.param(
+                VLM.DEEPSEEK_VL_2,
+                "<|ref|>cat<|/ref|><|det|>[[900, 800, 100, 200]]<|/det|>",
+                {},
+                id="deepseek-vl-2",
+            ),
+        ],
+    )
+    def test_transposed_model_corners_are_ordered(
+        self, vlm: VLM, result: object, kwargs: dict
+    ) -> None:
+        """A model that emits a corner pair backwards still yields a valid box."""
+        detections = Detections.from_vlm(
+            vlm, result, resolution_wh=(1000, 800), **kwargs
+        )
+
+        assert np.all(detections.xyxy[:, 0] <= detections.xyxy[:, 2])
+        assert np.all(detections.xyxy[:, 1] <= detections.xyxy[:, 3])
+
+    def test_transposed_box_keeps_its_region(self) -> None:
+        """Ordering the corners must not move the region the box describes."""
+        transposed = Detections.from_vlm(
+            VLM.GOOGLE_GEMINI_2_5,
+            '[{"box_2d": [400, 300, 100, 200], "label": "cat"}]',
+            resolution_wh=(1000, 800),
+        )
+        upright = Detections.from_vlm(
+            VLM.GOOGLE_GEMINI_2_5,
+            '[{"box_2d": [100, 200, 400, 300], "label": "cat"}]',
+            resolution_wh=(1000, 800),
+        )
+
+        assert np.array_equal(transposed.xyxy, upright.xyxy)
+
+    def test_ordered_model_corners_are_unchanged(self) -> None:
+        """A correctly ordered box must pass through untouched, dtype included."""
+        detections = Detections.from_vlm(
+            VLM.FLORENCE_2,
+            {"<OD>": {"bboxes": [[10.0, 20.0, 30.0, 40.0]], "labels": ["cat"]}},
+            resolution_wh=(1000, 800),
+        )
+
+        assert np.array_equal(detections.xyxy, np.array([[10.0, 20.0, 30.0, 40.0]]))
+        assert detections.xyxy.dtype == np.float32


### PR DESCRIPTION
## Description

Two independent fixes, both restoring the `xyxy` invariant that
`Detections` and every box operation depend on.

**1. `PolygonZone` accepted polygons that enclose no area.**

Fewer than three vertices cannot bound a region, so `polygon_to_mask`
produced a single pixel or a bare line and every detection tested against
the zone read as outside — a zone that can never count, indistinguishable
from a correctly configured zone that happened to see nothing:

```python
import numpy as np, supervision as sv

det = sv.Detections(xyxy=np.array([[10.0, 10.0, 30.0, 30.0]]))
zone = sv.PolygonZone(polygon=np.array([[0, 0], [40, 40]]))   # 2 vertices
zone.trigger(det)          # array([False]) — silently, forever
zone.mask.sum()            # 41 — a line, not a region
```

Zero vertices did raise, but as `zero-size array to reduction operation
maximum` out of `np.max`, naming neither the polygon nor the requirement.

**2. `from_vlm` returned boxes with the corners transposed.**

Every VLM parser passed model coordinates through in whatever order they
arrived, so a model that emitted a corner pair backwards produced a row
with `x_min > x_max`:

```python
import numpy as np, supervision as sv

d = sv.Detections.from_vlm(
    sv.VLM.GOOGLE_GEMINI_2_5,
    '[{"box_2d": [400, 300, 100, 200], "label": "cat"}]',
    resolution_wh=(1000, 800),
)
d.xyxy                              # [[300., 320., 200., 80.]]
d.box_area                          # [24000.] — looks healthy
sv.box_iou_batch(d.xyxy, d.xyxy)    # [[0.0]] — zero IoU with itself
```

Nothing downstream caught it. `box_iou_batch` clamps intersection widths
at zero, so such a box survived `with_nms` as though it overlapped
nothing and counted as a total miss in mAP even when it named the right
region, while `box_area` concealed it — negating both sides leaves the
product positive. Confirmed on all nine parsers: PaliGemma, Qwen 2.5-VL,
Qwen 3-VL, DeepSeek-VL2, Florence-2, Moondream, and Gemini 2.0 / 2.5 / 3.5.

## Motivation and Context

Both are silent failures rather than errors: a zone stuck at zero and a
detection that scores as a miss give no signal that anything is wrong, so
they surface as "the model is bad" rather than as bugs.

## Changes Made

- `PolygonZone.__init__` validates vertex count against
  `MIN_POLYGON_POINT_COUNT` — the constant the library already defines and
  enforces in `mask_to_polygons` — and validates `(N, 2)` shape, which
  previously failed later and less clearly when unpacking `np.max`.
- Added `_sort_box_corners` in `detection/utils/boxes.py`, applied where
  each parser hands its boxes to `from_vlm`. Private, so no new public API.
  Ordering the pairs does not move the region, so a correct box is returned
  unchanged, dtype included.
- Deliberately out of scope: `Detections` still accepts a transposed `xyxy`
  built by hand. This PR fixes the parsers that produce them, not the
  constructor — validating there would change behaviour for every connector.

## Testing

```
uv run pytest                      # 3717 passed, 19 skipped
uv run pre-commit run --all-files  # all hooks pass
```

`TestPolygonZoneInit` (5 new tests) and `TestFromVlmCornerOrdering`
(10 new tests, one parametrized case per VLM). Reverting each source
change confirms the split: 4 of 5 and 9 of 10 fail on `develop`. The
remaining test in each group is a regression guard that passes both
before and after — a valid triangle is still accepted, and a correctly
ordered box still passes through untouched.

- [x] Added/updated tests, and the full suite passes locally
- [x] Updated docs (docstrings / mkdocs entry) for new or changed public API
- [x] Added a changelog entry in `docs/changelog.md` under `Unreleased`

## Additional Notes

Left alone: `PolygonZone`'s prune-free handling of float polygons, and the
fact that `Detections` itself does not reject transposed `xyxy`. Happy to
split this into two PRs if you'd prefer one concern each.