### PR TITLE
docs: convert fenced examples to doctests in detection/core.py

### DIFF
--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -2864,18 +2864,34 @@ class Detections:
             A subset of the Detections object or an item from the data field.
 
         Example:
-            ```python
-            import supervision as sv
+            ```pycon
+            >>> import numpy as np
+            >>> import supervision as sv
+            >>> detections = sv.Detections(
+            ...     xyxy=np.array(
+            ...         [[10, 10, 50, 50], [60, 10, 180, 50], [10, 60, 50, 180]]
+            ...     ),
+            ...     confidence=np.array([0.9, 0.4, 0.7]),
+            ...     class_id=np.array([0, 1, 0]),
+            ...     data={'feature_vector': np.array([1.0, 2.0, 3.0])},
+            ... )
+            >>> detections[0].xyxy
+            array([[10, 10, 50, 50]])
+            >>> detections[0:2].xyxy
+            array([[ 10,  10,  50,  50],
+                   [ 60,  10, 180,  50]])
+            >>> detections[[0, 2]].xyxy
+            array([[ 10,  10,  50,  50],
+                   [ 10,  60,  50, 180]])
+            >>> detections[detections.class_id == 0].xyxy
+            array([[ 10,  10,  50,  50],
+                   [ 10,  60,  50, 180]])
+            >>> detections[detections.confidence > 0.5].xyxy
+            array([[ 10,  10,  50,  50],
+                   [ 10,  60,  50, 180]])
+            >>> detections['feature_vector']
+            array([1., 2., 3.])
 
-            detections = sv.Detections()
-
-            first_detection = detections[0]
-            first_10_detections = detections[0:10]
-            some_detections = detections[[0, 2, 4]]
-            class_0_detections = detections[detections.class_id == 0]
-            high_confidence_detections = detections[detections.confidence > 0.5]
-
-            feature_vector = detections['feature_vector']
             ```
         """
         if isinstance(index, str):
@@ -2906,6 +2922,20 @@ class Detections:
                  for class_id
                  in detections.class_id
              ]
+            ```
+
+            ```pycon
+            >>> import numpy as np
+            >>> import supervision as sv
+            >>> detections = sv.Detections(
+            ...     xyxy=np.array([[10, 10, 50, 50], [60, 10, 180, 50]]),
+            ...     class_id=np.array([0, 1]),
+            ... )
+            >>> names = {0: 'person', 1: 'car'}
+            >>> detections['names'] = [names[c] for c in detections.class_id]
+            >>> detections['names']
+            array(['person', 'car'], dtype='<U6')
+
             ```
 
         Raises:
@@ -3015,24 +3045,21 @@ class Detections:
                 number of boxes (width / height for each box).
 
         Examples:
-            ```python
-            import numpy as np
-            import supervision as sv
+            ```pycon
+            >>> import numpy as np
+            >>> import supervision as sv
+            >>> xyxy = np.array([
+            ...     [10, 10, 50, 50],
+            ...     [60, 10, 180, 50],
+            ...     [10, 60, 50, 180],
+            ... ])
+            >>> detections = sv.Detections(xyxy=xyxy)
+            >>> detections.box_aspect_ratio
+            array([1.        , 3.        , 0.33333333])
+            >>> ar = detections.box_aspect_ratio
+            >>> detections[(ar < 2.0) & (ar > 0.5)].xyxy
+            array([[10, 10, 50, 50]])
 
