### PR TITLE
refactoring and simplifications

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,8 @@ date_modified: 2026-09-08
 
 - `sv.VLM.GOOGLE_GEMINI_3_6` and `sv.VLM.GOOGLE_GEMINI_3_7` — `sv.Detections.from_vlm` now parses the structured `{"boxes": [...]}` detection and segmentation format, including normalized polygon masks.
 
+- `sv.Detections.from_vlm` now keeps `class_id` integer-typed when a `classes` filter removes every detection. The index array was built from an empty list, so NumPy defaulted it to `float64` for `sv.VLM.PALIGEMMA`, `sv.VLM.DEEPSEEK_VL_2` and `sv.VLM.GOOGLE_GEMINI_2_0` — `sv.VLM.QWEN_2_5_VL` and `sv.VLM.QWEN_3_VL` already pinned the dtype and the rest now match them. Results with at least one surviving detection are unchanged.
+
 ### 0.30.2 <small>Sep 3, 2026</small>
 
 - `sv.xcycwh_to_xyxy` no longer truncates coordinates for integer input arrays. Half of an odd width or height is fractional, and the previous implementation wrote those values into a copy of the integer input, silently rounding them; the converted boxes are now exact.

--- a/src/supervision/annotators/core.py
+++ b/src/supervision/annotators/core.py
@@ -15,6 +15,8 @@ from supervision.annotators.utils import (
     PENDING_TRACK_ID,
     ColorLookup,
     Trace,
+    _iter_resolved_colors,
+    _resolve_annotator_color,
     _validate_labels,
     calculate_dynamic_kernel_size,
     calculate_dynamic_pixel_size,
@@ -258,16 +260,10 @@ class BoxAnnotator(BaseAnnotator):
         """
         if not isinstance(scene, np.ndarray):
             return scene
-        for detection_idx in range(len(detections)):
+        for detection_idx, color in _iter_resolved_colors(
+            detections, self.color, self.color_lookup, custom_color_lookup
+        ):
             x1, y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
-            color = resolve_color(
-                color=self.color,
-                detections=detections,
-                detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
-            )
             cv2.rectangle(
                 img=scene,
                 pt1=(x1, y1),
@@ -366,16 +362,10 @@ class OrientedBoxAnnotator(BaseAnnotator):
             return scene
         obb_boxes = np.array(detections.data[ORIENTED_BOX_COORDINATES]).astype(int)
 
-        for detection_idx in range(len(detections)):
+        for detection_idx, color in _iter_resolved_colors(
+            detections, self.color, self.color_lookup, custom_color_lookup
+        ):
             obb = obb_boxes[detection_idx]
-            color = resolve_color(
-                color=self.color,
-                detections=detections,
-                detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
-            )
 
             cv2.drawContours(scene, [obb], 0, color.as_bgr(), self.thickness)
 
@@ -695,13 +685,12 @@ class PolygonAnnotator(BaseAnnotator):
             return scene
 
         for detection_idx, mask, offset in _iter_mask_crops(detections):
-            color = resolve_color(
+            color = _resolve_annotator_color(
                 color=self.color,
                 detections=detections,
                 detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
+                color_lookup=self.color_lookup,
+                custom_color_lookup=custom_color_lookup,
             )
             for polygon in mask_to_polygons(mask=mask):
                 if offset is not None:
@@ -782,16 +771,10 @@ class ColorAnnotator(BaseAnnotator):
         if not isinstance(scene, np.ndarray):
             return scene
         scene_with_boxes = scene.copy()
-        for detection_idx in range(len(detections)):
+        for detection_idx, color in _iter_resolved_colors(
+            detections, self.color, self.color_lookup, custom_color_lookup
+        ):
             x1, y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
-            color = resolve_color(
-                color=self.color,
-                detections=detections,
-                detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
-            )
             cv2.rectangle(
                 img=scene_with_boxes,
                 pt1=(x1, y1),
@@ -987,16 +970,10 @@ class EllipseAnnotator(BaseAnnotator):
         """
         if not isinstance(scene, np.ndarray):
             return scene
-        for detection_idx in range(len(detections)):
+        for detection_idx, color in _iter_resolved_colors(
+            detections, self.color, self.color_lookup, custom_color_lookup
+        ):
             x1, _y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
-            color = resolve_color(
-                color=self.color,
-                detections=detections,
-                detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
-            )
             center = (int((x1 + x2) / 2), y2)
             width = x2 - x1
             cv2.ellipse(
@@ -1080,16 +1057,10 @@ class BoxCornerAnnotator(BaseAnnotator):
         """
         if not isinstance(scene, np.ndarray):
             return scene
-        for detection_idx in range(len(detections)):
+        for detection_idx, color in _iter_resolved_colors(
+            detections, self.color, self.color_lookup, custom_color_lookup
+        ):
             x1, y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
-            color = resolve_color(
-                color=self.color,
-                detections=detections,
-                detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
-            )
             corners = [(x1, y1), (x2, y1), (x1, y2), (x2, y2)]
 
             for x, y in corners:
@@ -1170,18 +1141,12 @@ class CircleAnnotator(BaseAnnotator):
         """
         if not isinstance(scene, np.ndarray):
             return scene
-        for detection_idx in range(len(detections)):
+        for detection_idx, color in _iter_resolved_colors(
+            detections, self.color, self.color_lookup, custom_color_lookup
+        ):
             x1, y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
             center = ((x1 + x2) // 2, (y1 + y2) // 2)
             distance = sqrt((x1 - center[0]) ** 2 + (y1 - center[1]) ** 2)
-            color = resolve_color(
-                color=self.color,
-                detections=detections,
-                detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
-            )
             cv2.circle(
                 img=scene,
                 center=center,
@@ -1270,26 +1235,19 @@ class DotAnnotator(BaseAnnotator):
         if not isinstance(scene, np.ndarray):
             return scene
         xy = detections.get_anchors_coordinates(anchor=self.position)
-        for detection_idx in range(len(detections)):
-            color = resolve_color(
-                color=self.color,
-                detections=detections,
-                detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
-            )
+        for detection_idx, color in _iter_resolved_colors(
+            detections, self.color, self.color_lookup, custom_color_lookup
+        ):
             center = (int(xy[detection_idx, 0]), int(xy[detection_idx, 1]))
 
             cv2.circle(scene, center, self.radius, color.as_bgr(), -1)
             if self.outline_thickness:
-                outline_color = resolve_color(
+                outline_color = _resolve_annotator_color(
                     color=self.outline_color,
                     detections=detections,
                     detection_idx=detection_idx,
-                    color_lookup=self.color_lookup
-                    if custom_color_lookup is None
-                    else custom_color_lookup,
+                    color_lookup=self.color_lookup,
+                    custom_color_lookup=custom_color_lookup,
                 )
                 cv2.circle(
                     scene,
@@ -2273,13 +2231,12 @@ class TraceAnnotator(BaseAnnotator):
             if tracker_id_val is None:
                 continue
             tracker_id = int(tracker_id_val)
-            color = resolve_color(
+            color = _resolve_annotator_color(
                 color=self.color,
                 detections=filtered_detections,
                 detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
+                color_lookup=self.color_lookup,
+                custom_color_lookup=custom_color_lookup,
             )
             xy = self.trace.get(tracker_id=tracker_id)
             spline_points: npt.NDArray[np.int32] = xy.astype(np.int32)
@@ -2657,15 +2614,9 @@ class TriangleAnnotator(BaseAnnotator):
         if not isinstance(scene, np.ndarray):
             return scene
         xy = detections.get_anchors_coordinates(anchor=self.position)
-        for detection_idx in range(len(detections)):
-            color = resolve_color(
-                color=self.color,
-                detections=detections,
-                detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
-            )
+        for detection_idx, color in _iter_resolved_colors(
+            detections, self.color, self.color_lookup, custom_color_lookup
+        ):
             tip_x, tip_y = int(xy[detection_idx, 0]), int(xy[detection_idx, 1])
             vertices = np.array(
                 [
@@ -2678,13 +2629,12 @@ class TriangleAnnotator(BaseAnnotator):
 
             cv2.fillPoly(scene, [vertices], color.as_bgr())
             if self.outline_thickness:
-                outline_color = resolve_color(
+                outline_color = _resolve_annotator_color(
                     color=self.outline_color,
                     detections=detections,
                     detection_idx=detection_idx,
-                    color_lookup=self.color_lookup
-                    if custom_color_lookup is None
-                    else custom_color_lookup,
+                    color_lookup=self.color_lookup,
+                    custom_color_lookup=custom_color_lookup,
                 )
                 cv2.polylines(
                     scene,
@@ -2770,16 +2720,10 @@ class RoundBoxAnnotator(BaseAnnotator):
         """
         if not isinstance(scene, np.ndarray):
             return scene
-        for detection_idx in range(len(detections)):
+        for detection_idx, color in _iter_resolved_colors(
+            detections, self.color, self.color_lookup, custom_color_lookup
+        ):
             x1, y1, x2, y2 = detections.xyxy[detection_idx].astype(int)
-            color = resolve_color(
-                color=self.color,
-                detections=detections,
-                detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
-            )
 
             radius = (
                 int((x2 - x1) // 2 * self.roundness)
@@ -2937,13 +2881,12 @@ class PercentageBarAnnotator(BaseAnnotator):
                 assert detections.confidence is not None  # MyPy type hint
                 value = detections.confidence[detection_idx]
 
-            color = resolve_color(
+            color = _resolve_annotator_color(
                 color=self.color,
                 detections=detections,
                 detection_idx=detection_idx,
-                color_lookup=self.color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
+                color_lookup=self.color_lookup,
+                custom_color_lookup=custom_color_lookup,
             )
             cv2.rectangle(
                 img=scene,
@@ -3139,13 +3082,12 @@ class CropAnnotator(BaseAnnotator):
                 anchor=anchor, crop_wh=crop_wh, position=self.position
             )
             scene = _overlay_image(image=scene, overlay=resized_crop, anchor=(x1, y1))
-            color = resolve_color(
+            color = _resolve_annotator_color(
                 color=self.border_color,
                 detections=detections,
                 detection_idx=idx,
-                color_lookup=self.border_color_lookup
-                if custom_color_lookup is None
-                else custom_color_lookup,
+                color_lookup=self.border_color_lookup,
+                custom_color_lookup=custom_color_lookup,
             )
             cv2.rectangle(
                 img=scene,

--- a/src/supervision/annotators/utils.py
+++ b/src/supervision/annotators/utils.py
@@ -1,5 +1,6 @@
 import re
 import textwrap
+from collections.abc import Iterator
 from enum import Enum
 from typing import Any, cast
 
@@ -163,6 +164,79 @@ def resolve_color(
     ):
         return PENDING_TRACK_COLOR
     return get_color_by_index(color=color, idx=idx)
+
+
+def _resolve_annotator_color(
+    color: Color | ColorPalette,
+    detections: Detections,
+    detection_idx: int,
+    color_lookup: ColorLookup | npt.NDArray[np.int_],
+    custom_color_lookup: ColorLookup | npt.NDArray[np.int_] | None,
+) -> Color:
+    """Resolve a detection's color, letting a per-call lookup override the default.
+
+    Every annotator accepts an optional `custom_color_lookup` on `annotate()` that
+    takes precedence over the lookup it was constructed with. Holding that precedence
+    rule here gives it one definition instead of restating the same conditional at
+    each of the annotators' `resolve_color` call sites.
+
+    Args:
+        color: The annotator's color or palette.
+        detections: The detections being annotated.
+        detection_idx: Index of the detection whose color to resolve.
+        color_lookup: The lookup the annotator was constructed with, used when
+            `custom_color_lookup` is `None`.
+        custom_color_lookup: Per-call lookup override, or `None` to keep
+            `color_lookup`.
+
+    Returns:
+        The resolved color for `detection_idx`.
+    """
+    return resolve_color(
+        color=color,
+        detections=detections,
+        detection_idx=detection_idx,
+        color_lookup=color_lookup
+        if custom_color_lookup is None
+        else custom_color_lookup,
+    )
+
+
+def _iter_resolved_colors(
+    detections: Detections,
+    color: Color | ColorPalette,
+    color_lookup: ColorLookup | npt.NDArray[np.int_],
+    custom_color_lookup: ColorLookup | npt.NDArray[np.int_] | None,
+) -> Iterator[tuple[int, Color]]:
+    """Iterate detections paired with the color each should be drawn in.
+
+    Annotators that draw one shape per detection all open with the same loop: walk
+    `range(len(detections))` and resolve that index's color. Yielding both together
+    keeps the color-precedence arguments, which do not vary across iterations, at the
+    loop header instead of restating them inside every iteration.
+
+    Args:
+        detections: The detections being annotated.
+        color: The annotator's color or palette.
+        color_lookup: The lookup the annotator was constructed with, used when
+            `custom_color_lookup` is `None`.
+        custom_color_lookup: Per-call lookup override, or `None` to keep
+            `color_lookup`.
+
+    Yields:
+        Tuples of `(detection_idx, color)`, in detection order.
+    """
+    for detection_idx in range(len(detections)):
+        yield (
+            detection_idx,
+            _resolve_annotator_color(
+                color=color,
+                detections=detections,
+                detection_idx=detection_idx,
+                color_lookup=color_lookup,
+                custom_color_lookup=custom_color_lookup,
+            ),
+        )
 
 
 def wrap_text(text: object, max_line_length: int | None = None) -> list[str]:

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from functools import reduce
 from typing import Any, cast
@@ -87,6 +87,28 @@ from supervision.validators import (
     _validate_detections_fields,
     _validate_resolution,
 )
+
+#: VLM parsers taking a string result and returning `(xyxy, class_id, class_name)`.
+_VLM_BOX_PARSERS: dict[VLM, Callable[..., tuple[Any, Any, Any]]] = {
+    VLM.PALIGEMMA: from_paligemma,
+    VLM.QWEN_2_5_VL: from_qwen_2_5_vl,
+    VLM.QWEN_3_VL: from_qwen_3_vl,
+    VLM.DEEPSEEK_VL_2: from_deepseek_vl_2,
+    VLM.GOOGLE_GEMINI_2_0: from_google_gemini_2_0,
+}
+
+#: VLM parsers taking a string result and additionally returning `confidence` and
+#: `mask`, as `(xyxy, class_id, class_name, confidence, mask)`.
+_VLM_SEGMENTATION_PARSERS: dict[VLM, Callable[..., tuple[Any, Any, Any, Any, Any]]] = {
+    VLM.GOOGLE_GEMINI_2_5: from_google_gemini_2_5,
+    VLM.GOOGLE_GEMINI_3_5: from_google_gemini_3_5,
+    VLM.GOOGLE_GEMINI_3_6: from_google_gemini_3_6,
+    VLM.GOOGLE_GEMINI_3_7: from_google_gemini_3_7,
+}
+
+#: VLMs whose parsers report no per-detection score, so `Detections.from_vlm` fills
+#: `confidence` with an all-ones array to keep the field populated.
+_VLM_UNIT_CONFIDENCE: frozenset[VLM] = frozenset({VLM.QWEN_2_5_VL, VLM.QWEN_3_VL})
 
 
 @dataclass
@@ -2036,158 +2058,129 @@ class Detections:
 
         vlm = _validate_vlm_parameters(vlm, result, kwargs)
 
-        if vlm == VLM.PALIGEMMA:
+        # `_validate_vlm_parameters` already enforced `RESULT_TYPES[vlm]`, but the type
+        # checker cannot narrow `result` through that table lookup, so each group
+        # restates the type it expects before delegating to its handler.
+        if vlm in _VLM_BOX_PARSERS or vlm in _VLM_SEGMENTATION_PARSERS:
             if not isinstance(result, str):
                 raise ValueError(
                     f"Invalid VLM result type: {type(result)}. Must be str."
                 )
-            xyxy, class_id, class_name = from_paligemma(result, **kwargs)
-            xyxy = _sort_box_corners(xyxy)
-            data: _DetectionDataType = {
-                CLASS_NAME_DATA_FIELD: class_name,
-            }
-            return cls(xyxy=xyxy, class_id=class_id, data=data)
-
-        if vlm == VLM.QWEN_2_5_VL:
-            if not isinstance(result, str):
-                raise ValueError(
-                    f"Invalid VLM result type: {type(result)}. Must be str."
-                )
-            xyxy, class_id, class_name = from_qwen_2_5_vl(result, **kwargs)
-            xyxy = _sort_box_corners(xyxy)
-            data = {CLASS_NAME_DATA_FIELD: class_name}
-            confidence_arr: npt.NDArray[np.floating[Any]] = np.ones(
-                len(xyxy), dtype=float
-            )
-            return cls(
-                xyxy=xyxy, class_id=class_id, confidence=confidence_arr, data=data
-            )
-
-        if vlm == VLM.QWEN_3_VL:
-            if not isinstance(result, str):
-                raise ValueError(
-                    f"Invalid VLM result type: {type(result)}. Must be str."
-                )
-            xyxy, class_id, class_name = from_qwen_3_vl(result, **kwargs)
-            xyxy = _sort_box_corners(xyxy)
-            data = {CLASS_NAME_DATA_FIELD: class_name}
-            confidence_arr = np.ones(len(xyxy), dtype=float)
-            return cls(
-                xyxy=xyxy, class_id=class_id, confidence=confidence_arr, data=data
-            )
-
-        if vlm == VLM.DEEPSEEK_VL_2:
-            if not isinstance(result, str):
-                raise ValueError(
-                    f"Invalid VLM result type: {type(result)}. Must be str."
-                )
-            xyxy, class_id, class_name = from_deepseek_vl_2(result, **kwargs)
-            xyxy = _sort_box_corners(xyxy)
-            data = {CLASS_NAME_DATA_FIELD: class_name}
-            return cls(xyxy=xyxy, class_id=class_id, data=data)
+            return cls._from_vlm_text_result(vlm, result, **kwargs)
 
         if vlm == VLM.FLORENCE_2:
             if not isinstance(result, dict):
                 raise ValueError(
                     f"Invalid VLM result type: {type(result)}. Must be dict."
                 )
-            xyxy, labels, mask, xyxyxyxy = from_florence_2(result, **kwargs)
-            xyxy = _sort_box_corners(xyxy)
-            if len(xyxy) == 0:
-                empty = cls.empty()
-                empty.data = {CLASS_NAME_DATA_FIELD: np.empty(0, dtype=str)}
-                return empty
-
-            data = {}
-            if labels is not None:
-                data[CLASS_NAME_DATA_FIELD] = labels
-            if xyxyxyxy is not None:
-                data[ORIENTED_BOX_COORDINATES] = xyxyxyxy
-
-            return cls(xyxy=xyxy, mask=mask, data=data)
-
-        if vlm == VLM.GOOGLE_GEMINI_2_0:
-            if not isinstance(result, str):
-                raise ValueError(
-                    f"Invalid VLM result type: {type(result)}. Must be str."
-                )
-            xyxy, class_id, class_name = from_google_gemini_2_0(result, **kwargs)
-            xyxy = _sort_box_corners(xyxy)
-            data = {CLASS_NAME_DATA_FIELD: class_name}
-            return cls(xyxy=xyxy, class_id=class_id, data=data)
+            return cls._from_florence_2_result(result, **kwargs)
 
         if vlm == VLM.MOONDREAM:
             if not isinstance(result, dict):
                 raise ValueError(
                     f"Invalid VLM result type: {type(result)}. Must be dict."
                 )
-            xyxy = from_moondream(result, **kwargs)
-            xyxy = _sort_box_corners(xyxy)
-            return cls(xyxy=xyxy)
-
-        if vlm == VLM.GOOGLE_GEMINI_2_5:
-            if not isinstance(result, str):
-                raise ValueError(
-                    f"Invalid VLM result type: {type(result)}. Must be str."
-                )
-            gemini_result = from_google_gemini_2_5(result, **kwargs)
-            gemini_xyxy = _sort_box_corners(gemini_result[0])
-            data = {CLASS_NAME_DATA_FIELD: gemini_result[2]}
-            return cls(
-                xyxy=gemini_xyxy,
-                class_id=gemini_result[1],
-                mask=gemini_result[4],
-                confidence=gemini_result[3],
-                data=data,
-            )
-
-        if vlm == VLM.GOOGLE_GEMINI_3_5:
-            if not isinstance(result, str):
-                raise ValueError(
-                    f"Invalid VLM result type: {type(result)}. Must be str."
-                )
-            gemini_result = from_google_gemini_3_5(result, **kwargs)
-            gemini_xyxy = _sort_box_corners(gemini_result[0])
-            data = {CLASS_NAME_DATA_FIELD: gemini_result[2]}
-            return cls(
-                xyxy=gemini_xyxy,
-                class_id=gemini_result[1],
-                mask=gemini_result[4],
-                confidence=gemini_result[3],
-                data=data,
-            )
-
-        if vlm == VLM.GOOGLE_GEMINI_3_6:
-            if not isinstance(result, str):
-                raise ValueError(
-                    f"Invalid VLM result type: {type(result)}. Must be str."
-                )
-            gemini_result = from_google_gemini_3_6(result, **kwargs)
-            data = {CLASS_NAME_DATA_FIELD: gemini_result[2]}
-            return cls(
-                xyxy=gemini_result[0],
-                class_id=gemini_result[1],
-                mask=gemini_result[4],
-                confidence=gemini_result[3],
-                data=data,
-            )
-
-        if vlm == VLM.GOOGLE_GEMINI_3_7:
-            if not isinstance(result, str):
-                raise ValueError(
-                    f"Invalid VLM result type: {type(result)}. Must be str."
-                )
-            gemini_result = from_google_gemini_3_7(result, **kwargs)
-            data = {CLASS_NAME_DATA_FIELD: gemini_result[2]}
-            return cls(
-                xyxy=gemini_result[0],
-                class_id=gemini_result[1],
-                mask=gemini_result[4],
-                confidence=gemini_result[3],
-                data=data,
-            )
+            return cls._from_moondream_result(result, **kwargs)
 
         raise ValueError(f"Unsupported VLM value: {vlm}.")
+
+    @classmethod
+    def _from_vlm_text_result(cls, vlm: VLM, result: str, **kwargs: Any) -> Detections:
+        """Build detections from the VLMs whose parser consumes a string result.
+
+        Covers both `_VLM_BOX_PARSERS`, which report boxes and labels only, and
+        `_VLM_SEGMENTATION_PARSERS`, which additionally report confidence and masks.
+        The two differ only in how many arrays their parser hands back, so they share
+        one construction site here rather than one near-identical branch each.
+
+        Args:
+            vlm: The VLM whose parser to dispatch to; must be a key of either
+                `_VLM_BOX_PARSERS` or `_VLM_SEGMENTATION_PARSERS`.
+            result: The raw string response from the model.
+            **kwargs: Parser arguments, already validated against
+                `REQUIRED_ARGUMENTS` and `ALLOWED_ARGUMENTS`.
+
+        Returns:
+            The parsed `Detections`.
+        """
+        mask: npt.NDArray[np.bool_] | CompactMask | None
+        confidence: npt.NDArray[np.floating] | None
+        if vlm in _VLM_BOX_PARSERS:
+            xyxy, class_id, class_name = _VLM_BOX_PARSERS[vlm](result, **kwargs)
+            mask = None
+            confidence = (
+                np.ones(len(xyxy), dtype=float) if vlm in _VLM_UNIT_CONFIDENCE else None
+            )
+        else:
+            xyxy, class_id, class_name, confidence, mask = _VLM_SEGMENTATION_PARSERS[
+                vlm
+            ](result, **kwargs)
+
+        # Sorting is redundant for the Gemini parsers, which already order each box's
+        # corners, but it is idempotent and keeps every string-result VLM on one code
+        # path instead of tracking which parsers happen to emit ordered corners.
+        return cls(
+            xyxy=_sort_box_corners(xyxy),
+            class_id=class_id,
+            mask=mask,
+            confidence=confidence,
+            data={CLASS_NAME_DATA_FIELD: class_name},
+        )
+
+    @classmethod
+    def _from_florence_2_result(
+        cls, result: dict[str, Any], **kwargs: Any
+    ) -> Detections:
+        """Build detections from a Florence-2 task payload.
+
+        Florence-2 is the only VLM whose per-detection fields vary by task: labels are
+        absent for region proposals and oriented boxes are present only for
+        `<OCR_WITH_REGION>`, so `data` is assembled from whichever the task returned
+        rather than from a fixed set of keys.
+
+        Args:
+            result: The task payload returned by the model.
+            **kwargs: Parser arguments, already validated against
+                `REQUIRED_ARGUMENTS` and `ALLOWED_ARGUMENTS`.
+
+        Returns:
+            The parsed `Detections`, or an empty one carrying an empty `class_name`
+                array when the task reported no boxes.
+        """
+        xyxy, labels, mask, xyxyxyxy = from_florence_2(result, **kwargs)
+        xyxy = _sort_box_corners(xyxy)
+        if len(xyxy) == 0:
+            empty = cls.empty()
+            empty.data = {CLASS_NAME_DATA_FIELD: np.empty(0, dtype=str)}
+            return empty
+
+        data: _DetectionDataType = {}
+        if labels is not None:
+            data[CLASS_NAME_DATA_FIELD] = labels
+        if xyxyxyxy is not None:
+            data[ORIENTED_BOX_COORDINATES] = xyxyxyxy
+
+        return cls(xyxy=xyxy, mask=mask, data=data)
+
+    @classmethod
+    def _from_moondream_result(
+        cls, result: dict[str, Any], **kwargs: Any
+    ) -> Detections:
+        """Build detections from a Moondream payload.
+
+        Moondream reports boxes only - no labels, scores, or masks - so the result
+        carries `xyxy` and nothing else.
+
+        Args:
+            result: The JSON payload returned by the model.
+            **kwargs: Parser arguments, already validated against
+                `REQUIRED_ARGUMENTS` and `ALLOWED_ARGUMENTS`.
+
+        Returns:
+            The parsed `Detections`, carrying boxes only.
+        """
+        xyxy = from_moondream(result, **kwargs)
+        return cls(xyxy=_sort_box_corners(xyxy))
 
     @classmethod
     def from_easyocr(cls, easyocr_results: list[Any]) -> Detections:

--- a/src/supervision/detection/vlm.py
+++ b/src/supervision/detection/vlm.py
@@ -5,6 +5,7 @@ import base64
 import io
 import json
 import re
+from collections.abc import Callable
 from enum import Enum
 from typing import Any, cast
 
@@ -225,6 +226,40 @@ def validate_vlm_parameters(vlm: VLM | str, result: Any, kwargs: dict[str, Any])
     return void(vlm, result, kwargs)  # type: ignore[no-any-return]
 
 
+def _filter_by_classes(
+    xyxy: npt.NDArray[Any],
+    class_name: npt.NDArray[Any],
+    classes: list[str],
+) -> tuple[npt.NDArray[Any], npt.NDArray[Any], npt.NDArray[Any]]:
+    """Keep detections whose class name is in `classes` and assign `class_id`.
+
+    Shared by the VLM parsers (`from_paligemma`, `from_qwen_2_5_vl`,
+    `from_deepseek_vl_2`, `from_google_gemini_2_0`) that all filter detections with
+    an identical `name in classes` mask and then derive `class_id` from
+    `classes.index(name)` - extracting it once keeps that mask/index pairing from
+    drifting between callers.
+
+    Args:
+        xyxy: Array of shape `(n, 4)` with box coordinates, aligned with
+            `class_name`.
+        class_name: Array of shape `(n,)` with class labels.
+        classes: List of valid class names to keep; also used to assign
+            `class_id` via `classes.index(name)`.
+
+    Returns:
+        A tuple of `(xyxy, class_name, class_id)` narrowed to the detections
+            whose class name is in `classes`, where `class_id` is an array of
+            shape `(n,)` with indices into `classes`.
+    """
+    mask = np.array([name in classes for name in class_name], dtype=bool)
+    xyxy = xyxy[mask]
+    class_name = class_name[mask]
+    # `dtype=int` matters only when every detection is filtered out: an empty list
+    # would otherwise make NumPy pick `float64` for an array of class indices.
+    class_id = np.array([classes.index(name) for name in class_name], dtype=int)
+    return xyxy, class_name, class_id
+
+
 def from_paligemma(
     result: str, resolution_wh: tuple[int, int], classes: list[str] | None = None
 ) -> tuple[npt.NDArray[Any], npt.NDArray[Any] | None, npt.NDArray[Any]]:
@@ -260,10 +295,9 @@ def from_paligemma(
     class_id: npt.NDArray[Any] | None = None
 
     if classes is not None:
-        mask = np.array([name in classes for name in class_name], dtype=bool)
-        xyxy_arr = xyxy_arr[mask]
-        class_name = class_name[mask]
-        class_id = np.array([classes.index(name) for name in class_name])
+        xyxy_arr, class_name, class_id = _filter_by_classes(
+            xyxy_arr, class_name, classes
+        )
 
     return xyxy_arr, class_id, class_name
 
@@ -394,10 +428,7 @@ def from_qwen_2_5_vl(
     class_id = None
 
     if classes is not None:
-        mask = np.array([label in classes for label in class_name], dtype=bool)
-        xyxy = xyxy[mask]
-        class_name = class_name[mask]
-        class_id = np.array([classes.index(label) for label in class_name], dtype=int)
+        xyxy, class_name, class_id = _filter_by_classes(xyxy, class_name, classes)
 
     return xyxy, class_id, class_name
 
@@ -494,10 +525,7 @@ def from_deepseek_vl_2(
     )
 
     if classes is not None:
-        mask = np.array([name in classes for name in class_name], dtype=bool)
-        xyxy = xyxy[mask]
-        class_name = class_name[mask]
-        class_id = np.array([classes.index(name) for name in class_name])
+        xyxy, class_name, class_id = _filter_by_classes(xyxy, class_name, classes)
     else:
         unique_classes = sorted(list(set(class_name)))
         class_to_id = {name: i for i, name in enumerate(unique_classes)}
@@ -688,6 +716,30 @@ def _recover_gemini_boxes_payload(text: str) -> dict[str, Any] | None:
     return {"boxes": _recover_gemini_json_objects(text[array_index:])}
 
 
+def _parse_gemini_json(result: str, recover: Callable[[str], Any]) -> Any:
+    """Strip a Gemini response's markdown fence and decode its JSON payload.
+
+    Shared by the Gemini parsers (`from_google_gemini_2_0`, `from_google_gemini_2_5`,
+    `from_google_gemini_3_6`) that all fence-strip then `json.loads`, falling back to
+    a recovery function on `JSONDecodeError` - extracting it once keeps that
+    strip/decode/recover sequence from drifting between callers as each targets a
+    different malformed-response shape.
+
+    Args:
+        result: Raw response text, which may wrap its JSON in a ```json fence.
+        recover: Called with the fence-stripped text when `json.loads` fails;
+            returns the best-effort recovered payload.
+
+    Returns:
+        The decoded JSON value, or whatever `recover` returns when decoding fails.
+    """
+    stripped = _strip_gemini_json_fence(result)
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return recover(stripped)
+
+
 def _parse_gemini_boxes(
     items: list[dict[str, Any]],
     resolution_wh: tuple[int, int],
@@ -823,18 +875,13 @@ def from_google_gemini_2_0(
     """
     w, h = _validate_resolution(resolution_wh)
 
-    result = _strip_gemini_json_fence(result)
-
-    try:
-        data = json.loads(result)
-    except json.JSONDecodeError:
-        data = _recover_gemini_json_objects(result)
+    data = _parse_gemini_json(result, _recover_gemini_json_objects)
 
     if not isinstance(data, list):
         return np.empty((0, 4)), np.empty((0,), dtype=int), np.empty((0,), dtype=str)
 
     labels = []
-    xyxy = []
+    xyxy_list = []
 
     for item in data:
         if not isinstance(item, dict) or "box_2d" not in item or "label" not in item:
@@ -842,13 +889,13 @@ def from_google_gemini_2_0(
         labels.append(item["label"])
         box = item["box_2d"]
         # Gemini bbox order is [y_min, x_min, y_max, x_max]
-        xyxy.append([box[1], box[0], box[3], box[2]])
+        xyxy_list.append([box[1], box[0], box[3], box[2]])
 
-    if len(xyxy) == 0:
+    if len(xyxy_list) == 0:
         return np.empty((0, 4)), np.empty((0,), dtype=int), np.empty((0,), dtype=str)
 
     xyxy = denormalize_boxes(
-        np.array(xyxy, dtype=np.float64),
+        np.array(xyxy_list, dtype=np.float64),
         resolution_wh=(w, h),
         normalization_factor=1000,
     )
@@ -856,10 +903,7 @@ def from_google_gemini_2_0(
     class_id = None
 
     if classes is not None:
-        mask = np.array([name in classes for name in class_name], dtype=bool)
-        xyxy = xyxy[mask]
-        class_name = class_name[mask]
-        class_id = np.array([classes.index(name) for name in class_name])
+        xyxy, class_name, class_id = _filter_by_classes(xyxy, class_name, classes)
 
     return xyxy, class_id, class_name
 
@@ -909,12 +953,7 @@ def from_google_gemini_2_5(
     """
     w, h = _validate_resolution(resolution_wh)
 
-    result = _strip_gemini_json_fence(result)
-
-    try:
-        data = json.loads(result)
-    except json.JSONDecodeError:
-        data = _recover_gemini_json_objects(result)
+    data = _parse_gemini_json(result, _recover_gemini_json_objects)
 
     empty_result = (
         np.empty((0, 4)),
@@ -1070,12 +1109,7 @@ def from_google_gemini_3_6(
     """
     w, h = _validate_resolution(resolution_wh)
 
-    result = _strip_gemini_json_fence(result)
-
-    try:
-        payload = json.loads(result)
-    except json.JSONDecodeError:
-        payload = _recover_gemini_boxes_payload(result)
+    payload = _parse_gemini_json(result, _recover_gemini_boxes_payload)
 
     if not isinstance(payload, dict) or not isinstance(payload.get("boxes"), list):
         return (

--- a/src/supervision/metrics/_confusion_matrix_metric.py
+++ b/src/supervision/metrics/_confusion_matrix_metric.py
@@ -1,0 +1,677 @@
+"""Shared implementation behind the confusion-matrix detection metrics.
+
+`Precision`, `Recall` and `F1Score` reduce detections to the very same per-class,
+per-IoU-threshold `(TP, FP, FN)` matrix. They differ only in the formula applied to
+that matrix, in the result dataclass they fill, and in the labels used when a result
+is rendered. This module owns everything they share.
+
+The public classes stay in their own modules on purpose: the API reference does not
+enable `inherited_members`, so a public method moved onto a shared base would silently
+disappear from the rendered documentation.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeVar, cast
+
+import numpy as np
+import numpy.typing as npt
+
+from supervision.config import ORIENTED_BOX_COORDINATES
+from supervision.detection.compact_mask import CompactMask
+from supervision.detection.core import Detections
+from supervision.detection.utils.iou_and_nms import (
+    box_iou_batch,
+    mask_iou_batch,
+    oriented_box_iou_batch,
+)
+from supervision.draw.color import LEGACY_COLOR_PALETTE
+from supervision.metrics.core import AveragingMethod, Metric, MetricTarget
+from supervision.metrics.utils.matching import (
+    _match_detection_batch_with_target_indices,
+)
+from supervision.metrics.utils.object_size import (
+    ObjectSizeCategory,
+    get_detection_size_category,
+)
+from supervision.metrics.utils.utils import ensure_pandas_installed
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+_ResultT = TypeVar("_ResultT")
+
+
+def _validate_confusion_matrix(confusion_matrix: npt.NDArray[np.float64]) -> None:
+    """Raise when the last axis does not hold `(TP, FP, FN)` triplets.
+
+    Guards every metric formula, which indexes that axis positionally and would
+    otherwise silently score whatever the caller passed in.
+    """
+    if not confusion_matrix.shape[-1] == 3:
+        raise ValueError(
+            f"Confusion matrix must have shape (..., 3), got {confusion_matrix.shape}"
+        )
+
+
+class _ConfusionMatrixMetric(Metric[_ResultT]):
+    """Shared machinery for metrics derived from a `(TP, FP, FN)` confusion matrix.
+
+    Subclasses keep their own public `__init__`, `reset`, `update` and `compute` so
+    that the API reference keeps rendering them, and supply the metric-specific parts
+    through three hooks: the `_metric_name` used in error messages, the
+    `_score_from_confusion_matrix` formula, and the `_build_result` factory.
+    """
+
+    #: Name of the metric as it appears in error messages, e.g. `"Precision"`.
+    _metric_name: ClassVar[str]
+
+    _metric_target: MetricTarget
+    averaging_method: AveragingMethod
+    _predictions_list: list[Detections]
+    _targets_list: list[Detections]
+
+    @abstractmethod
+    def _score_from_confusion_matrix(
+        self, confusion_matrix: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Return the metric value implied by each entry of the confusion matrix."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _build_result(
+        self,
+        scores: npt.NDArray[np.float64],
+        per_class_scores: npt.NDArray[np.float64],
+        iou_thresholds: npt.NDArray[np.float32],
+        matched_classes: npt.NDArray[np.int32],
+    ) -> _ResultT:
+        """Wrap computed scores in the metric-specific result dataclass."""
+        raise NotImplementedError
+
+    def _compute(
+        self,
+        predictions_list: list[Detections],
+        targets_list: list[Detections],
+        size_category: ObjectSizeCategory = ObjectSizeCategory.ANY,
+    ) -> _ResultT:
+        """Build per-image stats tuples and delegate to class-level computation.
+
+        Each stats tuple is
+        ``(matches, ignored_matches, confidence, class_ids, true_class_ids)``:
+        - Both empty: skip (no information).
+        - Targets empty, predictions present: all predictions are FPs; true_class_ids
+          is ``zeros((0,))``.
+        - Targets present: IoU matching produces ``matches`` array.
+        """
+        iou_thresholds = np.linspace(0.5, 0.95, 10, dtype=np.float32)
+        stats: list[Any] = []
+
+        for predictions, targets in zip(predictions_list, targets_list):
+            prediction_contents = self._detections_content(predictions)
+            target_contents = self._detections_content(targets)
+            prediction_size_mask = np.ones(len(predictions), dtype=bool)
+            target_size_mask = np.ones(len(targets), dtype=bool)
+            if size_category != ObjectSizeCategory.ANY:
+                if len(predictions) > 0:
+                    prediction_size_mask = (
+                        get_detection_size_category(predictions, self._metric_target)
+                        == size_category.value
+                    )
+                if len(targets) > 0:
+                    target_size_mask = (
+                        get_detection_size_category(targets, self._metric_target)
+                        == size_category.value
+                    )
+
+            if len(targets) == 0 and len(predictions) > 0:
+                # Only predictions are present (e.g. a background image); every
+                # prediction is a false positive. Their classes are still tracked so
+                # that `matched_classes` agrees across the three metrics.
+                if predictions.class_id is None or predictions.confidence is None:
+                    raise ValueError(
+                        f"{self._metric_name} metric requires `class_id` and "
+                        "`confidence` on predictions."
+                    )
+                prediction_class_ids = np.asarray(predictions.class_id, dtype=np.int32)[
+                    prediction_size_mask
+                ]
+                prediction_confidence = np.asarray(
+                    predictions.confidence, dtype=np.float32
+                )[prediction_size_mask]
+                if len(prediction_class_ids) == 0:
+                    continue
+                stats.append(
+                    (
+                        np.zeros(
+                            (len(prediction_class_ids), iou_thresholds.size),
+                            dtype=np.bool_,
+                        ),
+                        np.zeros(
+                            (len(prediction_class_ids), iou_thresholds.size),
+                            dtype=np.bool_,
+                        ),
+                        prediction_confidence,
+                        prediction_class_ids,
+                        np.zeros((0,), dtype=np.int32),
+                    )
+                )
+            elif len(targets) > 0:
+                if predictions.class_id is None or targets.class_id is None:
+                    raise ValueError(
+                        f"{self._metric_name} metric requires `class_id` on both "
+                        "predictions and targets."
+                    )
+                if len(predictions) == 0:
+                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)[
+                        target_size_mask
+                    ]
+                    if len(target_class_ids) == 0:
+                        continue
+                    stats.append(
+                        (
+                            np.zeros((0, iou_thresholds.size), dtype=bool),
+                            np.zeros((0, iou_thresholds.size), dtype=bool),
+                            np.zeros((0,), dtype=np.float32),
+                            np.zeros((0,), dtype=int),
+                            target_class_ids,
+                        )
+                    )
+
+                else:
+                    if predictions.confidence is None:
+                        raise ValueError(
+                            f"{self._metric_name} metric requires `confidence` on "
+                            "predictions."
+                        )
+                    prediction_class_ids = np.asarray(
+                        predictions.class_id, dtype=np.int32
+                    )
+                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)
+                    prediction_confidence = np.asarray(
+                        predictions.confidence, dtype=np.float32
+                    )
+                    if self._metric_target == MetricTarget.BOXES:
+                        # BOXES target never yields CompactMask; narrow for mypy.
+                        iou = box_iou_batch(
+                            cast(npt.NDArray[np.number], target_contents),
+                            cast(npt.NDArray[np.number], prediction_contents),
+                        )
+                    elif self._metric_target == MetricTarget.MASKS:
+                        iou = mask_iou_batch(target_contents, prediction_contents)
+                    elif self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
+                        # OBB target never yields CompactMask; narrow for mypy.
+                        iou = oriented_box_iou_batch(
+                            cast(npt.NDArray[np.number], target_contents),
+                            cast(npt.NDArray[np.number], prediction_contents),
+                        )
+                    else:
+                        raise ValueError(
+                            "Unsupported metric target for IoU calculation"
+                        )
+
+                    # None keeps the matcher on its single-round fast path
+                    # when no size bucket is scored.
+                    target_scored_mask = (
+                        target_size_mask
+                        if size_category != ObjectSizeCategory.ANY
+                        else None
+                    )
+                    matches, matched_target_indices = (
+                        _match_detection_batch_with_target_indices(
+                            prediction_class_ids,
+                            target_class_ids,
+                            iou,
+                            iou_thresholds,
+                            target_scored_mask=target_scored_mask,
+                        )
+                    )
+                    ignored_matches = np.zeros_like(matches, dtype=bool)
+                    if size_category != ObjectSizeCategory.ANY:
+                        valid_target_match = matched_target_indices >= 0
+                        matched_scored_target = np.zeros_like(matches, dtype=bool)
+                        if np.any(valid_target_match):
+                            matched_scored_target[valid_target_match] = (
+                                target_size_mask[
+                                    matched_target_indices[valid_target_match]
+                                ]
+                            )
+                        prediction_scored = (
+                            prediction_size_mask[:, None] | matched_scored_target
+                        )
+                        ignored_matches = ~prediction_scored | (
+                            valid_target_match & ~matched_scored_target
+                        )
+                        prediction_keep = np.any(~ignored_matches, axis=1)
+                        matches = (
+                            matches[prediction_keep]
+                            & matched_scored_target[prediction_keep]
+                        )
+                        ignored_matches = ignored_matches[prediction_keep]
+                        prediction_confidence = prediction_confidence[prediction_keep]
+                        prediction_class_ids = prediction_class_ids[prediction_keep]
+                        target_class_ids = target_class_ids[target_size_mask]
+                        if (
+                            len(prediction_class_ids) == 0
+                            and len(target_class_ids) == 0
+                        ):
+                            continue
+                    stats.append(
+                        (
+                            matches,
+                            ignored_matches,
+                            prediction_confidence,
+                            prediction_class_ids,
+                            target_class_ids,
+                        )
+                    )
+
+        if not stats:
+            return self._build_result(
+                scores=np.zeros(iou_thresholds.shape[0]),
+                per_class_scores=np.zeros((0, iou_thresholds.shape[0])),
+                iou_thresholds=iou_thresholds,
+                matched_classes=np.array([], dtype=int),
+            )
+
+        concatenated_stats = [np.concatenate(items, 0) for items in zip(*stats)]
+        scores, per_class_scores, unique_classes = self._compute_scores_for_classes(
+            *concatenated_stats
+        )
+
+        return self._build_result(
+            scores=scores,
+            per_class_scores=per_class_scores,
+            iou_thresholds=iou_thresholds,
+            matched_classes=unique_classes,
+        )
+
+    def _compute_scores_for_classes(
+        self,
+        matches: npt.NDArray[np.bool_],
+        ignored_matches: npt.NDArray[np.bool_],
+        prediction_confidence: npt.NDArray[np.float32],
+        prediction_class_ids: npt.NDArray[np.int32],
+        true_class_ids: npt.NDArray[np.int32],
+    ) -> tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.int32],
+    ]:
+        """Compute per-class and aggregated scores from stats of all images.
+
+        ``unique_classes`` is the union of ground-truth and predicted classes, so a
+        class that only ever appears in the predictions is tracked with a score of
+        `0.0` rather than dropped. This keeps the tracked class set identical across
+        the three metrics and matches sklearn, which infers labels from the union of
+        ``y_true`` and ``y_pred``.
+        """
+        sorted_indices = np.argsort(-prediction_confidence)
+        matches = matches[sorted_indices]
+        ignored_matches = ignored_matches[sorted_indices]
+        prediction_class_ids = prediction_class_ids[sorted_indices]
+        true_classes, true_counts = np.unique(true_class_ids, return_counts=True)
+        pred_classes = np.unique(prediction_class_ids)
+        # Dedupe each side first, then union1d the already-unique arrays: this skips
+        # union1d's internal re-sort/re-unique of the full concatenation and measured
+        # ~1.4x faster than np.unique(np.concatenate(...)). Deduping after the union
+        # (or union1d on the raw arrays) yields no speedup.
+        unique_classes = np.union1d(true_classes, pred_classes)
+        class_counts = np.zeros(unique_classes.shape[0], dtype=int)
+        class_counts[np.searchsorted(unique_classes, true_classes)] = true_counts
+
+        # Shape: PxTh,P,C,C -> CxThx3
+        confusion_matrix = self._compute_confusion_matrix(
+            matches, ignored_matches, prediction_class_ids, unique_classes, class_counts
+        )
+
+        # Shape: CxThx3 -> CxTh
+        per_class_scores = self._score_from_confusion_matrix(confusion_matrix)
+
+        # Shape: CxTh -> Th
+        if self.averaging_method == AveragingMethod.MACRO:
+            scores = np.mean(per_class_scores, axis=0)
+        elif self.averaging_method == AveragingMethod.MICRO:
+            confusion_matrix_merged = confusion_matrix.sum(0)
+            scores = self._score_from_confusion_matrix(confusion_matrix_merged)
+        elif self.averaging_method == AveragingMethod.WEIGHTED:
+            class_counts = class_counts.astype(np.float32)
+            if class_counts.sum() == 0:
+                # No ground-truth support (e.g. only false-positive classes, or a
+                # size bucket with predictions but no targets): weighting is
+                # undefined, so report 0 as the empty case did before.
+                scores = np.zeros(per_class_scores.shape[1])
+            else:
+                scores = np.average(per_class_scores, axis=0, weights=class_counts)
+
+        return scores, per_class_scores, unique_classes
+
+    @staticmethod
+    def _compute_confusion_matrix(
+        sorted_matches: npt.NDArray[np.bool_],
+        sorted_ignored_matches: npt.NDArray[np.bool_],
+        sorted_prediction_class_ids: npt.NDArray[np.int32],
+        unique_classes: npt.NDArray[np.integer],
+        class_counts: npt.NDArray[np.integer],
+    ) -> npt.NDArray[np.float64]:
+        """Compute the confusion matrix for each class and IoU threshold.
+
+        Assumes the matches and prediction_class_ids are sorted by confidence
+        in descending order.
+
+        Args:
+            sorted_matches: shape (P, Th), that is True
+                if the prediction is a true positive at the given IoU threshold.
+            sorted_ignored_matches: shape (P, Th), that is True
+                if the prediction should not affect the given IoU threshold.
+            sorted_prediction_class_ids: shape (P,), containing
+                the class id for each prediction.
+            unique_classes: shape (C,), containing the unique
+                class ids.
+            class_counts: shape (C,), containing the number
+                of true instances for each class.
+
+        Returns:
+            shape (C, Th, 3), containing the true positives, false
+                positives, and false negatives for each class and IoU threshold.
+        """
+        num_thresholds = sorted_matches.shape[1]
+        num_classes = unique_classes.shape[0]
+
+        confusion_matrix: npt.NDArray[np.float64] = np.zeros(
+            (num_classes, num_thresholds, 3), dtype=np.float64
+        )
+        for class_idx, class_id in enumerate(unique_classes):
+            is_class = sorted_prediction_class_ids == class_id
+            num_true = class_counts[class_idx]
+            num_predictions = is_class.sum()
+
+            if num_predictions == 0:
+                true_positives = np.zeros(num_thresholds)
+                false_positives = np.zeros(num_thresholds)
+                false_negatives = np.full(num_thresholds, num_true)
+            elif num_true == 0:
+                true_positives = np.zeros(num_thresholds)
+                false_positives = (~sorted_ignored_matches[is_class]).sum(0)
+                false_negatives = np.zeros(num_thresholds)
+            else:
+                true_positives = sorted_matches[is_class].sum(0)
+                false_positives = (
+                    ~sorted_matches[is_class] & ~sorted_ignored_matches[is_class]
+                ).sum(0)
+                false_negatives = num_true - true_positives
+            confusion_matrix[class_idx] = np.stack(
+                [true_positives, false_positives, false_negatives], axis=1
+            )
+        return confusion_matrix
+
+    def _detections_content(
+        self, detections: Detections
+    ) -> npt.NDArray[Any] | CompactMask:
+        """Return boxes, masks or oriented bounding boxes from detections.
+
+        For the mask target this may return a
+        :class:`~supervision.detection.compact_mask.CompactMask` rather than a
+        dense boolean array when the detections carry compact masks.
+        """
+        if self._metric_target == MetricTarget.BOXES:
+            return cast(npt.NDArray[Any], detections.xyxy)
+        if self._metric_target == MetricTarget.MASKS:
+            if detections.mask is not None:
+                # detections.mask is NDArray[bool] | CompactMask; return as-is.
+                return detections.mask
+            if len(detections) > 0:
+                raise ValueError(
+                    f"{self._metric_name} with `MetricTarget.MASKS` requires "
+                    "detections to include masks."
+                )
+            return self._make_empty_content()
+        if self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
+            obb = detections.data.get(ORIENTED_BOX_COORDINATES)
+            if obb is not None and len(obb) > 0:
+                result_obb: npt.NDArray[np.float32] = np.array(obb, dtype=np.float32)
+                return result_obb
+            return self._make_empty_content()
+        raise ValueError(f"Invalid metric target: {self._metric_target}")
+
+    def _make_empty_content(self) -> npt.NDArray[Any]:
+        """Return the empty content array matching the configured metric target."""
+        if self._metric_target == MetricTarget.BOXES:
+            empty_boxes: npt.NDArray[np.float32] = np.empty((0, 4), dtype=np.float32)
+            return empty_boxes
+        if self._metric_target == MetricTarget.MASKS:
+            empty_masks: npt.NDArray[np.bool_] = np.empty((0, 0, 0), dtype=bool)
+            return empty_masks
+        if self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
+            empty_obb: npt.NDArray[np.float32] = np.empty((0, 4, 2), dtype=np.float32)
+            return empty_obb
+        raise ValueError(f"Invalid metric target: {self._metric_target}")
+
+    def _filter_detections_by_size(
+        self, detections: Detections, size_category: ObjectSizeCategory
+    ) -> Detections:
+        """Return a copy of detections with contents filtered by object size."""
+        new_detections = deepcopy(detections)
+        if detections.is_empty() or size_category == ObjectSizeCategory.ANY:
+            return new_detections
+
+        sizes = get_detection_size_category(new_detections, self._metric_target)
+        size_mask = sizes == size_category.value
+
+        new_detections.xyxy = new_detections.xyxy[size_mask]
+        if new_detections.mask is not None:
+            new_detections.mask = new_detections.mask[size_mask]
+        if new_detections.class_id is not None:
+            new_detections.class_id = new_detections.class_id[size_mask]
+        if new_detections.confidence is not None:
+            new_detections.confidence = new_detections.confidence[size_mask]
+        if new_detections.tracker_id is not None:
+            new_detections.tracker_id = new_detections.tracker_id[size_mask]
+        if new_detections.data is not None:
+            for key, value in new_detections.data.items():
+                new_detections.data[key] = np.array(value)[size_mask]
+
+        return new_detections
+
+    def _filter_predictions_and_targets_by_size(
+        self,
+        predictions_list: list[Detections],
+        targets_list: list[Detections],
+        size_category: ObjectSizeCategory,
+    ) -> tuple[list[Detections], list[Detections]]:
+        """Filter predictions and targets by object size category."""
+        new_predictions_list = []
+        new_targets_list = []
+        for predictions, targets in zip(predictions_list, targets_list):
+            new_predictions_list.append(
+                self._filter_detections_by_size(predictions, size_category)
+            )
+            new_targets_list.append(
+                self._filter_detections_by_size(targets, size_category)
+            )
+        return new_predictions_list, new_targets_list
+
+
+@dataclass(frozen=True)
+class _ResultLabels:
+    """Metric-specific wording used when a result is printed, tabulated or plotted.
+
+    Attributes:
+        short: compact label, e.g. `"P"`; used in score lines, DataFrame columns
+            and object-size plot labels.
+        long: full metric name, e.g. `"Precision"`; heads the per-class listing and
+            the two headline plot labels.
+        plot_title: metric name as it opens the plot title, e.g. `"F1 Score"`.
+        metric_target_padding: spacing between `"Metric target:"` and its value.
+    """
+
+    short: str
+    long: str
+    plot_title: str
+    metric_target_padding: str
+
+
+@dataclass(frozen=True)
+class _ResultView:
+    """Field-name-agnostic snapshot of one metric result.
+
+    The three result dataclasses expose the same values under different public field
+    names (`precision_scores`, `recall_scores`, `f1_scores`, ...), so the shared
+    renderers work on this view instead of on the results themselves.
+    """
+
+    class_name: str
+    labels: _ResultLabels
+    metric_target: MetricTarget
+    averaging_method: AveragingMethod
+    score_at_50: float
+    score_at_75: float
+    scores: npt.NDArray[np.float64]
+    per_class_scores: npt.NDArray[np.float64]
+    iou_thresholds: npt.NDArray[np.float32]
+    matched_classes: npt.NDArray[np.int32]
+    small_objects: _ResultView | None
+    medium_objects: _ResultView | None
+    large_objects: _ResultView | None
+
+
+class _SupportsResultView(Protocol):
+    """A metric result able to describe itself as a `_ResultView`."""
+
+    def _result_view(self) -> _ResultView:
+        """Return the field-name-agnostic view of this result."""
+        ...
+
+
+def _optional_result_view(result: _SupportsResultView | None) -> _ResultView | None:
+    """Return the view of an optional nested object-size result."""
+    if result is None:
+        return None
+    return result._result_view()
+
+
+def _format_result(view: _ResultView) -> str:
+    """Render a metric result and its object-size breakdown as a pretty string.
+
+    Every score line is padded to a column derived from the longest of them, so metric
+    labels of differing width still line up under each other.
+    """
+    labels = view.labels
+    value_column = len(f"{labels.short} @ thresh:") + 1
+    score_at_50_label = f"{labels.short} @ 50:".ljust(value_column)
+    score_at_75_label = f"{labels.short} @ 75:".ljust(value_column)
+    scores_label = f"{labels.short} @ thresh:".ljust(value_column)
+    iou_thresholds_label = "IoU thresh:".ljust(value_column)
+
+    out_str = (
+        f"{view.class_name}:\n"
+        f"Metric target:{labels.metric_target_padding}{view.metric_target}\n"
+        f"Averaging method: {view.averaging_method}\n"
+        f"{score_at_50_label}{view.score_at_50:.4f}\n"
+        f"{score_at_75_label}{view.score_at_75:.4f}\n"
+        f"{scores_label}{view.scores}\n"
+        f"{iou_thresholds_label}{view.iou_thresholds}\n"
+        f"{labels.long} per class:\n"
+    )
+    if view.per_class_scores.size == 0:
+        out_str += "  No results\n"
+    for class_id, score_of_class in zip(view.matched_classes, view.per_class_scores):
+        out_str += f"  {class_id}: {score_of_class}\n"
+
+    indent = "  "
+    for name, bucket in (
+        ("Small", view.small_objects),
+        ("Medium", view.medium_objects),
+        ("Large", view.large_objects),
+    ):
+        if bucket is None:
+            continue
+        indented = indent + _format_result(bucket).replace("\n", f"\n{indent}")
+        out_str += f"\n{name} objects:\n{indented}"
+
+    return out_str
+
+
+def _result_to_pandas(view: _ResultView) -> pd.DataFrame:
+    """Convert a metric result and its object-size breakdown to a one-row DataFrame."""
+    ensure_pandas_installed()
+    import pandas as pd
+
+    short = view.labels.short
+    pandas_data: dict[str, Any] = {
+        f"{short}@50": view.score_at_50,
+        f"{short}@75": view.score_at_75,
+    }
+
+    for prefix, bucket in (
+        ("small_objects", view.small_objects),
+        ("medium_objects", view.medium_objects),
+        ("large_objects", view.large_objects),
+    ):
+        if bucket is None:
+            continue
+        bucket_frame = _result_to_pandas(bucket)
+        for key, value in bucket_frame.items():
+            pandas_data[f"{prefix}_{key}"] = value
+
+    return pd.DataFrame(pandas_data, index=[0])
+
+
+def _plot_result(view: _ResultView) -> None:
+    """Plot the metric value at IoU 0.5 and 0.75, split by object size."""
+    from matplotlib import pyplot as plt
+
+    result_labels = view.labels
+    labels = [f"{result_labels.long}@50", f"{result_labels.long}@75"]
+    values = [view.score_at_50, view.score_at_75]
+    colors = [LEGACY_COLOR_PALETTE[0]] * 2
+
+    for name, palette_index, bucket in (
+        ("Small", 3, view.small_objects),
+        ("Medium", 2, view.medium_objects),
+        ("Large", 4, view.large_objects),
+    ):
+        if bucket is None:
+            continue
+        labels += [
+            f"{name}: {result_labels.short}@50",
+            f"{name}: {result_labels.short}@75",
+        ]
+        values += [bucket.score_at_50, bucket.score_at_75]
+        colors += [LEGACY_COLOR_PALETTE[palette_index]] * 2
+
+    plt.rcParams["font.family"] = "monospace"
+
+    _, ax = plt.subplots(figsize=(10, 6))
+    ax.set_ylim(0, 1)
+    ax.set_ylabel("Value", fontweight="bold")
+    title = (
+        f"{result_labels.plot_title}, by Object Size"
+        f"\n(target: {view.metric_target.value},"
+        f" averaging: {view.averaging_method.value})"
+    )
+    ax.set_title(title, fontweight="bold")
+
+    x_positions = range(len(labels))
+    bars = ax.bar(x_positions, values, color=colors, align="center")
+
+    ax.set_xticks(x_positions)
+    ax.set_xticklabels(labels, rotation=45, ha="right")
+
+    for bar in bars:
+        y_value = bar.get_height()
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            y_value + 0.02,
+            f"{y_value:.2f}",
+            ha="center",
+            va="bottom",
+        )
+
+    plt.rcParams["font.family"] = "sans-serif"
+
+    plt.tight_layout()
+    plt.show()

--- a/src/supervision/metrics/f1_score.py
+++ b/src/supervision/metrics/f1_score.py
@@ -1,36 +1,37 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
-from supervision.config import ORIENTED_BOX_COORDINATES
-from supervision.detection.compact_mask import CompactMask
 from supervision.detection.core import Detections
-from supervision.detection.utils.iou_and_nms import (
-    box_iou_batch,
-    mask_iou_batch,
-    oriented_box_iou_batch,
+from supervision.metrics._confusion_matrix_metric import (
+    _ConfusionMatrixMetric,
+    _format_result,
+    _optional_result_view,
+    _plot_result,
+    _result_to_pandas,
+    _ResultLabels,
+    _ResultView,
+    _validate_confusion_matrix,
 )
-from supervision.draw.color import LEGACY_COLOR_PALETTE
-from supervision.metrics.core import AveragingMethod, Metric, MetricTarget
-from supervision.metrics.utils.matching import (
-    _match_detection_batch_with_target_indices,
-)
-from supervision.metrics.utils.object_size import (
-    ObjectSizeCategory,
-    get_detection_size_category,
-)
-from supervision.metrics.utils.utils import ensure_pandas_installed
+from supervision.metrics.core import AveragingMethod, MetricTarget
+from supervision.metrics.utils.object_size import ObjectSizeCategory
 
 if TYPE_CHECKING:
     import pandas as pd
 
+_F1_LABELS = _ResultLabels(
+    short="F1",
+    long="F1",
+    plot_title="F1 Score",
+    metric_target_padding=" ",
+)
 
-class F1Score(Metric["F1ScoreResult"]):
+
+class F1Score(_ConfusionMatrixMetric["F1ScoreResult"]):
     """F1 Score is a metric used to evaluate object detection models. It is the harmonic
     mean of precision and recall, calculated at different IoU thresholds.
 
@@ -64,6 +65,8 @@ class F1Score(Metric["F1ScoreResult"]):
         https://media.roboflow.com/supervision-docs/metrics/f1_plot_example.png
     ){ align=center width="800" }
     """
+
+    _metric_name = "F1Score"
 
     def __init__(
         self,
@@ -138,340 +141,31 @@ class F1Score(Metric["F1ScoreResult"]):
 
         return result
 
-    def _compute(
+    def _score_from_confusion_matrix(
+        self, confusion_matrix: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Return the F1 score implied by each entry of the confusion matrix."""
+        return self._compute_f1(confusion_matrix)
+
+    def _build_result(
         self,
-        predictions_list: list[Detections],
-        targets_list: list[Detections],
-        size_category: ObjectSizeCategory = ObjectSizeCategory.ANY,
+        scores: npt.NDArray[np.float64],
+        per_class_scores: npt.NDArray[np.float64],
+        iou_thresholds: npt.NDArray[np.float32],
+        matched_classes: npt.NDArray[np.int32],
     ) -> F1ScoreResult:
-        """Build per-image stats tuples and delegate to class-level computation.
-
-        Each stats tuple is
-        ``(matches, ignored_matches, confidence, class_ids, true_class_ids)``:
-        - Both empty: skip (no information).
-        - Targets empty, predictions present: all predictions are FPs; true_class_ids
-          is ``zeros((0,))``.
-        - Targets present: IoU matching produces ``matches`` array.
-        """
-        iou_thresholds = np.linspace(0.5, 0.95, 10, dtype=np.float32)
-        stats: list[Any] = []
-
-        for predictions, targets in zip(predictions_list, targets_list):
-            prediction_contents = self._detections_content(predictions)
-            target_contents = self._detections_content(targets)
-            prediction_size_mask = np.ones(len(predictions), dtype=bool)
-            target_size_mask = np.ones(len(targets), dtype=bool)
-            if size_category != ObjectSizeCategory.ANY:
-                if len(predictions) > 0:
-                    prediction_size_mask = (
-                        get_detection_size_category(predictions, self._metric_target)
-                        == size_category.value
-                    )
-                if len(targets) > 0:
-                    target_size_mask = (
-                        get_detection_size_category(targets, self._metric_target)
-                        == size_category.value
-                    )
-
-            if len(targets) == 0 and len(predictions) > 0:
-                # Only predictions are present (e.g. a background image); every
-                # prediction is a false positive.
-                if predictions.class_id is None or predictions.confidence is None:
-                    raise ValueError(
-                        "F1Score metric requires `class_id` and `confidence` "
-                        "on predictions."
-                    )
-                prediction_class_ids = np.asarray(predictions.class_id, dtype=np.int32)[
-                    prediction_size_mask
-                ]
-                prediction_confidence = np.asarray(
-                    predictions.confidence, dtype=np.float32
-                )[prediction_size_mask]
-                if len(prediction_class_ids) == 0:
-                    continue
-                stats.append(
-                    (
-                        np.zeros(
-                            (len(prediction_class_ids), iou_thresholds.size),
-                            dtype=np.bool_,
-                        ),
-                        np.zeros(
-                            (len(prediction_class_ids), iou_thresholds.size),
-                            dtype=np.bool_,
-                        ),
-                        prediction_confidence,
-                        prediction_class_ids,
-                        np.zeros((0,), dtype=np.int32),
-                    )
-                )
-            elif len(targets) > 0:
-                if predictions.class_id is None or targets.class_id is None:
-                    raise ValueError(
-                        "F1Score metric requires `class_id` on both predictions "
-                        "and targets."
-                    )
-                if len(predictions) == 0:
-                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)[
-                        target_size_mask
-                    ]
-                    if len(target_class_ids) == 0:
-                        continue
-                    stats.append(
-                        (
-                            np.zeros((0, iou_thresholds.size), dtype=bool),
-                            np.zeros((0, iou_thresholds.size), dtype=bool),
-                            np.zeros((0,), dtype=np.float32),
-                            np.zeros((0,), dtype=int),
-                            target_class_ids,
-                        )
-                    )
-
-                else:
-                    if predictions.confidence is None:
-                        raise ValueError(
-                            "F1Score metric requires `confidence` on predictions."
-                        )
-                    prediction_class_ids = np.asarray(
-                        predictions.class_id, dtype=np.int32
-                    )
-                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)
-                    prediction_confidence = np.asarray(
-                        predictions.confidence, dtype=np.float32
-                    )
-                    if self._metric_target == MetricTarget.BOXES:
-                        # BOXES target never yields CompactMask; narrow for mypy.
-                        iou = box_iou_batch(
-                            cast(npt.NDArray[np.number], target_contents),
-                            cast(npt.NDArray[np.number], prediction_contents),
-                        )
-                    elif self._metric_target == MetricTarget.MASKS:
-                        iou = mask_iou_batch(target_contents, prediction_contents)
-                    elif self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
-                        # OBB target never yields CompactMask; narrow for mypy.
-                        iou = oriented_box_iou_batch(
-                            cast(npt.NDArray[np.number], target_contents),
-                            cast(npt.NDArray[np.number], prediction_contents),
-                        )
-                    else:
-                        raise ValueError(
-                            "Unsupported metric target for IoU calculation"
-                        )
-
-                    # None keeps the matcher on its single-round fast path
-                    # when no size bucket is scored.
-                    target_scored_mask = (
-                        target_size_mask
-                        if size_category != ObjectSizeCategory.ANY
-                        else None
-                    )
-                    matches, matched_target_indices = (
-                        _match_detection_batch_with_target_indices(
-                            prediction_class_ids,
-                            target_class_ids,
-                            iou,
-                            iou_thresholds,
-                            target_scored_mask=target_scored_mask,
-                        )
-                    )
-                    ignored_matches = np.zeros_like(matches, dtype=bool)
-                    if size_category != ObjectSizeCategory.ANY:
-                        valid_target_match = matched_target_indices >= 0
-                        matched_scored_target = np.zeros_like(matches, dtype=bool)
-                        if np.any(valid_target_match):
-                            matched_scored_target[valid_target_match] = (
-                                target_size_mask[
-                                    matched_target_indices[valid_target_match]
-                                ]
-                            )
-                        prediction_scored = (
-                            prediction_size_mask[:, None] | matched_scored_target
-                        )
-                        ignored_matches = ~prediction_scored | (
-                            valid_target_match & ~matched_scored_target
-                        )
-                        prediction_keep = np.any(~ignored_matches, axis=1)
-                        matches = (
-                            matches[prediction_keep]
-                            & matched_scored_target[prediction_keep]
-                        )
-                        ignored_matches = ignored_matches[prediction_keep]
-                        prediction_confidence = prediction_confidence[prediction_keep]
-                        prediction_class_ids = prediction_class_ids[prediction_keep]
-                        target_class_ids = target_class_ids[target_size_mask]
-                        if (
-                            len(prediction_class_ids) == 0
-                            and len(target_class_ids) == 0
-                        ):
-                            continue
-                    stats.append(
-                        (
-                            matches,
-                            ignored_matches,
-                            prediction_confidence,
-                            prediction_class_ids,
-                            target_class_ids,
-                        )
-                    )
-
-        if not stats:
-            return F1ScoreResult(
-                metric_target=self._metric_target,
-                averaging_method=self.averaging_method,
-                f1_scores=np.zeros(iou_thresholds.shape[0]),
-                f1_per_class=np.zeros((0, iou_thresholds.shape[0])),
-                iou_thresholds=iou_thresholds,
-                matched_classes=np.array([], dtype=int),
-                small_objects=None,
-                medium_objects=None,
-                large_objects=None,
-            )
-
-        concatenated_stats = [np.concatenate(items, 0) for items in zip(*stats)]
-        f1_scores, f1_per_class, unique_classes = self._compute_f1_for_classes(
-            *concatenated_stats
-        )
-
+        """Wrap the computed F1 scores in an `F1ScoreResult`."""
         return F1ScoreResult(
             metric_target=self._metric_target,
             averaging_method=self.averaging_method,
-            f1_scores=f1_scores,
-            f1_per_class=f1_per_class,
+            f1_scores=scores,
+            f1_per_class=per_class_scores,
             iou_thresholds=iou_thresholds,
-            matched_classes=unique_classes,
+            matched_classes=matched_classes,
             small_objects=None,
             medium_objects=None,
             large_objects=None,
         )
-
-    def _compute_f1_for_classes(
-        self,
-        matches: npt.NDArray[np.bool_],
-        ignored_matches: npt.NDArray[np.bool_],
-        prediction_confidence: npt.NDArray[np.float32],
-        prediction_class_ids: npt.NDArray[np.int32],
-        true_class_ids: npt.NDArray[np.int32],
-    ) -> tuple[
-        npt.NDArray[np.float64],
-        npt.NDArray[np.float64],
-        npt.NDArray[np.int32],
-    ]:
-        """Compute F1 scores from concatenated stats across all images.
-
-        ``unique_classes`` is the union of GT and predicted classes so that predictions
-        of classes absent from GT still count as false positives.
-        """
-        sorted_indices = np.argsort(-prediction_confidence)
-        matches = matches[sorted_indices]
-        ignored_matches = ignored_matches[sorted_indices]
-        prediction_class_ids = prediction_class_ids[sorted_indices]
-        # Predictions whose class never appears in the ground truth are still
-        # false positives, so include those classes in the confusion matrix
-        # (their true-instance count is zero).
-        unique_classes = np.unique(
-            np.concatenate((true_class_ids, prediction_class_ids))
-        )
-        true_classes, true_counts = np.unique(true_class_ids, return_counts=True)
-        class_counts = np.zeros(unique_classes.shape[0], dtype=int)
-        class_counts[np.searchsorted(unique_classes, true_classes)] = true_counts
-
-        # Shape: PxTh,P,C,C -> CxThx3
-        confusion_matrix = self._compute_confusion_matrix(
-            matches, ignored_matches, prediction_class_ids, unique_classes, class_counts
-        )
-
-        # Shape: CxThx3 -> CxTh
-        f1_per_class = self._compute_f1(confusion_matrix)
-
-        # Shape: CxTh -> Th
-        if self.averaging_method == AveragingMethod.MACRO:
-            f1_scores = np.mean(f1_per_class, axis=0)
-        elif self.averaging_method == AveragingMethod.MICRO:
-            confusion_matrix_merged = confusion_matrix.sum(0)
-            f1_scores = self._compute_f1(confusion_matrix_merged)
-        elif self.averaging_method == AveragingMethod.WEIGHTED:
-            class_counts = class_counts.astype(np.float32)
-            if class_counts.sum() == 0:
-                # No ground-truth support (e.g. only false-positive classes, or a
-                # size bucket with predictions but no targets): weighting is
-                # undefined, so report 0 as the empty case did before.
-                f1_scores = np.zeros(f1_per_class.shape[1])
-            else:
-                f1_scores = np.average(f1_per_class, axis=0, weights=class_counts)
-
-        return f1_scores, f1_per_class, unique_classes
-
-    @staticmethod
-    def _match_detection_batch(
-        predictions_classes: npt.NDArray[np.int32],
-        target_classes: npt.NDArray[np.int32],
-        iou: npt.NDArray[np.float32],
-        iou_thresholds: npt.NDArray[np.float32],
-    ) -> npt.NDArray[np.bool_]:
-        result_correct, _ = _match_detection_batch_with_target_indices(
-            predictions_classes, target_classes, iou, iou_thresholds
-        )
-        return result_correct
-
-    @staticmethod
-    def _compute_confusion_matrix(
-        sorted_matches: npt.NDArray[np.bool_],
-        sorted_ignored_matches: npt.NDArray[np.bool_],
-        sorted_prediction_class_ids: npt.NDArray[np.int32],
-        unique_classes: npt.NDArray[np.int32],
-        class_counts: npt.NDArray[np.int32],
-    ) -> npt.NDArray[np.float64]:
-        """Compute the confusion matrix for each class and IoU threshold.
-
-        Assumes the matches and prediction_class_ids are sorted by confidence
-        in descending order.
-
-        Args:
-            sorted_matches: shape (P, Th), that is True
-                if the prediction is a true positive at the given IoU threshold.
-            sorted_ignored_matches: shape (P, Th), that is True
-                if the prediction should not affect the given IoU threshold.
-            sorted_prediction_class_ids: shape (P,), containing
-                the class id for each prediction.
-            unique_classes: shape (C,), containing the unique
-                class ids.
-            class_counts: shape (C,), containing the number
-                of true instances for each class.
-
-        Returns:
-            shape (C, Th, 3), containing the true positives, false
-                positives, and false negatives for each class and IoU threshold.
-        """
-        num_thresholds = sorted_matches.shape[1]
-        num_classes = unique_classes.shape[0]
-
-        confusion_matrix: npt.NDArray[np.float64] = np.zeros(
-            (num_classes, num_thresholds, 3), dtype=np.float64
-        )
-        for class_idx, class_id in enumerate(unique_classes):
-            is_class = sorted_prediction_class_ids == class_id
-            num_true = class_counts[class_idx]
-            num_predictions = is_class.sum()
-
-            if num_predictions == 0:
-                true_positives = np.zeros(num_thresholds)
-                false_positives = np.zeros(num_thresholds)
-                false_negatives = np.full(num_thresholds, num_true)
-            elif num_true == 0:
-                true_positives = np.zeros(num_thresholds)
-                false_positives = (~sorted_ignored_matches[is_class]).sum(0)
-                false_negatives = np.zeros(num_thresholds)
-            else:
-                true_positives = sorted_matches[is_class].sum(0)
-                false_positives = (
-                    ~sorted_matches[is_class] & ~sorted_ignored_matches[is_class]
-                ).sum(0)
-                false_negatives = num_true - true_positives
-            confusion_matrix[class_idx] = np.stack(
-                [true_positives, false_positives, false_negatives], axis=1
-            )
-
-        result_confusion_matrix: npt.NDArray[np.float64] = confusion_matrix
-        return result_confusion_matrix
 
     @staticmethod
     def _compute_f1(
@@ -486,11 +180,7 @@ class F1Score(Metric["F1ScoreResult"]):
         Returns:
             shape (N, ...), containing the F1 score for each element.
         """
-        if not confusion_matrix.shape[-1] == 3:
-            raise ValueError(
-                f"Confusion matrix must have shape (..., 3), got "
-                f"{confusion_matrix.shape}"
-            )
+        _validate_confusion_matrix(confusion_matrix)
         true_positives = confusion_matrix[..., 0]
         false_positives = confusion_matrix[..., 1]
         false_negatives = confusion_matrix[..., 2]
@@ -506,91 +196,6 @@ class F1Score(Metric["F1ScoreResult"]):
 
         result_f1_score: npt.NDArray[np.float64] = f1_score
         return result_f1_score
-
-    def _detections_content(
-        self, detections: Detections
-    ) -> npt.NDArray[Any] | CompactMask:
-        """Return boxes, masks or oriented bounding boxes from detections.
-
-        For the mask target this may return a
-        :class:`~supervision.detection.compact_mask.CompactMask` rather than a
-        dense boolean array when the detections carry compact masks.
-        """
-        if self._metric_target == MetricTarget.BOXES:
-            return cast(npt.NDArray[Any], detections.xyxy)
-        if self._metric_target == MetricTarget.MASKS:
-            if detections.mask is not None:
-                # detections.mask is NDArray[bool] | CompactMask; return as-is.
-                return detections.mask
-            if len(detections) > 0:
-                raise ValueError(
-                    "F1Score with `MetricTarget.MASKS` requires detections to "
-                    "include masks."
-                )
-            return self._make_empty_content()
-        if self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
-            obb = detections.data.get(ORIENTED_BOX_COORDINATES)
-            if obb is not None and len(obb) > 0:
-                result_obb: npt.NDArray[np.float32] = np.array(obb, dtype=np.float32)
-                return result_obb
-            return self._make_empty_content()
-        raise ValueError(f"Invalid metric target: {self._metric_target}")
-
-    def _make_empty_content(self) -> npt.NDArray[Any]:
-        if self._metric_target == MetricTarget.BOXES:
-            empty_boxes: npt.NDArray[np.float32] = np.empty((0, 4), dtype=np.float32)
-            return empty_boxes
-        if self._metric_target == MetricTarget.MASKS:
-            empty_masks: npt.NDArray[np.bool_] = np.empty((0, 0, 0), dtype=bool)
-            return empty_masks
-        if self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
-            empty_obb: npt.NDArray[np.float32] = np.empty((0, 4, 2), dtype=np.float32)
-            return empty_obb
-        raise ValueError(f"Invalid metric target: {self._metric_target}")
-
-    def _filter_detections_by_size(
-        self, detections: Detections, size_category: ObjectSizeCategory
-    ) -> Detections:
-        """Return a copy of detections with contents filtered by object size."""
-        new_detections = deepcopy(detections)
-        if detections.is_empty() or size_category == ObjectSizeCategory.ANY:
-            return new_detections
-
-        sizes = get_detection_size_category(new_detections, self._metric_target)
-        size_mask = sizes == size_category.value
-
-        new_detections.xyxy = new_detections.xyxy[size_mask]
-        if new_detections.mask is not None:
-            new_detections.mask = new_detections.mask[size_mask]
-        if new_detections.class_id is not None:
-            new_detections.class_id = new_detections.class_id[size_mask]
-        if new_detections.confidence is not None:
-            new_detections.confidence = new_detections.confidence[size_mask]
-        if new_detections.tracker_id is not None:
-            new_detections.tracker_id = new_detections.tracker_id[size_mask]
-        if new_detections.data is not None:
-            for key, value in new_detections.data.items():
-                new_detections.data[key] = np.array(value)[size_mask]
-
-        return new_detections
-
-    def _filter_predictions_and_targets_by_size(
-        self,
-        predictions_list: list[Detections],
-        targets_list: list[Detections],
-        size_category: ObjectSizeCategory,
-    ) -> tuple[list[Detections], list[Detections]]:
-        """Filter predictions and targets by object size category."""
-        new_predictions_list = []
-        new_targets_list = []
-        for predictions, targets in zip(predictions_list, targets_list):
-            new_predictions_list.append(
-                self._filter_detections_by_size(predictions, size_category)
-            )
-            new_targets_list.append(
-                self._filter_detections_by_size(targets, size_category)
-            )
-        return new_predictions_list, new_targets_list
 
 
 @dataclass
@@ -643,6 +248,24 @@ class F1ScoreResult:
     medium_objects: F1ScoreResult | None
     large_objects: F1ScoreResult | None
 
+    def _result_view(self) -> _ResultView:
+        """Describe this result in the form the shared renderers consume."""
+        return _ResultView(
+            class_name=self.__class__.__name__,
+            labels=_F1_LABELS,
+            metric_target=self.metric_target,
+            averaging_method=self.averaging_method,
+            score_at_50=self.f1_50,
+            score_at_75=self.f1_75,
+            scores=self.f1_scores,
+            per_class_scores=self.f1_per_class,
+            iou_thresholds=self.iou_thresholds,
+            matched_classes=self.matched_classes,
+            small_objects=_optional_result_view(self.small_objects),
+            medium_objects=_optional_result_view(self.medium_objects),
+            large_objects=_optional_result_view(self.large_objects),
+        )
+
     def __str__(self) -> str:
         """Format as a pretty string.
 
@@ -682,33 +305,7 @@ class F1ScoreResult:
 
             ```
         """
-        out_str = (
-            f"{self.__class__.__name__}:\n"
-            f"Metric target: {self.metric_target}\n"
-            f"Averaging method: {self.averaging_method}\n"
-            f"F1 @ 50:     {self.f1_50:.4f}\n"
-            f"F1 @ 75:     {self.f1_75:.4f}\n"
-            f"F1 @ thresh: {self.f1_scores}\n"
-            f"IoU thresh:  {self.iou_thresholds}\n"
-            f"F1 per class:\n"
-        )
-        if self.f1_per_class.size == 0:
-            out_str += "  No results\n"
-        for class_id, f1_of_class in zip(self.matched_classes, self.f1_per_class):
-            out_str += f"  {class_id}: {f1_of_class}\n"
-
-        indent = "  "
-        if self.small_objects is not None:
-            indented = indent + str(self.small_objects).replace("\n", f"\n{indent}")
-            out_str += f"\nSmall objects:\n{indented}"
-        if self.medium_objects is not None:
-            indented = indent + str(self.medium_objects).replace("\n", f"\n{indent}")
-            out_str += f"\nMedium objects:\n{indented}"
-        if self.large_objects is not None:
-            indented = indent + str(self.large_objects).replace("\n", f"\n{indent}")
-            out_str += f"\nLarge objects:\n{indented}"
-
-        return out_str
+        return _format_result(self._result_view())
 
     def to_pandas(self) -> pd.DataFrame:
         """Convert the result to a pandas DataFrame.
@@ -716,28 +313,7 @@ class F1ScoreResult:
         Returns:
             The result as a DataFrame.
         """
-        ensure_pandas_installed()
-        import pandas as pd
-
-        pandas_data: dict[str, Any] = {
-            "F1@50": self.f1_50,
-            "F1@75": self.f1_75,
-        }
-
-        if self.small_objects is not None:
-            small_objects_df = self.small_objects.to_pandas()
-            for key, value in small_objects_df.items():
-                pandas_data[f"small_objects_{key}"] = value
-        if self.medium_objects is not None:
-            medium_objects_df = self.medium_objects.to_pandas()
-            for key, value in medium_objects_df.items():
-                pandas_data[f"medium_objects_{key}"] = value
-        if self.large_objects is not None:
-            large_objects_df = self.large_objects.to_pandas()
-            for key, value in large_objects_df.items():
-                pandas_data[f"large_objects_{key}"] = value
-
-        return pd.DataFrame(pandas_data, index=[0])
+        return _result_to_pandas(self._result_view())
 
     def plot(self) -> None:
         """Plot the F1 results.
@@ -746,59 +322,4 @@ class F1ScoreResult:
         https://media.roboflow.com/supervision-docs/metrics/f1_plot_example.png
         ){ align=center width="800" }
         """
-        from matplotlib import pyplot as plt
-
-        labels = ["F1@50", "F1@75"]
-        values = [self.f1_50, self.f1_75]
-        colors = [LEGACY_COLOR_PALETTE[0]] * 2
-
-        if self.small_objects is not None:
-            small_objects = self.small_objects
-            labels += ["Small: F1@50", "Small: F1@75"]
-            values += [small_objects.f1_50, small_objects.f1_75]
-            colors += [LEGACY_COLOR_PALETTE[3]] * 2
-
-        if self.medium_objects is not None:
-            medium_objects = self.medium_objects
-            labels += ["Medium: F1@50", "Medium: F1@75"]
-            values += [medium_objects.f1_50, medium_objects.f1_75]
-            colors += [LEGACY_COLOR_PALETTE[2]] * 2
-
-        if self.large_objects is not None:
-            large_objects = self.large_objects
-            labels += ["Large: F1@50", "Large: F1@75"]
-            values += [large_objects.f1_50, large_objects.f1_75]
-            colors += [LEGACY_COLOR_PALETTE[4]] * 2
-
-        plt.rcParams["font.family"] = "monospace"
-
-        _, ax = plt.subplots(figsize=(10, 6))
-        ax.set_ylim(0, 1)
-        ax.set_ylabel("Value", fontweight="bold")
-        title = (
-            f"F1 Score, by Object Size"
-            f"\n(target: {self.metric_target.value},"
-            f" averaging: {self.averaging_method.value})"
-        )
-        ax.set_title(title, fontweight="bold")
-
-        x_positions = range(len(labels))
-        bars = ax.bar(x_positions, values, color=colors, align="center")
-
-        ax.set_xticks(x_positions)
-        ax.set_xticklabels(labels, rotation=45, ha="right")
-
-        for bar in bars:
-            y_value = bar.get_height()
-            ax.text(
-                bar.get_x() + bar.get_width() / 2,
-                y_value + 0.02,
-                f"{y_value:.2f}",
-                ha="center",
-                va="bottom",
-            )
-
-        plt.rcParams["font.family"] = "sans-serif"
-
-        plt.tight_layout()
-        plt.show()
+        _plot_result(self._result_view())

--- a/src/supervision/metrics/precision.py
+++ b/src/supervision/metrics/precision.py
@@ -1,35 +1,37 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
-from supervision.config import ORIENTED_BOX_COORDINATES
 from supervision.detection.core import Detections
-from supervision.detection.utils.iou_and_nms import (
-    box_iou_batch,
-    mask_iou_batch,
-    oriented_box_iou_batch,
+from supervision.metrics._confusion_matrix_metric import (
+    _ConfusionMatrixMetric,
+    _format_result,
+    _optional_result_view,
+    _plot_result,
+    _result_to_pandas,
+    _ResultLabels,
+    _ResultView,
+    _validate_confusion_matrix,
 )
-from supervision.draw.color import LEGACY_COLOR_PALETTE
-from supervision.metrics.core import AveragingMethod, Metric, MetricTarget
-from supervision.metrics.utils.matching import (
-    _match_detection_batch_with_target_indices,
-)
-from supervision.metrics.utils.object_size import (
-    ObjectSizeCategory,
-    get_detection_size_category,
-)
-from supervision.metrics.utils.utils import ensure_pandas_installed
+from supervision.metrics.core import AveragingMethod, MetricTarget
+from supervision.metrics.utils.object_size import ObjectSizeCategory
 
 if TYPE_CHECKING:
     import pandas as pd
 
+_PRECISION_LABELS = _ResultLabels(
+    short="P",
+    long="Precision",
+    plot_title="Precision",
+    metric_target_padding="    ",
+)
 
-class Precision(Metric["PrecisionResult"]):
+
+class Precision(_ConfusionMatrixMetric["PrecisionResult"]):
     """Precision is a metric used to evaluate object detection models. It is the ratio
     of true positive detections to the total number of predicted detections. We
     calculate it at different IoU thresholds.
@@ -66,6 +68,8 @@ class Precision(Metric["PrecisionResult"]):
         https://media.roboflow.com/supervision-docs/metrics/precision_plot_example.png
     ){ align=center width="800" }
     """
+
+    _metric_name = "Precision"
 
     def __init__(
         self,
@@ -140,335 +144,31 @@ class Precision(Metric["PrecisionResult"]):
 
         return result
 
-    def _compute(
+    def _score_from_confusion_matrix(
+        self, confusion_matrix: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Return the precision implied by each entry of the confusion matrix."""
+        return self._compute_precision(confusion_matrix)
+
+    def _build_result(
         self,
-        predictions_list: list[Detections],
-        targets_list: list[Detections],
-        size_category: ObjectSizeCategory = ObjectSizeCategory.ANY,
+        scores: npt.NDArray[np.float64],
+        per_class_scores: npt.NDArray[np.float64],
+        iou_thresholds: npt.NDArray[np.float32],
+        matched_classes: npt.NDArray[np.int32],
     ) -> PrecisionResult:
-        """Build per-image stats tuples and delegate to class-level computation.
-
-        Each stats tuple is
-        ``(matches, ignored_matches, confidence, class_ids, true_class_ids)``:
-        - Both empty: skip (no information).
-        - Targets empty, predictions present: all predictions are FPs; true_class_ids
-          is ``zeros((0,))``.
-        - Targets present: IoU matching produces ``matches`` array.
-        """
-        iou_thresholds = np.linspace(0.5, 0.95, 10, dtype=np.float32)
-        stats: list[Any] = []
-
-        for predictions, targets in zip(predictions_list, targets_list):
-            prediction_contents = self._detections_content(predictions)
-            target_contents = self._detections_content(targets)
-            prediction_size_mask = np.ones(len(predictions), dtype=bool)
-            target_size_mask = np.ones(len(targets), dtype=bool)
-            if size_category != ObjectSizeCategory.ANY:
-                if len(predictions) > 0:
-                    prediction_size_mask = (
-                        get_detection_size_category(predictions, self._metric_target)
-                        == size_category.value
-                    )
-                if len(targets) > 0:
-                    target_size_mask = (
-                        get_detection_size_category(targets, self._metric_target)
-                        == size_category.value
-                    )
-
-            if len(targets) == 0 and len(predictions) > 0:
-                # Only predictions are present (e.g. a background image); every
-                # prediction is a false positive.
-                if predictions.class_id is None or predictions.confidence is None:
-                    raise ValueError(
-                        "Precision metric requires `class_id` and `confidence` "
-                        "on predictions."
-                    )
-                prediction_class_ids = np.asarray(predictions.class_id, dtype=np.int32)[
-                    prediction_size_mask
-                ]
-                prediction_confidence = np.asarray(
-                    predictions.confidence, dtype=np.float32
-                )[prediction_size_mask]
-                if len(prediction_class_ids) == 0:
-                    continue
-                stats.append(
-                    (
-                        np.zeros(
-                            (len(prediction_class_ids), iou_thresholds.size),
-                            dtype=np.bool_,
-                        ),
-                        np.zeros(
-                            (len(prediction_class_ids), iou_thresholds.size),
-                            dtype=np.bool_,
-                        ),
-                        prediction_confidence,
-                        prediction_class_ids,
-                        np.zeros((0,), dtype=np.int32),
-                    )
-                )
-            elif len(targets) > 0:
-                if predictions.class_id is None or targets.class_id is None:
-                    raise ValueError(
-                        "Precision metric requires `class_id` on both predictions "
-                        "and targets."
-                    )
-                if len(predictions) == 0:
-                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)[
-                        target_size_mask
-                    ]
-                    if len(target_class_ids) == 0:
-                        continue
-                    stats.append(
-                        (
-                            np.zeros((0, iou_thresholds.size), dtype=bool),
-                            np.zeros((0, iou_thresholds.size), dtype=bool),
-                            np.zeros((0,), dtype=np.float32),
-                            np.zeros((0,), dtype=int),
-                            target_class_ids,
-                        )
-                    )
-
-                else:
-                    if predictions.confidence is None:
-                        raise ValueError(
-                            "Precision metric requires `confidence` on predictions."
-                        )
-                    prediction_class_ids = np.asarray(
-                        predictions.class_id, dtype=np.int32
-                    )
-                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)
-                    prediction_confidence = np.asarray(
-                        predictions.confidence, dtype=np.float32
-                    )
-                    if self._metric_target == MetricTarget.BOXES:
-                        iou = box_iou_batch(target_contents, prediction_contents)
-                    elif self._metric_target == MetricTarget.MASKS:
-                        iou = mask_iou_batch(target_contents, prediction_contents)
-                    elif self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
-                        iou = oriented_box_iou_batch(
-                            target_contents, prediction_contents
-                        )
-                    else:
-                        raise ValueError(
-                            "Unsupported metric target for IoU calculation"
-                        )
-
-                    # None keeps the matcher on its single-round fast path
-                    # when no size bucket is scored.
-                    target_scored_mask = (
-                        target_size_mask
-                        if size_category != ObjectSizeCategory.ANY
-                        else None
-                    )
-                    matches, matched_target_indices = (
-                        _match_detection_batch_with_target_indices(
-                            prediction_class_ids,
-                            target_class_ids,
-                            iou,
-                            iou_thresholds,
-                            target_scored_mask=target_scored_mask,
-                        )
-                    )
-                    ignored_matches = np.zeros_like(matches, dtype=bool)
-                    if size_category != ObjectSizeCategory.ANY:
-                        valid_target_match = matched_target_indices >= 0
-                        matched_scored_target = np.zeros_like(matches, dtype=bool)
-                        if np.any(valid_target_match):
-                            matched_scored_target[valid_target_match] = (
-                                target_size_mask[
-                                    matched_target_indices[valid_target_match]
-                                ]
-                            )
-                        prediction_scored = (
-                            prediction_size_mask[:, None] | matched_scored_target
-                        )
-                        ignored_matches = ~prediction_scored | (
-                            valid_target_match & ~matched_scored_target
-                        )
-                        prediction_keep = np.any(~ignored_matches, axis=1)
-                        matches = (
-                            matches[prediction_keep]
-                            & matched_scored_target[prediction_keep]
-                        )
-                        ignored_matches = ignored_matches[prediction_keep]
-                        prediction_confidence = prediction_confidence[prediction_keep]
-                        prediction_class_ids = prediction_class_ids[prediction_keep]
-                        target_class_ids = target_class_ids[target_size_mask]
-                        if (
-                            len(prediction_class_ids) == 0
-                            and len(target_class_ids) == 0
-                        ):
-                            continue
-                    stats.append(
-                        (
-                            matches,
-                            ignored_matches,
-                            prediction_confidence,
-                            prediction_class_ids,
-                            target_class_ids,
-                        )
-                    )
-
-        if not stats:
-            return PrecisionResult(
-                metric_target=self._metric_target,
-                averaging_method=self.averaging_method,
-                precision_scores=np.zeros(iou_thresholds.shape[0]),
-                precision_per_class=np.zeros((0, iou_thresholds.shape[0])),
-                iou_thresholds=iou_thresholds,
-                matched_classes=np.array([], dtype=int),
-                small_objects=None,
-                medium_objects=None,
-                large_objects=None,
-            )
-
-        concatenated_stats = [np.concatenate(items, 0) for items in zip(*stats)]
-        precision_scores, precision_per_class, unique_classes = (
-            self._compute_precision_for_classes(*concatenated_stats)
-        )
-
+        """Wrap the computed precision scores in a `PrecisionResult`."""
         return PrecisionResult(
             metric_target=self._metric_target,
             averaging_method=self.averaging_method,
-            precision_scores=precision_scores,
-            precision_per_class=precision_per_class,
+            precision_scores=scores,
+            precision_per_class=per_class_scores,
             iou_thresholds=iou_thresholds,
-            matched_classes=unique_classes,
+            matched_classes=matched_classes,
             small_objects=None,
             medium_objects=None,
             large_objects=None,
         )
-
-    def _compute_precision_for_classes(
-        self,
-        matches: npt.NDArray[np.bool_],
-        ignored_matches: npt.NDArray[np.bool_],
-        prediction_confidence: npt.NDArray[np.float32],
-        prediction_class_ids: npt.NDArray[np.int32],
-        true_class_ids: npt.NDArray[np.int32],
-    ) -> tuple[
-        npt.NDArray[np.float64],
-        npt.NDArray[np.float64],
-        npt.NDArray[np.int32],
-    ]:
-        """Compute precision scores from concatenated stats across all images.
-
-        ``unique_classes`` is the union of GT and predicted classes so that predictions
-        of classes absent from GT still count as false positives.
-        """
-        sorted_indices = np.argsort(-prediction_confidence)
-        matches = matches[sorted_indices]
-        ignored_matches = ignored_matches[sorted_indices]
-        prediction_class_ids = prediction_class_ids[sorted_indices]
-        # Predictions whose class never appears in the ground truth are still
-        # false positives, so include those classes in the confusion matrix
-        # (their true-instance count is zero).
-        unique_classes = np.unique(
-            np.concatenate((true_class_ids, prediction_class_ids))
-        )
-        true_classes, true_counts = np.unique(true_class_ids, return_counts=True)
-        class_counts = np.zeros(unique_classes.shape[0], dtype=int)
-        class_counts[np.searchsorted(unique_classes, true_classes)] = true_counts
-
-        # Shape: PxTh,P,C,C -> CxThx3
-        confusion_matrix = self._compute_confusion_matrix(
-            matches, ignored_matches, prediction_class_ids, unique_classes, class_counts
-        )
-
-        # Shape: CxThx3 -> CxTh
-        precision_per_class = self._compute_precision(confusion_matrix)
-
-        # Shape: CxTh -> Th
-        if self.averaging_method == AveragingMethod.MACRO:
-            precision_scores = np.mean(precision_per_class, axis=0)
-        elif self.averaging_method == AveragingMethod.MICRO:
-            confusion_matrix_merged = confusion_matrix.sum(0)
-            precision_scores = self._compute_precision(confusion_matrix_merged)
-        elif self.averaging_method == AveragingMethod.WEIGHTED:
-            class_counts = class_counts.astype(np.float32)
-            if class_counts.sum() == 0:
-                # No ground-truth support (e.g. only false-positive classes, or a
-                # size bucket with predictions but no targets): weighting is
-                # undefined, so report 0 as the empty case did before.
-                precision_scores = np.zeros(precision_per_class.shape[1])
-            else:
-                precision_scores = np.average(
-                    precision_per_class, axis=0, weights=class_counts
-                )
-
-        return precision_scores, precision_per_class, unique_classes
-
-    @staticmethod
-    def _match_detection_batch(
-        predictions_classes: npt.NDArray[np.int32],
-        target_classes: npt.NDArray[np.int32],
-        iou: npt.NDArray[np.float32],
-        iou_thresholds: npt.NDArray[np.float32],
-    ) -> npt.NDArray[np.bool_]:
-        result_correct, _ = _match_detection_batch_with_target_indices(
-            predictions_classes, target_classes, iou, iou_thresholds
-        )
-        return result_correct
-
-    @staticmethod
-    def _compute_confusion_matrix(
-        sorted_matches: npt.NDArray[np.bool_],
-        sorted_ignored_matches: npt.NDArray[np.bool_],
-        sorted_prediction_class_ids: npt.NDArray[np.int32],
-        unique_classes: npt.NDArray[np.int32],
-        class_counts: npt.NDArray[np.int32],
-    ) -> npt.NDArray[np.float64]:
-        """Compute the confusion matrix for each class and IoU threshold.
-
-        Assumes the matches and prediction_class_ids are sorted by confidence
-        in descending order.
-
-        Args:
-            sorted_matches: shape (P, Th), that is True
-                if the prediction is a true positive at the given IoU threshold.
-            sorted_ignored_matches: shape (P, Th), that is True
-                if the prediction should not affect the given IoU threshold.
-            sorted_prediction_class_ids: shape (P,), containing
-                the class id for each prediction.
-            unique_classes: shape (C,), containing the unique
-                class ids.
-            class_counts: shape (C,), containing the number
-                of true instances for each class.
-
-        Returns:
-            shape (C, Th, 3), containing the true positives, false
-                positives, and false negatives for each class and IoU threshold.
-        """
-        num_thresholds = sorted_matches.shape[1]
-        num_classes = unique_classes.shape[0]
-
-        confusion_matrix: npt.NDArray[np.float64] = np.zeros(
-            (num_classes, num_thresholds, 3), dtype=np.float64
-        )
-        for class_idx, class_id in enumerate(unique_classes):
-            is_class = sorted_prediction_class_ids == class_id
-            num_true = class_counts[class_idx]
-            num_predictions = is_class.sum()
-
-            if num_predictions == 0:
-                true_positives = np.zeros(num_thresholds)
-                false_positives = np.zeros(num_thresholds)
-                false_negatives = np.full(num_thresholds, num_true)
-            elif num_true == 0:
-                true_positives = np.zeros(num_thresholds)
-                false_positives = (~sorted_ignored_matches[is_class]).sum(0)
-                false_negatives = np.zeros(num_thresholds)
-            else:
-                true_positives = sorted_matches[is_class].sum(0)
-                false_positives = (
-                    ~sorted_matches[is_class] & ~sorted_ignored_matches[is_class]
-                ).sum(0)
-                false_negatives = num_true - true_positives
-            confusion_matrix[class_idx] = np.stack(
-                [true_positives, false_positives, false_negatives], axis=1
-            )
-        result_matrix: npt.NDArray[np.float64] = confusion_matrix
-        return result_matrix
 
     @staticmethod
     def _compute_precision(
@@ -483,11 +183,7 @@ class Precision(Metric["PrecisionResult"]):
         Returns:
             shape (N, ...), containing the precision for each element.
         """
-        if not confusion_matrix.shape[-1] == 3:
-            raise ValueError(
-                f"Confusion matrix must have shape (..., 3), got "
-                f"{confusion_matrix.shape}"
-            )
+        _validate_confusion_matrix(confusion_matrix)
         true_positives = confusion_matrix[..., 0]
         false_positives = confusion_matrix[..., 1]
 
@@ -501,86 +197,6 @@ class Precision(Metric["PrecisionResult"]):
 
         result_precision: npt.NDArray[np.float64] = precision
         return result_precision
-
-    def _detections_content(self, detections: Detections) -> npt.NDArray[Any]:
-        """Return boxes, masks or oriented bounding boxes from detections."""
-        if self._metric_target == MetricTarget.BOXES:
-            return cast(npt.NDArray[Any], detections.xyxy)
-        if self._metric_target == MetricTarget.MASKS:
-            if detections.mask is not None:
-                return cast(npt.NDArray[Any], detections.mask)
-            if len(detections) > 0:
-                raise ValueError(
-                    "Precision with `MetricTarget.MASKS` requires detections to "
-                    "include masks."
-                )
-            return self._make_empty_content()
-        if self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
-            obb = detections.data.get(ORIENTED_BOX_COORDINATES)
-            if obb is not None and len(obb) > 0:
-                result_obb: npt.NDArray[np.float32] = np.array(obb, dtype=np.float32)
-                return result_obb
-            return self._make_empty_content()
-        raise ValueError(f"Invalid metric target: {self._metric_target}")
-
-    def _make_empty_content(self) -> npt.NDArray[Any]:
-        if self._metric_target == MetricTarget.BOXES:
-            empty_boxes: npt.NDArray[np.float32] = np.empty((0, 4), dtype=np.float32)
-            return empty_boxes
-
-        if self._metric_target == MetricTarget.MASKS:
-            empty_masks: npt.NDArray[np.bool_] = np.empty((0, 0, 0), dtype=bool)
-            return empty_masks
-
-        if self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
-            empty_obb: npt.NDArray[np.float32] = np.empty((0, 4, 2), dtype=np.float32)
-            return empty_obb
-
-        raise ValueError(f"Invalid metric target: {self._metric_target}")
-
-    def _filter_detections_by_size(
-        self, detections: Detections, size_category: ObjectSizeCategory
-    ) -> Detections:
-        """Return a copy of detections with contents filtered by object size."""
-        new_detections = deepcopy(detections)
-        if detections.is_empty() or size_category == ObjectSizeCategory.ANY:
-            return new_detections
-
-        sizes = get_detection_size_category(new_detections, self._metric_target)
-        size_mask = sizes == size_category.value
-
-        new_detections.xyxy = new_detections.xyxy[size_mask]
-        if new_detections.mask is not None:
-            new_detections.mask = new_detections.mask[size_mask]
-        if new_detections.class_id is not None:
-            new_detections.class_id = new_detections.class_id[size_mask]
-        if new_detections.confidence is not None:
-            new_detections.confidence = new_detections.confidence[size_mask]
-        if new_detections.tracker_id is not None:
-            new_detections.tracker_id = new_detections.tracker_id[size_mask]
-        if new_detections.data is not None:
-            for key, value in new_detections.data.items():
-                new_detections.data[key] = np.array(value)[size_mask]
-
-        return new_detections
-
-    def _filter_predictions_and_targets_by_size(
-        self,
-        predictions_list: list[Detections],
-        targets_list: list[Detections],
-        size_category: ObjectSizeCategory,
-    ) -> tuple[list[Detections], list[Detections]]:
-        """Filter predictions and targets by object size category."""
-        new_predictions_list = []
-        new_targets_list = []
-        for predictions, targets in zip(predictions_list, targets_list):
-            new_predictions_list.append(
-                self._filter_detections_by_size(predictions, size_category)
-            )
-            new_targets_list.append(
-                self._filter_detections_by_size(targets, size_category)
-            )
-        return new_predictions_list, new_targets_list
 
 
 @dataclass
@@ -633,6 +249,24 @@ class PrecisionResult:
     medium_objects: PrecisionResult | None
     large_objects: PrecisionResult | None
 
+    def _result_view(self) -> _ResultView:
+        """Describe this result in the form the shared renderers consume."""
+        return _ResultView(
+            class_name=self.__class__.__name__,
+            labels=_PRECISION_LABELS,
+            metric_target=self.metric_target,
+            averaging_method=self.averaging_method,
+            score_at_50=self.precision_at_50,
+            score_at_75=self.precision_at_75,
+            scores=self.precision_scores,
+            per_class_scores=self.precision_per_class,
+            iou_thresholds=self.iou_thresholds,
+            matched_classes=self.matched_classes,
+            small_objects=_optional_result_view(self.small_objects),
+            medium_objects=_optional_result_view(self.medium_objects),
+            large_objects=_optional_result_view(self.large_objects),
+        )
+
     def __str__(self) -> str:
         """Format as a pretty string.
 
@@ -674,35 +308,7 @@ class PrecisionResult:
 
             ```
         """
-        out_str = (
-            f"{self.__class__.__name__}:\n"
-            f"Metric target:    {self.metric_target}\n"
-            f"Averaging method: {self.averaging_method}\n"
-            f"P @ 50:     {self.precision_at_50:.4f}\n"
-            f"P @ 75:     {self.precision_at_75:.4f}\n"
-            f"P @ thresh: {self.precision_scores}\n"
-            f"IoU thresh: {self.iou_thresholds}\n"
-            f"Precision per class:\n"
-        )
-        if self.precision_per_class.size == 0:
-            out_str += "  No results\n"
-        for class_id, precision_of_class in zip(
-            self.matched_classes, self.precision_per_class
-        ):
-            out_str += f"  {class_id}: {precision_of_class}\n"
-
-        indent = "  "
-        if self.small_objects is not None:
-            indented = indent + str(self.small_objects).replace("\n", f"\n{indent}")
-            out_str += f"\nSmall objects:\n{indented}"
-        if self.medium_objects is not None:
-            indented = indent + str(self.medium_objects).replace("\n", f"\n{indent}")
-            out_str += f"\nMedium objects:\n{indented}"
-        if self.large_objects is not None:
-            indented = indent + str(self.large_objects).replace("\n", f"\n{indent}")
-            out_str += f"\nLarge objects:\n{indented}"
-
-        return out_str
+        return _format_result(self._result_view())
 
     def to_pandas(self) -> pd.DataFrame:
         """Convert the result to a pandas DataFrame.
@@ -710,28 +316,7 @@ class PrecisionResult:
         Returns:
             The result as a DataFrame.
         """
-        ensure_pandas_installed()
-        import pandas as pd
-
-        pandas_data = {
-            "P@50": self.precision_at_50,
-            "P@75": self.precision_at_75,
-        }
-
-        if self.small_objects is not None:
-            small_objects_df = self.small_objects.to_pandas()
-            for key, value in small_objects_df.items():
-                pandas_data[f"small_objects_{key}"] = value
-        if self.medium_objects is not None:
-            medium_objects_df = self.medium_objects.to_pandas()
-            for key, value in medium_objects_df.items():
-                pandas_data[f"medium_objects_{key}"] = value
-        if self.large_objects is not None:
-            large_objects_df = self.large_objects.to_pandas()
-            for key, value in large_objects_df.items():
-                pandas_data[f"large_objects_{key}"] = value
-
-        return pd.DataFrame(pandas_data, index=[0])
+        return _result_to_pandas(self._result_view())
 
     def plot(self) -> None:
         """Plot the precision results.
@@ -740,59 +325,4 @@ class PrecisionResult:
         https://media.roboflow.com/supervision-docs/metrics/precision_plot_example.png
         ){ align=center width="800" }
         """
-        from matplotlib import pyplot as plt
-
-        labels = ["Precision@50", "Precision@75"]
-        values = [self.precision_at_50, self.precision_at_75]
-        colors = [LEGACY_COLOR_PALETTE[0]] * 2
-
-        if self.small_objects is not None:
-            small_objects = self.small_objects
-            labels += ["Small: P@50", "Small: P@75"]
-            values += [small_objects.precision_at_50, small_objects.precision_at_75]
-            colors += [LEGACY_COLOR_PALETTE[3]] * 2
-
-        if self.medium_objects is not None:
-            medium_objects = self.medium_objects
-            labels += ["Medium: P@50", "Medium: P@75"]
-            values += [medium_objects.precision_at_50, medium_objects.precision_at_75]
-            colors += [LEGACY_COLOR_PALETTE[2]] * 2
-
-        if self.large_objects is not None:
-            large_objects = self.large_objects
-            labels += ["Large: P@50", "Large: P@75"]
-            values += [large_objects.precision_at_50, large_objects.precision_at_75]
-            colors += [LEGACY_COLOR_PALETTE[4]] * 2
-
-        plt.rcParams["font.family"] = "monospace"
-
-        _, ax = plt.subplots(figsize=(10, 6))
-        ax.set_ylim(0, 1)
-        ax.set_ylabel("Value", fontweight="bold")
-        title = (
-            f"Precision, by Object Size"
-            f"\n(target: {self.metric_target.value},"
-            f" averaging: {self.averaging_method.value})"
-        )
-        ax.set_title(title, fontweight="bold")
-
-        x_positions = range(len(labels))
-        bars = ax.bar(x_positions, values, color=colors, align="center")
-
-        ax.set_xticks(x_positions)
-        ax.set_xticklabels(labels, rotation=45, ha="right")
-
-        for bar in bars:
-            y_value = bar.get_height()
-            ax.text(
-                bar.get_x() + bar.get_width() / 2,
-                y_value + 0.02,
-                f"{y_value:.2f}",
-                ha="center",
-                va="bottom",
-            )
-
-        plt.rcParams["font.family"] = "sans-serif"
-
-        plt.tight_layout()
-        plt.show()
+        _plot_result(self._result_view())

--- a/src/supervision/metrics/recall.py
+++ b/src/supervision/metrics/recall.py
@@ -1,36 +1,37 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
-from supervision.config import ORIENTED_BOX_COORDINATES
-from supervision.detection.compact_mask import CompactMask
 from supervision.detection.core import Detections
-from supervision.detection.utils.iou_and_nms import (
-    box_iou_batch,
-    mask_iou_batch,
-    oriented_box_iou_batch,
+from supervision.metrics._confusion_matrix_metric import (
+    _ConfusionMatrixMetric,
+    _format_result,
+    _optional_result_view,
+    _plot_result,
+    _result_to_pandas,
+    _ResultLabels,
+    _ResultView,
+    _validate_confusion_matrix,
 )
-from supervision.draw.color import LEGACY_COLOR_PALETTE
-from supervision.metrics.core import AveragingMethod, Metric, MetricTarget
-from supervision.metrics.utils.matching import (
-    _match_detection_batch_with_target_indices,
-)
-from supervision.metrics.utils.object_size import (
-    ObjectSizeCategory,
-    get_detection_size_category,
-)
-from supervision.metrics.utils.utils import ensure_pandas_installed
+from supervision.metrics.core import AveragingMethod, MetricTarget
+from supervision.metrics.utils.object_size import ObjectSizeCategory
 
 if TYPE_CHECKING:
     import pandas as pd
 
+_RECALL_LABELS = _ResultLabels(
+    short="R",
+    long="Recall",
+    plot_title="Recall",
+    metric_target_padding="    ",
+)
 
-class Recall(Metric["RecallResult"]):
+
+class Recall(_ConfusionMatrixMetric["RecallResult"]):
     """Recall is a metric used to evaluate object detection models. It is the ratio of
     true positive detections to the total number of ground truth instances. We calculate
     it at different IoU thresholds.
@@ -92,6 +93,8 @@ class Recall(Metric["RecallResult"]):
         https://media.roboflow.com/supervision-docs/metrics/recall_plot_example.png
     ){ align=center width="800" }
     """
+
+    _metric_name = "Recall"
 
     def __init__(
         self,
@@ -166,333 +169,31 @@ class Recall(Metric["RecallResult"]):
 
         return result
 
-    def _compute(
+    def _score_from_confusion_matrix(
+        self, confusion_matrix: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Return the recall implied by each entry of the confusion matrix."""
+        return self._compute_recall(confusion_matrix)
+
+    def _build_result(
         self,
-        predictions_list: list[Detections],
-        targets_list: list[Detections],
-        size_category: ObjectSizeCategory = ObjectSizeCategory.ANY,
+        scores: npt.NDArray[np.float64],
+        per_class_scores: npt.NDArray[np.float64],
+        iou_thresholds: npt.NDArray[np.float32],
+        matched_classes: npt.NDArray[np.int32],
     ) -> RecallResult:
-        iou_thresholds = np.linspace(0.5, 0.95, 10, dtype=np.float32)
-        stats: list[Any] = []
-
-        for predictions, targets in zip(predictions_list, targets_list):
-            prediction_contents = self._detections_content(predictions)
-            target_contents = self._detections_content(targets)
-            prediction_size_mask = np.ones(len(predictions), dtype=bool)
-            target_size_mask = np.ones(len(targets), dtype=bool)
-            if size_category != ObjectSizeCategory.ANY:
-                if len(predictions) > 0:
-                    prediction_size_mask = (
-                        get_detection_size_category(predictions, self._metric_target)
-                        == size_category.value
-                    )
-                if len(targets) > 0:
-                    target_size_mask = (
-                        get_detection_size_category(targets, self._metric_target)
-                        == size_category.value
-                    )
-
-            if len(targets) == 0 and len(predictions) > 0:
-                # Only predictions are present (e.g. a background image). They produce
-                # no false negatives, so no recall value changes, but the classes still
-                # have to be tracked or `matched_classes` silently disagrees with
-                # Precision and F1Score for the same input.
-                if predictions.class_id is None or predictions.confidence is None:
-                    raise ValueError(
-                        "Recall metric requires `class_id` and `confidence` "
-                        "on predictions."
-                    )
-                prediction_class_ids = np.asarray(predictions.class_id, dtype=np.int32)[
-                    prediction_size_mask
-                ]
-                prediction_confidence = np.asarray(
-                    predictions.confidence, dtype=np.float32
-                )[prediction_size_mask]
-                if len(prediction_class_ids) == 0:
-                    continue
-                stats.append(
-                    (
-                        np.zeros(
-                            (len(prediction_class_ids), iou_thresholds.size),
-                            dtype=np.bool_,
-                        ),
-                        np.zeros(
-                            (len(prediction_class_ids), iou_thresholds.size),
-                            dtype=np.bool_,
-                        ),
-                        prediction_confidence,
-                        prediction_class_ids,
-                        np.zeros((0,), dtype=np.int32),
-                    )
-                )
-            elif len(targets) > 0:
-                if predictions.class_id is None or targets.class_id is None:
-                    raise ValueError(
-                        "Recall metric requires `class_id` on both predictions "
-                        "and targets."
-                    )
-                if len(predictions) == 0:
-                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)[
-                        target_size_mask
-                    ]
-                    if len(target_class_ids) == 0:
-                        continue
-                    stats.append(
-                        (
-                            np.zeros((0, iou_thresholds.size), dtype=bool),
-                            np.zeros((0, iou_thresholds.size), dtype=bool),
-                            np.zeros((0,), dtype=np.float32),
-                            np.zeros((0,), dtype=int),
-                            target_class_ids,
-                        )
-                    )
-
-                else:
-                    if predictions.confidence is None:
-                        raise ValueError(
-                            "Recall metric requires `confidence` on predictions."
-                        )
-                    prediction_class_ids = np.asarray(
-                        predictions.class_id, dtype=np.int32
-                    )
-                    target_class_ids = np.asarray(targets.class_id, dtype=np.int32)
-                    prediction_confidence = np.asarray(
-                        predictions.confidence, dtype=np.float32
-                    )
-                    if self._metric_target == MetricTarget.BOXES:
-                        # BOXES target never yields CompactMask; narrow for mypy.
-                        iou = box_iou_batch(
-                            cast(npt.NDArray[np.number], target_contents),
-                            cast(npt.NDArray[np.number], prediction_contents),
-                        )
-                    elif self._metric_target == MetricTarget.MASKS:
-                        iou = mask_iou_batch(target_contents, prediction_contents)
-                    elif self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
-                        # OBB target never yields CompactMask; narrow for mypy.
-                        iou = oriented_box_iou_batch(
-                            cast(npt.NDArray[np.number], target_contents),
-                            cast(npt.NDArray[np.number], prediction_contents),
-                        )
-                    else:
-                        raise ValueError(
-                            "Unsupported metric target for IoU calculation"
-                        )
-
-                    # None keeps the matcher on its single-round fast path
-                    # when no size bucket is scored.
-                    target_scored_mask = (
-                        target_size_mask
-                        if size_category != ObjectSizeCategory.ANY
-                        else None
-                    )
-                    matches, matched_target_indices = (
-                        _match_detection_batch_with_target_indices(
-                            prediction_class_ids,
-                            target_class_ids,
-                            iou,
-                            iou_thresholds,
-                            target_scored_mask=target_scored_mask,
-                        )
-                    )
-                    ignored_matches = np.zeros_like(matches, dtype=bool)
-                    if size_category != ObjectSizeCategory.ANY:
-                        valid_target_match = matched_target_indices >= 0
-                        matched_scored_target = np.zeros_like(matches, dtype=bool)
-                        if np.any(valid_target_match):
-                            matched_scored_target[valid_target_match] = (
-                                target_size_mask[
-                                    matched_target_indices[valid_target_match]
-                                ]
-                            )
-                        prediction_scored = (
-                            prediction_size_mask[:, None] | matched_scored_target
-                        )
-                        ignored_matches = ~prediction_scored | (
-                            valid_target_match & ~matched_scored_target
-                        )
-                        prediction_keep = np.any(~ignored_matches, axis=1)
-                        matches = (
-                            matches[prediction_keep]
-                            & matched_scored_target[prediction_keep]
-                        )
-                        ignored_matches = ignored_matches[prediction_keep]
-                        prediction_confidence = prediction_confidence[prediction_keep]
-                        prediction_class_ids = prediction_class_ids[prediction_keep]
-                        target_class_ids = target_class_ids[target_size_mask]
-                        if (
-                            len(prediction_class_ids) == 0
-                            and len(target_class_ids) == 0
-                        ):
-                            continue
-                    stats.append(
-                        (
-                            matches,
-                            ignored_matches,
-                            prediction_confidence,
-                            prediction_class_ids,
-                            target_class_ids,
-                        )
-                    )
-
-        if not stats:
-            return RecallResult(
-                metric_target=self._metric_target,
-                averaging_method=self.averaging_method,
-                recall_scores=np.zeros(iou_thresholds.shape[0]),
-                recall_per_class=np.zeros((0, iou_thresholds.shape[0])),
-                iou_thresholds=iou_thresholds,
-                matched_classes=np.array([], dtype=int),
-                small_objects=None,
-                medium_objects=None,
-                large_objects=None,
-            )
-
-        concatenated_stats = [np.concatenate(items, 0) for items in zip(*stats)]
-        recall_scores, recall_per_class, unique_classes = (
-            self._compute_recall_for_classes(*concatenated_stats)
-        )
-
+        """Wrap the computed recall scores in a `RecallResult`."""
         return RecallResult(
             metric_target=self._metric_target,
             averaging_method=self.averaging_method,
-            recall_scores=recall_scores,
-            recall_per_class=recall_per_class,
+            recall_scores=scores,
+            recall_per_class=per_class_scores,
             iou_thresholds=iou_thresholds,
-            matched_classes=unique_classes,
+            matched_classes=matched_classes,
             small_objects=None,
             medium_objects=None,
             large_objects=None,
         )
-
-    def _compute_recall_for_classes(
-        self,
-        matches: npt.NDArray[np.bool_],
-        ignored_matches: npt.NDArray[np.bool_],
-        prediction_confidence: npt.NDArray[np.float32],
-        prediction_class_ids: npt.NDArray[np.int32],
-        true_class_ids: npt.NDArray[np.int32],
-    ) -> tuple[
-        npt.NDArray[np.float64],
-        npt.NDArray[np.float64],
-        npt.NDArray[np.int32],
-    ]:
-        sorted_indices = np.argsort(-prediction_confidence)
-        matches = matches[sorted_indices]
-        ignored_matches = ignored_matches[sorted_indices]
-        prediction_class_ids = prediction_class_ids[sorted_indices]
-        # Classes that appear only in predictions have no ground-truth instances, so
-        # their recall is 0.0 rather than undefined. Including them keeps the tracked
-        # class set identical to Precision and F1Score and matches sklearn, which infers
-        # labels from the union of y_true and y_pred.
-        true_classes, true_counts = np.unique(true_class_ids, return_counts=True)
-        pred_classes = np.unique(prediction_class_ids)
-        # Dedupe each side first, then union1d the already-unique arrays: this skips
-        # union1d's internal re-sort/re-unique of the full concatenation and measured
-        # ~1.4x faster than np.unique(np.concatenate(...)). Deduping after the union
-        # (or union1d on the raw arrays) yields no speedup.
-        unique_classes = np.union1d(true_classes, pred_classes)
-        class_counts = np.zeros(unique_classes.shape[0], dtype=int)
-        class_counts[np.searchsorted(unique_classes, true_classes)] = true_counts
-
-        # Shape: PxTh,P,C,C -> CxThx3
-        confusion_matrix = self._compute_confusion_matrix(
-            matches, ignored_matches, prediction_class_ids, unique_classes, class_counts
-        )
-
-        # Shape: CxThx3 -> CxTh
-        recall_per_class = self._compute_recall(confusion_matrix)
-
-        # Shape: CxTh -> Th
-        if self.averaging_method == AveragingMethod.MACRO:
-            recall_scores = np.mean(recall_per_class, axis=0)
-        elif self.averaging_method == AveragingMethod.MICRO:
-            confusion_matrix_merged = confusion_matrix.sum(0)
-            recall_scores = self._compute_recall(confusion_matrix_merged)
-        elif self.averaging_method == AveragingMethod.WEIGHTED:
-            class_counts = class_counts.astype(np.float32)
-            if class_counts.sum() == 0:
-                # No ground-truth support (e.g. only false-positive classes, or a
-                # size bucket with predictions but no targets): weighting is
-                # undefined, so report 0 as the empty case did before.
-                recall_scores = np.zeros(recall_per_class.shape[1])
-            else:
-                recall_scores = np.average(
-                    recall_per_class, axis=0, weights=class_counts
-                )
-
-        return recall_scores, recall_per_class, unique_classes
-
-    @staticmethod
-    def _match_detection_batch(
-        predictions_classes: npt.NDArray[np.int32],
-        target_classes: npt.NDArray[np.int32],
-        iou: npt.NDArray[np.float32],
-        iou_thresholds: npt.NDArray[np.float32],
-    ) -> npt.NDArray[np.bool_]:
-        result_correct, _ = _match_detection_batch_with_target_indices(
-            predictions_classes, target_classes, iou, iou_thresholds
-        )
-        return result_correct
-
-    @staticmethod
-    def _compute_confusion_matrix(
-        sorted_matches: npt.NDArray[np.bool_],
-        sorted_ignored_matches: npt.NDArray[np.bool_],
-        sorted_prediction_class_ids: npt.NDArray[np.int32],
-        unique_classes: npt.NDArray[np.integer],
-        class_counts: npt.NDArray[np.integer],
-    ) -> npt.NDArray[np.float64]:
-        """Compute the confusion matrix for each class and IoU threshold.
-
-        Assumes the matches and prediction_class_ids are sorted by confidence
-        in descending order.
-
-        Args:
-            sorted_matches: shape (P, Th), that is True
-                if the prediction is a true positive at the given IoU threshold.
-            sorted_ignored_matches: shape (P, Th), that is True
-                if the prediction should not affect the given IoU threshold.
-            sorted_prediction_class_ids: shape (P,), containing
-                the class id for each prediction.
-            unique_classes: shape (C,), containing the unique
-                class ids.
-            class_counts: shape (C,), containing the number
-                of true instances for each class.
-
-        Returns:
-            shape (C, Th, 3), containing the true positives, false
-                positives, and false negatives for each class and IoU threshold.
-        """
-        num_thresholds = sorted_matches.shape[1]
-        num_classes = unique_classes.shape[0]
-
-        confusion_matrix: npt.NDArray[np.float64] = np.zeros(
-            (num_classes, num_thresholds, 3), dtype=np.float64
-        )
-        for class_idx, class_id in enumerate(unique_classes):
-            is_class = sorted_prediction_class_ids == class_id
-            num_true = class_counts[class_idx]
-            num_predictions = is_class.sum()
-
-            if num_predictions == 0:
-                true_positives = np.zeros(num_thresholds)
-                false_positives = np.zeros(num_thresholds)
-                false_negatives = np.full(num_thresholds, num_true)
-            elif num_true == 0:
-                true_positives = np.zeros(num_thresholds)
-                false_positives = (~sorted_ignored_matches[is_class]).sum(0)
-                false_negatives = np.zeros(num_thresholds)
-            else:
-                true_positives = sorted_matches[is_class].sum(0)
-                false_positives = (
-                    ~sorted_matches[is_class] & ~sorted_ignored_matches[is_class]
-                ).sum(0)
-                false_negatives = num_true - true_positives
-            confusion_matrix[class_idx] = np.stack(
-                [true_positives, false_positives, false_negatives], axis=1
-            )
-        result: npt.NDArray[np.float64] = confusion_matrix
-        return result
 
     @staticmethod
     def _compute_recall(
@@ -507,11 +208,7 @@ class Recall(Metric["RecallResult"]):
         Returns:
             shape (N, ...), containing the recall for each element.
         """
-        if not confusion_matrix.shape[-1] == 3:
-            raise ValueError(
-                f"Confusion matrix must have shape (..., 3), got "
-                f"{confusion_matrix.shape}"
-            )
+        _validate_confusion_matrix(confusion_matrix)
         true_positives = confusion_matrix[..., 0]
         false_negatives = confusion_matrix[..., 2]
 
@@ -525,96 +222,6 @@ class Recall(Metric["RecallResult"]):
 
         result_recall: npt.NDArray[np.float64] = recall
         return result_recall
-
-    def _detections_content(
-        self, detections: Detections
-    ) -> npt.NDArray[Any] | CompactMask:
-        """Return boxes, masks or oriented bounding boxes from detections.
-
-        For the mask target this may return a
-        :class:`~supervision.detection.compact_mask.CompactMask` rather than a
-        dense boolean array when the detections carry compact masks.
-        """
-        if self._metric_target == MetricTarget.BOXES:
-            return cast(npt.NDArray[Any], detections.xyxy)
-        if self._metric_target == MetricTarget.MASKS:
-            if detections.mask is not None:
-                # detections.mask is NDArray[bool] | CompactMask; return as-is.
-                return detections.mask
-            if len(detections) > 0:
-                raise ValueError(
-                    "Recall with `MetricTarget.MASKS` requires detections to "
-                    "include masks."
-                )
-            return self._make_empty_content()
-        if self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
-            obb = detections.data.get(ORIENTED_BOX_COORDINATES)
-            if obb is not None and len(obb) > 0:
-                result_obb: npt.NDArray[np.float32] = np.array(obb, dtype=np.float32)
-                return result_obb
-            return self._make_empty_content()
-        raise ValueError(f"Invalid metric target: {self._metric_target}")
-
-    def _make_empty_content(self) -> npt.NDArray[Any]:
-        if self._metric_target == MetricTarget.BOXES:
-            empty_boxes: npt.NDArray[np.float32] = np.empty((0, 4), dtype=np.float32)
-            return empty_boxes
-
-        if self._metric_target == MetricTarget.MASKS:
-            empty_masks: npt.NDArray[np.bool_] = np.empty((0, 0, 0), dtype=bool)
-            return empty_masks
-
-        if self._metric_target == MetricTarget.ORIENTED_BOUNDING_BOXES:
-            empty_obb: npt.NDArray[np.float32] = np.empty((0, 4, 2), dtype=np.float32)
-            return empty_obb
-
-        raise ValueError(f"Invalid metric target: {self._metric_target}")
-
-        raise ValueError(f"Invalid metric target: {self._metric_target}")
-
-    def _filter_detections_by_size(
-        self, detections: Detections, size_category: ObjectSizeCategory
-    ) -> Detections:
-        """Return a copy of detections with contents filtered by object size."""
-        new_detections = deepcopy(detections)
-        if detections.is_empty() or size_category == ObjectSizeCategory.ANY:
-            return new_detections
-
-        sizes = get_detection_size_category(new_detections, self._metric_target)
-        size_mask = sizes == size_category.value
-
-        new_detections.xyxy = new_detections.xyxy[size_mask]
-        if new_detections.mask is not None:
-            new_detections.mask = new_detections.mask[size_mask]
-        if new_detections.class_id is not None:
-            new_detections.class_id = new_detections.class_id[size_mask]
-        if new_detections.confidence is not None:
-            new_detections.confidence = new_detections.confidence[size_mask]
-        if new_detections.tracker_id is not None:
-            new_detections.tracker_id = new_detections.tracker_id[size_mask]
-        if new_detections.data is not None:
-            for key, value in new_detections.data.items():
-                new_detections.data[key] = np.array(value)[size_mask]
-
-        return new_detections
-
-    def _filter_predictions_and_targets_by_size(
-        self,
-        predictions_list: list[Detections],
-        targets_list: list[Detections],
-        size_category: ObjectSizeCategory,
-    ) -> tuple[list[Detections], list[Detections]]:
-        """Filter predictions and targets by object size category."""
-        new_predictions_list = []
-        new_targets_list = []
-        for predictions, targets in zip(predictions_list, targets_list):
-            new_predictions_list.append(
-                self._filter_detections_by_size(predictions, size_category)
-            )
-            new_targets_list.append(
-                self._filter_detections_by_size(targets, size_category)
-            )
-        return new_predictions_list, new_targets_list
 
 
 @dataclass
@@ -667,6 +274,24 @@ class RecallResult:
     medium_objects: RecallResult | None
     large_objects: RecallResult | None
 
+    def _result_view(self) -> _ResultView:
+        """Describe this result in the form the shared renderers consume."""
+        return _ResultView(
+            class_name=self.__class__.__name__,
+            labels=_RECALL_LABELS,
+            metric_target=self.metric_target,
+            averaging_method=self.averaging_method,
+            score_at_50=self.recall_at_50,
+            score_at_75=self.recall_at_75,
+            scores=self.recall_scores,
+            per_class_scores=self.recall_per_class,
+            iou_thresholds=self.iou_thresholds,
+            matched_classes=self.matched_classes,
+            small_objects=_optional_result_view(self.small_objects),
+            medium_objects=_optional_result_view(self.medium_objects),
+            large_objects=_optional_result_view(self.large_objects),
+        )
+
     def __str__(self) -> str:
         """Format as a pretty string.
 
@@ -706,35 +331,7 @@ class RecallResult:
 
             ```
         """
-        out_str = (
-            f"{self.__class__.__name__}:\n"
-            f"Metric target:    {self.metric_target}\n"
-            f"Averaging method: {self.averaging_method}\n"
-            f"R @ 50:     {self.recall_at_50:.4f}\n"
-            f"R @ 75:     {self.recall_at_75:.4f}\n"
-            f"R @ thresh: {self.recall_scores}\n"
-            f"IoU thresh: {self.iou_thresholds}\n"
-            f"Recall per class:\n"
-        )
-        if self.recall_per_class.size == 0:
-            out_str += "  No results\n"
-        for class_id, recall_of_class in zip(
-            self.matched_classes, self.recall_per_class
-        ):
-            out_str += f"  {class_id}: {recall_of_class}\n"
-
-        indent = "  "
-        if self.small_objects is not None:
-            indented = indent + str(self.small_objects).replace("\n", f"\n{indent}")
-            out_str += f"\nSmall objects:\n{indented}"
-        if self.medium_objects is not None:
-            indented = indent + str(self.medium_objects).replace("\n", f"\n{indent}")
-            out_str += f"\nMedium objects:\n{indented}"
-        if self.large_objects is not None:
-            indented = indent + str(self.large_objects).replace("\n", f"\n{indent}")
-            out_str += f"\nLarge objects:\n{indented}"
-
-        return out_str
+        return _format_result(self._result_view())
 
     def to_pandas(self) -> pd.DataFrame:
         """Convert the result to a pandas DataFrame.
@@ -742,28 +339,7 @@ class RecallResult:
         Returns:
             The result as a DataFrame.
         """
-        ensure_pandas_installed()
-        import pandas as pd
-
-        pandas_data: dict[str, Any] = {
-            "R@50": self.recall_at_50,
-            "R@75": self.recall_at_75,
-        }
-
-        if self.small_objects is not None:
-            small_objects_df = self.small_objects.to_pandas()
-            for key, value in small_objects_df.items():
-                pandas_data[f"small_objects_{key}"] = value
-        if self.medium_objects is not None:
-            medium_objects_df = self.medium_objects.to_pandas()
-            for key, value in medium_objects_df.items():
-                pandas_data[f"medium_objects_{key}"] = value
-        if self.large_objects is not None:
-            large_objects_df = self.large_objects.to_pandas()
-            for key, value in large_objects_df.items():
-                pandas_data[f"large_objects_{key}"] = value
-
-        return pd.DataFrame(pandas_data, index=[0])
+        return _result_to_pandas(self._result_view())
 
     def plot(self) -> None:
         """Plot the recall results.
@@ -772,59 +348,4 @@ class RecallResult:
         https://media.roboflow.com/supervision-docs/metrics/recall_plot_example.png
         ){ align=center width="800" }
         """
-        from matplotlib import pyplot as plt
-
-        labels = ["Recall@50", "Recall@75"]
-        values = [self.recall_at_50, self.recall_at_75]
-        colors = [LEGACY_COLOR_PALETTE[0]] * 2
-
-        if self.small_objects is not None:
-            small_objects = self.small_objects
-            labels += ["Small: R@50", "Small: R@75"]
-            values += [small_objects.recall_at_50, small_objects.recall_at_75]
-            colors += [LEGACY_COLOR_PALETTE[3]] * 2
-
-        if self.medium_objects is not None:
-            medium_objects = self.medium_objects
-            labels += ["Medium: R@50", "Medium: R@75"]
-            values += [medium_objects.recall_at_50, medium_objects.recall_at_75]
-            colors += [LEGACY_COLOR_PALETTE[2]] * 2
-
-        if self.large_objects is not None:
-            large_objects = self.large_objects
-            labels += ["Large: R@50", "Large: R@75"]
-            values += [large_objects.recall_at_50, large_objects.recall_at_75]
-            colors += [LEGACY_COLOR_PALETTE[4]] * 2
-
-        plt.rcParams["font.family"] = "monospace"
-
-        _, ax = plt.subplots(figsize=(10, 6))
-        ax.set_ylim(0, 1)
-        ax.set_ylabel("Value", fontweight="bold")
-        title = (
-            f"Recall, by Object Size"
-            f"\n(target: {self.metric_target.value},"
-            f" averaging: {self.averaging_method.value})"
-        )
-        ax.set_title(title, fontweight="bold")
-
-        x_positions = range(len(labels))
-        bars = ax.bar(x_positions, values, color=colors, align="center")
-
-        ax.set_xticks(x_positions)
-        ax.set_xticklabels(labels, rotation=45, ha="right")
-
-        for bar in bars:
-            y_value = bar.get_height()
-            ax.text(
-                bar.get_x() + bar.get_width() / 2,
-                y_value + 0.02,
-                f"{y_value:.2f}",
-                ha="center",
-                va="bottom",
-            )
-
-        plt.rcParams["font.family"] = "sans-serif"
-
-        plt.tight_layout()
-        plt.show()
+        _plot_result(self._result_view())


### PR DESCRIPTION
- `_filter_by_classes` in `detection/vlm.py` builds `class_id` with `dtype=int`, so a `classes` filter that removes every detection no longer yields a `float64` index array for `from_paligemma`, `from_deepseek_vl_2` and `from_google_gemini_2_0`; `from_qwen_2_5_vl` already pinned the dtype and now shares the helper.
- extract `_filter_by_classes` and `_parse_gemini_json` in `detection/vlm.py`, replacing four copies of the `name in classes` mask plus `classes.index(name)` pairing and three copies of the `_strip_gemini_json_fence` / `json.loads` / recovery-callable sequence.
- replace the eleven-arm `if vlm == VLM.X` chain in `Detections.from_vlm` with the `_VLM_BOX_PARSERS`, `_VLM_SEGMENTATION_PARSERS` and `_VLM_UNIT_CONFIDENCE` module-level tables, plus the private `_from_vlm_text_result`, `_from_florence_2_result` and `_from_moondream_result` handlers.
- `_sort_box_corners` now runs for every string-result VLM including `GOOGLE_GEMINI_3_6` and `GOOGLE_GEMINI_3_7`, which previously skipped it; `_parse_gemini_boxes` already orders each box, so the extra pass is a no-op.
- rename the `xyxy` accumulator in `from_google_gemini_2_0` to `xyxy_list`, keeping the list and the unpacked array distinct.
- record the `class_id` dtype repair in `docs/changelog.md`.