-            xyxy = np.array([
-                [10, 10, 50, 50],
-                [60, 10, 180, 50],
-                [10, 60, 50, 180],
-            ])
-
-            detections = sv.Detections(xyxy=xyxy)
-
-            detections.box_aspect_ratio
-            # array([1.0, 3.0, 0.33333333])
-
-            ar = detections.box_aspect_ratio
-            detections[(ar < 2.0) & (ar > 0.5)].xyxy
-            # array([[10., 10., 50., 50.]])
             ```
         """
         widths = self.xyxy[:, 2] - self.xyxy[:, 0]
@@ -3068,14 +3095,21 @@ class Detections:
             when conversion is not needed.
 
         Example:
-            ```python
-            import numpy as np
-            import supervision as sv
-            detections = sv.Detections(
-                xyxy=np.array([[0, 0, 10, 10]]),
-                mask=np.ones((1, 20, 20), dtype=bool),
-            )
-            compact = detections.to_compact_masks()
+            ```pycon
+            >>> import numpy as np
+            >>> import supervision as sv
+            >>> detections = sv.Detections(
+            ...     xyxy=np.array([[0, 0, 10, 10]]),
+            ...     mask=np.ones((1, 20, 20), dtype=bool),
+            ... )
+            >>> compact = detections.to_compact_masks()
+            >>> type(compact.mask).__name__
+            'CompactMask'
+            >>> compact.mask.image_shape
+            (20, 20)
+            >>> np.array_equal(compact.mask.to_dense(), detections.mask)
+            True
+
             ```
         """
         from supervision.detection.compact_mask import CompactMask
@@ -3567,7 +3601,7 @@ def merge_inner_detection_object_pair(
         result = model.infer(image)[0]
         detections = sv.Detections.from_inference(result)
 
-        merged_detections = merge_object_detection_pair(
+        merged_detections = merge_inner_detection_object_pair(
             detections[0], detections[1])
         ```
     """

--- a/src/supervision/detection/core.py
+++ b/src/supervision/detection/core.py
@@ -3601,8 +3601,11 @@ def merge_inner_detection_object_pair(
         result = model.infer(image)[0]
         detections = sv.Detections.from_inference(result)
 
+        from supervision.detection.core import merge_inner_detection_object_pair
+
         merged_detections = merge_inner_detection_object_pair(
-            detections[0], detections[1])
+            detections[0], detections[1]
+        )
         ```
     """
     if len(detections_1) != 1 or len(detections_2) != 1:


### PR DESCRIPTION
<details>
<summary>Before submitting</summary>

- [x] Self-reviewed the code
- [x] Updated documentation, follow [Google-style](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)
- [ ] Added docs entry for autogeneration (if new functions/classes)
- [x] Added/updated tests
- [x] All tests pass locally

</details>

## Description

Continues the doctest conversion effort from #2479 and #2484 in `detection/core.py`, the file with the most remaining non-executing ```` ```python ```` fences (36 before this PR, 33 after; the rest depend on external model libraries and cannot run in CI).

Converted to real `pycon` doctests:
- `Detections.box_aspect_ratio`
- `Detections.__getitem__`
- `Detections.to_compact_masks`
- `Detections.__setitem__`: kept the existing ultralytics integration example and added a self-contained doctest beside it (same "keep both" pattern agreed in #2484)

## Type of Change

- 📝 Documentation update

## Motivation and Context

Making the examples execute surfaced three defects:
- `box_aspect_ratio` documented the filtered `xyxy` as `array([[10., 10., 50., 50.]])`; the filter returns the input dtype, so the real output is `array([[10, 10, 50, 50]])`.
- `__getitem__` indexed an empty `sv.Detections()`, which raises `IndexError`. The example now builds three detections and demonstrates integer, slice, list, and boolean-mask indexing plus `data` key access.
- `merge_inner_detection_object_pair`'s example called `merge_object_detection_pair`, which does not exist. Corrected the name only, since the function is deprecated for removal in v0.32.

## Changes Made

- `src/supervision/detection/core.py`: four docstring examples converted or extended to `pycon` doctests, one function name corrected.

## Testing

- [x] I have tested this code locally
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass

`uv run pytest --doctest-modules src/supervision/detection/core.py` → 12 passed (8 before this PR). `pre-commit run --files src/supervision/detection/core.py` is clean (ruff, mypy, codespell, doctest fence check).

## Additional Notes

Remaining non-executing fences in this file are all framework integration examples (`from_ultralytics`, `from_transformers`, `from_sam`, etc.) that need model weights, so they are left as `python` blocks by design.
